### PR TITLE
Add profiling for PyTorch models

### DIFF
--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -357,18 +357,16 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
     plt.title("Distribution of (non-zero) weights")
     plt.tight_layout()
 
-    if X is not None and isinstance(model, keras.Model):
-        print("Profiling activations")
-        data = activations_keras(model, X, fmt='summary', plot=plot)
-        ap = plots[plot](data, fmt='summary') # activation plot
-        plt.title("Distribution of (non-zero) activations")
-        plt.tight_layout()
-    elif X is not None and isinstance(model, torch.nn.Sequential):
-        print("Profiling activations")
-        data = activations_torch(model, X, fmt='summary', plot=plot)
-        ap = plots[plot](data, fmt='summary')
-        plt.title("Distribution of (non-zero) activations")
-        plt.tight_layout()
+    print("Profiling activations")
+    if X is not None:
+        if isinstance(model, (keras.Model, torch.nn.Sequential)):
+            if isinstance(model, keras.Model):
+                data = activations_keras(model, X, fmt='summary', plot=plot)
+            else:
+                data = activations_torch(model, X, fmt='summary', plot=plot)
+            ap = plots[plot](data, fmt='summary') # activation plot
+            plt.title("Distribution of (non-zero) activations")
+            plt.tight_layout()
 
     if X is not None and isinstance(hls_model, HLSModel):
         t_data = activation_types_hlsmodel(hls_model)

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -275,7 +275,8 @@ def weights_torch(model, fmt='longform', plot='boxplot'):
                 if fmt == 'longform':
                     data['x'].extend(w.tolist())
                     data['layer'].extend([name for _ in range(n)])
-                    data['weight'].extend(['{}/{}'.format(name, i) for _ in range(n)])
+                    data['weight'].extend(['{}/{}'.format(name, i) for _
+                                           in range(n)])
                 elif fmt == 'summary':
                     data.append(array_to_summary(w, fmt=plot))
                     data[-1]['layer'] = name
@@ -313,6 +314,7 @@ def activations_torch(model, X, fmt='longform', plot='boxplot'):
         data = pandas.DataFrame(data)
     return data
 
+
 def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
     """
     Perform numerical profiling of a model
@@ -328,12 +330,14 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
         Must be formatted suitably for the model.predict(X) method
     plot : str, optional
         The type of plot to produce.
-        Options are: 'boxplot' (default), 'violinplot', 'histogram', 'FacetGrid'
+        Options are: 'boxplot' (default), 'violinplot', 'histogram',
+        'FacetGrid'
 
     Returns
     -------
     tuple
-        The pair of produced figures. First weights and biases, then activations
+        The pair of produced figures. First weights and biases,
+        then activations
     """
     wp, ap = None, None
 
@@ -345,11 +349,11 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
     elif model is not None and isinstance(model, torch.nn.Sequential):
         data = weights_torch(model, fmt='summary', plot=plot)
     else:
