### PR TITLE
ApplyAlpha layer inherits Trace setting from parent

### DIFF
--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -38,6 +38,33 @@ class FixedPrecisionType(object):
         typestring = 'ap_{signed}fixed<{args}>'.format(signed='u' if not self.signed else '', args=args)
         return typestring
 
+def convert_precision_string(precision):
+    assert isinstance(precision, str), "This method converts precision strings to PrecisionTypes. You provided a {}".format(type(precision))
+    bits = re.search('.+<(.+?)>', precision).group(1).split(',')
+    sat_mode = None
+    round_mode = None
+    sat_bits = None
+    if 'fixed' in precision:
+        W = int(bits[0])
+        I = int(bits[1])
+        fields = 2
+        signed = ~('u' in precision)
+    elif 'int' in precision:
+        W = int(bits[0])
+        I = W
+        fields = 1
+        signed = ~('u' in precision)
+    if len(bits) > fields:
+        sat_mode = bits[fields]
+    if len(bits) > fields+1:
+        round_mode = bits[fields+1]
+    if len(bits) > fields+2:
+        sat_bits = int(bits[fields+2])
+    if 'fixed' in precision:
+        return FixedPrecisionType(W, I, signed, round_mode, sat_mode, sat_bits)
+    elif 'int' in precision:
+        return IntegerPrecisionType(W, signed)
+
 def find_minimum_width(data, signed=True):
     """
     Helper function to find the minimum integer width to express all entries in the data array

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -460,7 +460,7 @@ class HLSModel(object):
         layer_sizes = {}
         n_traced = 0
         for layer in self.get_layers():
-            if layer.function_cpp() and self.config.get_layer_config_value(layer, 'Trace', False):
+            if layer.function_cpp() and layer.get_attr('Trace', False):
                 n_traced += len(layer.get_variables())
                 trace_output[layer.name] = []
                 layer_sizes[layer.name] = layer.get_output_variable().shape

--- a/hls4ml/model/optimizer/passes/qkeras.py
+++ b/hls4ml/model/optimizer/passes/qkeras.py
@@ -147,10 +147,11 @@ class QKerasFactorizeAlpha(OptimizerPass):
             'class_name' : 'Alpha',
             'inputs' : node.outputs,
             'n_in' : node.get_attr('n_out'),
-            'n_filt' : node.get_attr('n_filt') if node.get_attr('n_filt') is not None else -1,
+            'n_filt' : node.get_attr('n_filt', -1),
             'reuse_factor' : node.get_attr('reuse_factor'),
             'bias_t' : node.weights['bias'].type, 
-            'scale_t' : FixedPrecisionType() # TODO automate this
+            'scale_t' : FixedPrecisionType(), # TODO automate this
+            'Trace' : node.get_attr('Trace', False) 
         }
         alpha_layer = model.make_node('ApplyAlpha', node.name + '_alpha', attrs, node.outputs)
         alpha_layer.add_weights(scale, quantizer=None)

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -1,5 +1,6 @@
 import importlib
 from hls4ml.model.hls_model import HLSModel
+from hls4ml.model.hls_layers import IntegerPrecisionType, FixedPrecisionType, convert_precision_string
 import qkeras
 import numpy as np
 import pandas
@@ -120,17 +121,14 @@ def types_histogram(data, fmt='longform'):
 types_plots = {'boxplot' : types_boxplot,
                'histogram' : types_histogram}
 
-def ap_fixed_WIF(type_str):
-    if 'ap_fixed' in type_str:
-        W = int(type_str.split(',')[0].split('<')[1])
-        I = int(type_str.split(',')[1].split('>')[0])
+def ap_fixed_WIF(dtype):
+    if isinstance(dtype, str):
+        dtype = convert_precision_string(dtype)
+    if isinstance(dtype, FixedPrecisionType):
+        W, I = dtype.width, dtype.integer
         F = W - I
-    elif 'ap_int' in type_str:
-        W = int(type_str.replace('ap_int<','').replace('>',''))
-        I = W
-        F = 0
-    else:
-        W, I, F = 0, 0, 0
+    elif isinstance(dtype, IntegerPrecisionType):
+        W, I, F = dtype.width, dtype.width, 0
     return W, I, F
 
 def types_hlsmodel(model):

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -145,8 +145,9 @@ def config_from_keras_model(model, granularity='model', default_precision='ap_fi
             layer_config['ReuseFactor'] = default_reuse_factor
             layer_config['table_size'] = 1024
             is_softmax = layer['class_name'] == 'Softmax'
-            if 'activation' in layer['config'].keys():
-                is_softmax = is_softmax or (layer['config']['activation'] == 'softmax')
+            if 'config' in layer.keys():
+                if 'activation' in layer['config'].keys():
+                    is_softmax = is_softmax or (layer['config']['activation'] == 'softmax')
             if is_softmax:
                layer_config['exp_table_t'] = 'ap_fixed<18,8,AP_RND,AP_SAT>'
                layer_config['inv_table_t'] = 'ap_fixed<18,8,AP_RND,AP_SAT>'

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -174,7 +174,7 @@ class VivadoWriter(Writer):
                     if func:
                         for line in func:
                             newline += '    ' + line + '\n'
-                        if model.config.trace_output and model.config.get_layer_config_value(layer, 'Trace', False):
+                        if model.config.trace_output and layer.get_attr('Trace', False):
                             newline += '#ifndef __SYNTHESIS__\n'
                             for var in vars:
                                 newline += '    nnet::save_layer_output<{}>({}, "{}", {});\n'.format(var.type.name, var.name, layer.name, var.size_cpp())
@@ -471,7 +471,7 @@ class VivadoWriter(Writer):
             elif '//hls-fpga-machine-learning insert trace_outputs' in line:
                 newline = ''
                 for layer in model.get_layers():
-                    if layer.function_cpp() and model.config.trace_output and model.config.get_layer_config_value(layer, 'Trace', False):
+                    if layer.function_cpp() and model.config.trace_output and layer.get_attr('Trace', False):
                             vars = layer.get_variables()
                             for var in vars:
                                 newline += indent + 'nnet::trace_outputs->insert(std::pair<std::string, void *>("{}", (void *) malloc({} * element_size)));\n'.format(layer.name, var.size_cpp())


### PR DESCRIPTION
The QKeras optimization pass may insert an `ApplyAlpha` (`BatchNormalization`) layer for QKeras Dense or Conv layers with `alpha != 1`. Currently, these can only be `trace`d by adding the layer name to the config dictionary. Since the layer name is generated by the optimizer pass, it's a bit unwieldy for users (who may not anyway be aware that it's being added). 

This PR copies the `Trace` setting of the parent layer into the `ApplyAlpha` layer. 
I had to adjust some of the handling of the `Trace` settings to make it usable, specifically: rather than retrieving a layer's trace setting from the config, it's now retrieved from the layer attributes. Layer config entries were already made layer attributes, so this doesn't interfere with the existing functionality. 

I also added a 'convert_precision_string' method, continuing the push to remove precision strings everywhere, which is then used in the `profiling` to query the type width/integer bits.