### PR TITLE
Update Jenkins to use new Docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
 pipeline {
   agent {
     docker {
-      image 'hls4ml-with-vivado:latest'
+      image 'vivado-el7:1'
+      args  '-v /data/Xilinx:/data/Xilinx'
     }
   }
   options {
@@ -12,8 +13,8 @@ pipeline {
     stage('Keras to HLS') {
       steps {
         dir(path: 'test') {
-          sh '''#!/bin/bash
-              . activate hls4ml-py36
+          sh '''#!/bin/bash --login
+              conda activate hls4ml-py36
               pip install -U ../ --user
               ./convert-keras-models.sh -p 3 -x -f keras-models.txt
               pip uninstall hls4ml -y'''
@@ -22,31 +23,31 @@ pipeline {
     }
     stage('C Simulation') {
       parallel {
-        stage('2017.2') {
+        stage('2019.2') {
           when {
             allOf {
-              environment name: 'USE_VIVADO_2017', value: '1';
+              environment name: 'USE_VIVADO_2019', value: '1';
               environment name: 'TEST_SIMULATION', value: '1'
             }
           }
           steps {
             dir(path: 'test') {
               sh '''#!/bin/bash
-                 ./build-prj.sh -i /opt/Xilinx -v 2017.2 -c -p 2'''
+                 ./build-prj.sh -i /data/Xilinx -v 2019.2 -c -p 2'''
             }
           }
         }
-        stage('2018.2') {
+        stage('2020.1') {
           when {
             allOf {
-              environment name: 'USE_VIVADO_2018', value: '1';
+              environment name: 'USE_VIVADO_2020', value: '1';
               environment name: 'TEST_SIMULATION', value: '1'
             }
           }
           steps {
             dir(path: 'test') {
               sh '''#!/bin/bash
-                 ./build-prj.sh -i /opt/Xilinx -v 2018.2 -c -p 2'''
+                 ./build-prj.sh -i /data/Xilinx -v 2020.1 -c -p 2'''
             }
           }
         }
@@ -54,31 +55,31 @@ pipeline {
     }
     stage('C/RTL Synthesis') {
       parallel {
-        stage('2017.2') {
+        stage('2019.2') {
           when {
             allOf {
-              environment name: 'USE_VIVADO_2017', value: '1';
+              environment name: 'USE_VIVADO_2019', value: '1';
               environment name: 'TEST_SYNTHESIS', value: '1'
             }
           }
           steps {
             dir(path: 'test') {
               sh '''#!/bin/bash
-                 ./build-prj.sh -i /opt/Xilinx -v 2017.2 -s -r -p 2'''
+                 ./build-prj.sh -i /data/Xilinx -v 2019.2 -s -r -p 2'''
             }
           }
         }
-        stage('2018.2') {
+        stage('2020.1') {
           when {
             allOf {
-              environment name: 'USE_VIVADO_2018', value: '1';
+              environment name: 'USE_VIVADO_2020', value: '1';
               environment name: 'TEST_SYNTHESIS', value: '1'
             }
           }
           steps {
             dir(path: 'test') {
               sh '''#!/bin/bash
-                 ./build-prj.sh -i /opt/Xilinx -v 2018.2 -s -r -p 2'''
+                 ./build-prj.sh -i /data/Xilinx -v 2020.1 -s -r -p 2'''
             }
           }
         }

--- a/test/keras-models.txt
+++ b/test/keras-models.txt
@@ -19,8 +19,8 @@ KERAS_1layer
 KERAS_3layer
 #KERAS_3layer:KERAS_3layer_70pruned_retrained_weights
 #KERAS_conv1d
-KERAS_conv1d_small
-KERAS_conv2d_model
+#KERAS_conv1d_small
+#KERAS_conv2d_model
 #KERAS_dense_16x100x100x100x100x100x5
 KERAS_3layer_batch_norm
 KERAS_3layer_binary_smaller

--- a/test/keras-models.txt
+++ b/test/keras-models.txt
@@ -26,10 +26,7 @@ KERAS_3layer_batch_norm
 KERAS_3layer_binary_smaller
 KERAS_3layer_ternary_small
  
-# GarNet example: Need large reuse factor because input graph has 128 vertices
-# Commenting out due to failed synthesis with older vivado versions.
-# Uncomment after after testing workflow is updated.
-#garnet_1layer r:16
+garnet_1layer r:16
 
 # Resource strategy
 KERAS_3layer r:2 s:Resource


### PR DESCRIPTION
This PR updates the CI to use the new Docker images set up at Fermilab. Tests are now run on 2019.2 and 2020.1.