-        print("Only keras, PyTorch (Sequential) and HLSModel models " + \
+        print("Only keras, PyTorch (Sequential) and HLSModel models " +
               "can currently be profiled")
         return wp, ap
 
-    wp = plots[plot](data, fmt='summary') # weight plot
+    wp = plots[plot](data, fmt='summary')  # weight plot
     if isinstance(hls_model, HLSModel) and plot in types_plots:
         t_data = types_hlsmodel(hls_model)
         types_plots[plot](t_data, fmt='summary')
@@ -364,7 +368,7 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
                 data = activations_keras(model, X, fmt='summary', plot=plot)
             else:
                 data = activations_torch(model, X, fmt='summary', plot=plot)
-            ap = plots[plot](data, fmt='summary') # activation plot
+            ap = plots[plot](data, fmt='summary')  # activation plot
             plt.title("Distribution of (non-zero) activations")
             plt.tight_layout()
 
@@ -373,6 +377,7 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
         types_plots[plot](t_data, fmt='summary')
 
     return wp, ap
+
 
 ########COMPARE OUTPUT IMPLEMENTATION########
 def _is_ignored_layer(layer):

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -313,14 +313,14 @@ def activations_torch(model, X, fmt='longform', plot='boxplot'):
         data = pandas.DataFrame(data)
     return data
 
-def numerical(keras_model=None, hls_model=None, X=None, plot='boxplot'):
+def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
     """
     Perform numerical profiling of a model
 
     Parameters
     ----------
-    keras_model : keras model
-        The keras model to profile
+    model : keras or pytorch model
+        The model to profile
     hls_model : HLSModel
         The HLSModel to profile
     X : array-like, optional
@@ -339,11 +339,10 @@ def numerical(keras_model=None, hls_model=None, X=None, plot='boxplot'):
     print("Profiling weights")
     if hls_model is not None and isinstance(hls_model, HLSModel):
         data = weights_hlsmodel(hls_model, fmt='summary', plot=plot)
-    elif keras_model is not None and isinstance(keras_model, keras.Model):
-        data = weights_keras(keras_model, fmt='summary', plot=plot)
-    elif keras_model is not None and isinstance(keras_model,
-                                                torch.nn.Sequential):
-        data = weights_torch(keras_model, fmt='summary', plot=plot)
+    elif model is not None and isinstance(model, keras.Model):
+        data = weights_keras(model, fmt='summary', plot=plot)
+    elif model is not None and isinstance(model, torch.nn.Sequential):
+        data = weights_torch(model, fmt='summary', plot=plot)
     else:
         print("Only keras and HLSModel models can currently be profiled")
         return False, False
@@ -357,15 +356,15 @@ def numerical(keras_model=None, hls_model=None, X=None, plot='boxplot'):
     plt.tight_layout()
 
     ap = None
-    if X is not None and isinstance(keras_model, keras.Model):
+    if X is not None and isinstance(model, keras.Model):
         print("Profiling activations")
-        data = activations_keras(keras_model, X, fmt='summary', plot=plot)
+        data = activations_keras(model, X, fmt='summary', plot=plot)
         ap = plots[plot](data, fmt='summary') # activation plot
         plt.title("Distribution of (non-zero) activations")
         plt.tight_layout()
-    elif X is not None and isinstance(keras_model, torch.nn.Sequential):
+    elif X is not None and isinstance(model, torch.nn.Sequential):
         print("Profiling activations")
-        data = activations_torch(keras_model, X, fmt='summary', plot=plot)
+        data = activations_torch(model, X, fmt='summary', plot=plot)
         ap = plots[plot](data, fmt='summary')
         plt.title("Distribution of (non-zero) activations")
         plt.tight_layout()

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -345,7 +345,8 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
     elif model is not None and isinstance(model, torch.nn.Sequential):
         data = weights_torch(model, fmt='summary', plot=plot)
     else:
-        print("Only keras and HLSModel models can currently be profiled")
+        print("Only keras, PyTorch (Sequential) and HLSModel models " + \
+              "can currently be profiled")
         return wp, ap
 
     wp = plots[plot](data, fmt='summary') # weight plot

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -335,6 +335,7 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
     tuple
         The pair of produced figures. First weights and biases, then activations
     """
+    wp, ap = None, None
 
     print("Profiling weights")
     if hls_model is not None and isinstance(hls_model, HLSModel):
@@ -345,7 +346,7 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
         data = weights_torch(model, fmt='summary', plot=plot)
     else:
         print("Only keras and HLSModel models can currently be profiled")
-        return False, False
+        return wp, ap
 
     wp = plots[plot](data, fmt='summary') # weight plot
     if isinstance(hls_model, HLSModel) and plot in types_plots:
@@ -355,7 +356,6 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
     plt.title("Distribution of (non-zero) weights")
     plt.tight_layout()
 
-    ap = None
     if X is not None and isinstance(model, keras.Model):
         print("Profiling activations")
         data = activations_keras(model, X, fmt='summary', plot=plot)

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -6,6 +6,7 @@ import pandas
 from tensorflow import keras
 import seaborn as sb
 import matplotlib.pyplot as plt
+import torch
 
 def array_to_summary(x, fmt='boxplot'):
     if fmt == 'boxplot':
@@ -282,6 +283,10 @@ def numerical(keras_model=None, hls_model=None, X=None, plot='boxplot'):
         data = weights_hlsmodel(hls_model, fmt='summary', plot=plot)
     elif keras_model is not None and isinstance(keras_model, keras.Model):
         data = weights_keras(keras_model, fmt='summary', plot=plot)
+    elif keras_model is not None and isinstance(keras_model,
+                                                torch.nn.Sequential):
+        print("PyTorch models can not currently be profiled")
+        return False, False
     else:
         print("Only keras and HLSModel models can currently be profiled")
         return False, False
@@ -301,6 +306,8 @@ def numerical(keras_model=None, hls_model=None, X=None, plot='boxplot'):
         ap = plots[plot](data, fmt='summary') # activation plot
         plt.title("Distribution of (non-zero) activations")
         plt.tight_layout()
+    elif X is not None and isinstance(keras_model, torch.nn.Sequential):
+        print("PyTorch models can not currently be profiled")
 
     if X is not None and isinstance(hls_model, HLSModel):
         t_data = activation_types_hlsmodel(hls_model)

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -174,12 +174,15 @@ def activation_types_hlsmodel(model):
     return data
 
 def weights_hlsmodel(model, fmt='longform', plot='boxplot'):
+    suffix = ['w', 'b']
     if fmt == 'longform':
         data = {'x' : [], 'layer' : [], 'weight' : []}
     elif fmt == 'summary':
         data = []
     for layer in model.get_layers():
+        name = layer.name
         for iw, weight in enumerate(layer.get_weights()):
+            l = '{}/{}'.format(name, suffix[iw])
             w = weight.data.flatten()
             w = abs(w[w != 0])
             n = len(w)
@@ -187,18 +190,19 @@ def weights_hlsmodel(model, fmt='longform', plot='boxplot'):
                 break
             if fmt == 'longform':
                 data['x'].extend(w.tolist())
-                data['layer'].extend([layer.name for i in range(len(w))])
-                data['weight'].extend(['{}/{}'.format(layer.name, iw) for i in range(len(w))])
+                data['layer'].extend([name for i in range(len(w))])
+                data['weight'].extend([l for i in range(len(w))])
             elif fmt == 'summary':
                 data.append(array_to_summary(w, fmt=plot))
-                data[-1]['layer'] = layer.name
-                data[-1]['weight'] = '{}/{}'.format(layer.name, iw)
+                data[-1]['layer'] = name
+                data[-1]['weight'] = l
 
     if fmt == 'longform':
         data = pandas.DataFrame(data)
     return data
 
 def weights_keras(model, fmt='longform', plot='boxplot'):
+    suffix = ['w', 'b']
     if fmt == 'longform':
         data = {'x' : [], 'layer' : [], 'weight' : []}
     elif fmt == 'summary':
@@ -207,6 +211,7 @@ def weights_keras(model, fmt='longform', plot='boxplot'):
         name = layer.name
         weights = layer.get_weights()
         for i, w in enumerate(weights):
+            l = '{}/{}'.format(name, suffix[i])
             w = w.flatten()
             w = abs(w[w != 0])
             n = len(w)
@@ -215,11 +220,11 @@ def weights_keras(model, fmt='longform', plot='boxplot'):
             if fmt == 'longform':
                 data['x'].extend(w.tolist())
                 data['layer'].extend([name for j in range(n)])
-                data['weight'].extend(['{}/{}'.format(name, i) for j in range(n)])
+                data['weight'].extend([l for j in range(n)])
             elif fmt == 'summary':
                 data.append(array_to_summary(w, fmt=plot))
                 data[-1]['layer'] = name
-                data[-1]['weight'] = '{}/{}'.format(name, i)
+                data[-1]['weight'] = l
 
     if fmt == 'longform':
         data = pandas.DataFrame(data)
@@ -257,6 +262,7 @@ def activations_keras(model, X, fmt='longform', plot='boxplot'):
 
 
 def weights_torch(model, fmt='longform', plot='boxplot'):
+    suffix = ['w', 'b']
     if fmt == 'longform':
         data = {'x': [], 'layer': [], 'weight': []}
     elif fmt == 'summary':
@@ -266,6 +272,7 @@ def weights_torch(model, fmt='longform', plot='boxplot'):
             name = layer.__class__.__name__
             weights = list(layer.parameters())
             for i, w in enumerate(weights):
+                l = '{}/{}'.format(name, suffix[i])
                 w = weights[i].detach().numpy()
                 w = w.flatten()
                 w = abs(w[w != 0])
@@ -275,12 +282,11 @@ def weights_torch(model, fmt='longform', plot='boxplot'):
                 if fmt == 'longform':
                     data['x'].extend(w.tolist())
                     data['layer'].extend([name for _ in range(n)])
-                    data['weight'].extend(['{}/{}'.format(name, i) for _
-                                           in range(n)])
+                    data['weight'].extend([l for _ in range(n)])
                 elif fmt == 'summary':
                     data.append(array_to_summary(w, fmt=plot))
                     data[-1]['layer'] = name
-                    data[-1]['weight'] = '{}/{}'.format(name, i)
+                    data[-1]['weight'] = l
 
     if fmt == 'longform':
         data = pandas.DataFrame(data)

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ setup(name='hls4ml',
         'profiling': [
             'pandas',
             'seaborn',
-            'matplotlib',
-            'tensorflow'
+            'matplotlib'
         ]
       },
       scripts=['scripts/hls4ml'],


### PR DESCRIPTION
This PR extends profiling to support Pytorch `nn.Sequential` models. The two new methods mirror the behavior of the methods applied to Keras models.

Further collapsing  of three similar methods `weights_hlsmodel`, `weights_keras`, `weights_torch` (same for the `activations_<type>`) into one would be desirable.