### PR TITLE
Fixes for the use of resource strategy and new `product` functions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         dir(path: 'test') {
           sh '''#!/bin/bash --login
               conda activate hls4ml-py36
+              pip install git+git://github.com/google/qkeras.git@v0.8.0#egg=qkeras
               pip install -U ../ --user
               ./convert-keras-models.sh -x -f keras-models.txt
               pip uninstall hls4ml -y'''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         dir(path: 'test') {
           sh '''#!/bin/bash --login
               conda activate hls4ml-py36
+              pip install tensorflow
               pip install git+git://github.com/google/qkeras.git@v0.8.0#egg=qkeras
               pip install -U ../ --user
               ./convert-keras-models.sh -x -f keras-models.txt

--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -1364,9 +1364,12 @@ class Dot(Merge):
         self.add_output_variable(shape=[1], dim_names=['OUT_DOT_{}'.format(self.index)])
 
     def config_cpp(self):
+        inp1 = self.get_input_variable(self.inputs[0])
+        inp2 = self.get_input_variable(self.inputs[1])
         params = self._default_config_params()
         params['n_out'] = 1
-        params['n_in'] = self.get_input_variable(self.inputs[0]).shape[0]
+        params['n_in'] = inp1.shape[0]
+        params['product_type'] = self.model.config.backend.product_type(inp1.type.precision, inp2.type.precision)
         return self._config_template.format(**params)
 
 class Concatenate(Merge):

--- a/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm.h
@@ -71,7 +71,7 @@ void normalize(
         #pragma HLS ARRAY_PARTITION variable=bias complete
 
         int multiplier_limit  = ceil(float(CONFIG_T::n_in) / float(CONFIG_T::reuse_factor));
-        #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
+        CONFIG_T::template product<data_T, typename CONFIG_T::scale_t, res_T>::limit(multiplier_limit);
 
     } else if (CONFIG_T::io_type == io_serial) {
         #pragma HLS ARRAY_RESHAPE variable=scale complete dim=1

--- a/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm_stream.h
@@ -43,7 +43,7 @@ void normalize(
 
     constexpr unsigned multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_in, CONFIG_T::reuse_factor);
     constexpr unsigned ii = CONFIG_T::n_in / multiplier_limit;
-    #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
+    CONFIG_T::template product<typename data_T::value_type, typename CONFIG_T::scale_t, typename res_T::value_type>::limit(multiplier_limit);
 
     BatchNormLoop: for (int i = 0; i < CONFIG_T::n_in / data_T::size; i++) {
         #pragma HLS PIPELINE II=ii

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv1d.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv1d.h
@@ -58,7 +58,7 @@ void conv_1d_cl(
     typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
     typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
 {
-    if (CONFIG_T::strategy == latency) {
+    if (CONFIG_T::strategy == nnet::latency) {
         conv_1d_latency_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);
     } else {
         conv_1d_resource_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv2d.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv2d.h
@@ -65,7 +65,7 @@ void conv_2d_cf(
     typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
     typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
 {
-    if (CONFIG_T::strategy == latency) {
+    if (CONFIG_T::strategy == nnet::latency) {
         conv_2d_latency_cf<data_T, res_T, CONFIG_T>(data, res, weights, biases);
     } else {
         conv_2d_resource_cf<data_T, res_T, CONFIG_T>(data, res, weights, biases);
@@ -79,7 +79,7 @@ void conv_2d_cl(
     typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
     typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
 {
-    if (CONFIG_T::strategy == latency) {
+    if (CONFIG_T::strategy == nnet::latency) {
         conv_2d_latency_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);
     } else {
         conv_2d_resource_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense.h
@@ -41,7 +41,7 @@ void dense(
     typename CONFIG_T::weight_t  weights[CONFIG_T::n_in*CONFIG_T::n_out],
     typename CONFIG_T::bias_t    biases[CONFIG_T::n_out])
 {
-    if (CONFIG_T::strategy == latency) {
+    if (CONFIG_T::strategy == nnet::latency) {
         dense_latency<data_T, res_T, CONFIG_T>(data, res, weights, biases);
     } else {
         dense_resource<data_T, res_T, CONFIG_T>(data, res, weights, biases);

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense_latency.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense_latency.h
@@ -54,7 +54,7 @@ void dense_latency(
         #pragma HLS ARRAY_PARTITION variable=acc complete
 
         int multiplier_limit  = ceil(float(CONFIG_T::n_in*CONFIG_T::n_out) / float(CONFIG_T::reuse_factor)) - floor(float(CONFIG_T::n_zeros) / float(CONFIG_T::reuse_factor));
-        #pragma HLS ALLOCATION instances=product limit=multiplier_limit function
+        CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::limit(multiplier_limit);
 
     } else if (CONFIG_T::io_type == io_serial){
         // Only reduce cycle_factor if n_out is evenly divisible by reuse_factor
@@ -90,7 +90,7 @@ void dense_latency(
         Product2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
             if (CONFIG_T::io_type == io_serial) {
                 int multiplier_limit  = ceil(float(CONFIG_T::n_out) / float(CONFIG_T::reuse_factor));
-                #pragma HLS ALLOCATION instances=product limit=multiplier_limit function
+                CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::limit(multiplier_limit);
             }
         int index = ii*CONFIG_T::n_out+jj;
         mult[index] = CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(cache, weights[index]);

--- a/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
@@ -129,7 +129,7 @@ void dot1d(
     #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
     constexpr unsigned multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_in, CONFIG_T::reuse_factor);
-    #pragma HLS ALLOCATION instances=product limit=multiplier_limit function
+    CONFIG_T::template product<input1_T, input2_T, typename CONFIG_T::accum_t>::limit(multiplier_limit);
 
     typename CONFIG_T::accum_t mult[CONFIG_T::n_in];
     #pragma HLS ARRAY_PARTITION variable=mult complete

--- a/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
@@ -21,7 +21,7 @@
 #define NNET_MERGE_H_
 
 #include "nnet_common.h"
-#include "nnet_dense.h"
+#include "nnet_mult.h"
 #include "hls_stream.h"
 #include <math.h>
 
@@ -37,6 +37,9 @@ struct dot_config {
     static const unsigned n_out = 1;
     static const unsigned reuse_factor = 1;
     typedef float accum_t;
+    // Product function to use
+    template<class x_T, class y_T, class res_T>
+    using product = nnet::product::mult<x_T, y_T, res_T>;
 };
 
 struct concat_config {
@@ -134,7 +137,7 @@ void dot1d(
 
     Product: for(int i_mult=0; i_mult < CONFIG_T::n_in; i_mult++) {
         #pragma HLS UNROLL
-        mult[i_mult] = product<input1_T, input2_T, typename CONFIG_T::accum_t>(data1[i_mult], data2[i_mult]);
+        mult[i_mult] = CONFIG_T::template product<input1_T, input2_T, typename CONFIG_T::accum_t>::product(data1[i_mult], data2[i_mult]);
     }
 
     Accum: for(int i_acc = 0; i_acc < CONFIG_T::n_in; i_acc++) {
@@ -142,10 +145,7 @@ void dot1d(
         acc += mult[i_acc];
     }
 
-    Result: for(int i_res = 0; i_res < CONFIG_T::n_out; i_res++) {
-        #pragma HLS_UNROLL
-        res[i_res] = cast<input1_T, res_T, CONFIG_T>(acc);
-    }
+    res[0] = cast<input1_T, res_T, CONFIG_T>(acc);
 }
 
 

--- a/hls4ml/templates/vivado/nnet_utils/nnet_mult.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_mult.h
@@ -20,9 +20,10 @@ class Product{
     public:
     static y_T product(x_T a, w_T w){
         // 'Normal' product
-        #pragma HLS inline off
+        #pragma HLS INLINE
         return a * w;
     }
+    static void limit(unsigned multiplier_limit) {} // Nothing to do here
 };
 
 template<class x_T, class w_T, class y_T>
@@ -30,7 +31,7 @@ class both_binary : public Product<x_T, w_T, y_T>{
     public:
     static y_T product(x_T a, w_T w){
         // specialisation for 1-bit weights and incoming data
-        #pragma HLS inline off
+        #pragma HLS INLINE
         return a == w;
     }
 };
@@ -40,7 +41,7 @@ class weight_binary : public Product<x_T, w_T, y_T>{
     public:
     static y_T product(x_T a, w_T w){
         // Specialisation for 1-bit weights, arbitrary data
-        #pragma HLS inline off
+        #pragma HLS INLINE
         return w == 0 ? (x_T) -a : a;
     }
 };
@@ -50,7 +51,7 @@ class weight_ternary : public Product<x_T, w_T, y_T>{
     public:
     static y_T product(x_T a, w_T w){
         // Specialisation for 2-bit weights, arbitrary data
-        #pragma HLS inline off
+        #pragma HLS INLINE
         if (w == 0) return (x_T) 0;
         else if(w == -1) return (x_T) -a;
         else return (x_T) a; // if(w == 1)
@@ -62,8 +63,12 @@ class mult : public Product<x_T, w_T, y_T>{
     public:
     static y_T product(x_T a, w_T w){
         // 'Normal' product
-        #pragma HLS inline off
+        #pragma HLS INLINE
         return a * w;
+    }
+    static void limit(unsigned multiplier_limit){
+        #pragma HLS INLINE
+        #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
     }
 };
 
@@ -72,7 +77,7 @@ class weight_exponential : public Product<x_T, w_T, y_T>{
     public:
     static y_T product(x_T a, w_T w){
         // Shift product for exponential weights
-        #pragma HLS inline off
+        #pragma HLS INLINE
         // shift by the exponent. Negative weights shift right
         y_T ay = a;
         y_T y = ay << w.weight;

--- a/hls4ml/templates/vivado/nnet_utils/nnet_sepconv_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_sepconv_stream.h
@@ -27,12 +27,12 @@ void depthwise_product(
     #pragma HLS ARRAY_PARTITION variable=mult complete
 
     int multiplier_limit  = ceil(float(CONFIG_T::kernel_size * CONFIG_T::n_chan) / float(CONFIG_T::reuse_factor)) - floor(float(CONFIG_T::n_zeros) / float(CONFIG_T::reuse_factor));
-    #pragma HLS ALLOCATION instances=product limit=multiplier_limit function
+    CONFIG_T::mult_config::template product<data_T, typename CONFIG_T::mult_config::weight_t, typename CONFIG_T::mult_config::accum_t>::limit(multiplier_limit);
 
     // Do the matrix-multiply
     Product: for(int ii = 0; ii < CONFIG_T::kernel_size * CONFIG_T::n_chan; ii++) {
         #pragma HLS UNROLL
-        mult[ii] = CONFIG_T::mult_config::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(data[ii], weights[ii]);
+        mult[ii] = CONFIG_T::mult_config::template product<data_T, typename CONFIG_T::mult_config::weight_t, typename CONFIG_T::mult_config::accum_t>::product(data[ii], weights[ii]);
     }
 
     // Initialize accumulator with input biases

--- a/hls4ml/templates/vivado/nnet_utils/nnet_sepconv_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_sepconv_stream.h
@@ -32,7 +32,7 @@ void depthwise_product(
     // Do the matrix-multiply
     Product: for(int ii = 0; ii < CONFIG_T::kernel_size * CONFIG_T::n_chan; ii++) {
         #pragma HLS UNROLL
-        mult[ii] = product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>(data[ii], weights[ii]);
+        mult[ii] = CONFIG_T::mult_config::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(data[ii], weights[ii]);
     }
 
     // Initialize accumulator with input biases

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -63,6 +63,7 @@ conv_mult_config_template = """struct config{index}_mult : nnet::dense_config {{
     static const unsigned n_in = {n_in};
     static const unsigned n_out = {n_out};
     static const unsigned reuse_factor = {reuse};
+    static const unsigned strategy = nnet::{strategy};
     typedef {accum_t} accum_t;
     typedef {bias_t} bias_t;
     typedef {weight_t} weight_t;

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -199,6 +199,8 @@ dot_config_template = """struct config{index} : nnet::dot_config {{
     static const unsigned n_out = {n_out};
     static const unsigned reuse_factor = {reuse};
     typedef {accum_t} accum_t;
+    template<class x_T, class y_T, class res_T>
+    using product = nnet::product::{product_type}<x_T, y_T, res_T>;
 }};\n"""
 
 concat_config_template = """struct config{index} : nnet::concat_config {{

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -133,6 +133,7 @@ pooling1d_config_template = """struct config{index} : nnet::pooling1d_config {{
     static const unsigned pad_right = {pad_right};
     static const unsigned stride_width = {stride_width};
     static const nnet::Pool_Op pool_op = nnet::{pool_op};
+    static const unsigned reuse = {reuse};
 }};\n"""
 
 pooling2d_config_template = """struct config{index} : nnet::pooling2d_config {{


### PR DESCRIPTION
Two related fixes. The first one ensures that the proper multiplication function is called wrt the strategy specified in config. The second one adds new `product` functions to `SeparableConv` layers, which was missed in previous PR.