### PR TITLE
Fix Vivado reports parsing

### DIFF
--- a/hls4ml/report/vivado_report.py
+++ b/hls4ml/report/vivado_report.py
@@ -154,7 +154,7 @@ def parse_vivado_report(hls_dir):
         for child in area_node.find('./Resources'):
             report[child.tag] = child.text
         for child in area_node.find('./AvailableResources'):
-            report[child.tag] = child.text
+            report['Available' + child.tag] = child.text
     else:
         print('Synthesis report not found.')
 


### PR DESCRIPTION
Current code for parsing overwrites the used resources with the available resources, making the report dict useless. This fixes it.