### PR TITLE
autopep8 + clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+---
+# BasedOnStyle:  Google
+ColumnLimit:     120
+IndentWidth:     4
+BreakBeforeBraces: Stroustrup
+...
+

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -40,6 +40,7 @@ try:
 except ImportError:
     __tensorflow_enabled__ = False
 
+
 def parse_yaml_config(config_file):
     """Parse conversion configuration from the provided YAML file.
 
@@ -80,6 +81,7 @@ def parse_yaml_config(config_file):
         parsed_config = yaml.load(file, Loader=yaml.SafeLoader)
     return parsed_config
 
+
 def convert_from_config(config):
     """Convert to hls4ml model based on the provided configuration.
 
@@ -117,8 +119,9 @@ def convert_from_config(config):
 
     return model
 
+
 def convert_from_keras_model(model, output_dir='my-hls-test', project_name='myproject',
-    fpga_part='xcku115-flvb2104-2-i', clock_period=5, io_type='io_parallel', hls_config={}):
+                             fpga_part='xcku115-flvb2104-2-i', clock_period=5, io_type='io_parallel', hls_config={}):
     """Convert to hls4ml model based on the provided configuration.
 
     Args:

--- a/hls4ml/converters/keras/convolution.py
+++ b/hls4ml/converters/keras/convolution.py
@@ -11,7 +11,7 @@ def parse_conv1d_layer(keras_layer, input_names, input_shapes, data_reader, conf
     assert('Conv1D' in keras_layer['class_name'])
 
     layer = parse_default_keras_layer(keras_layer, input_names)
-    
+
     (
         layer['in_width'],
         layer['n_chan']
@@ -46,7 +46,7 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader, conf
     assert('Conv2D' in keras_layer['class_name'])
 
     layer = parse_default_keras_layer(keras_layer, input_names)
-    
+
     (
         layer['in_height'],
         layer['in_width'],
@@ -55,14 +55,14 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader, conf
 
     if 'filters' in keras_layer['config']:
         layer['n_filt'] = keras_layer['config']['filters']
-    else:    
+    else:
         layer['n_filt'] = layer['n_chan']
     layer['filt_height'] = keras_layer['config']['kernel_size'][0]
     layer['filt_width'] = keras_layer['config']['kernel_size'][1]
     layer['stride_height'] = keras_layer['config']['strides'][0]
     layer['stride_width'] = keras_layer['config']['strides'][1]
     layer['padding'] = keras_layer['config']['padding']
-    
+
     (
         layer['out_height'],
         layer['out_width'],

--- a/hls4ml/converters/keras/graph.py
+++ b/hls4ml/converters/keras/graph.py
@@ -2,6 +2,7 @@ from hls4ml.converters.keras_to_hls import parse_default_keras_layer
 from hls4ml.converters.keras_to_hls import keras_handler
 from hls4ml.converters.keras.core import TernaryQuantizer
 
+
 @keras_handler('GarNet', 'GarNetStack')
 def parse_garnet_layer(keras_layer, input_names, input_shapes, data_reader, config):
     assert(keras_layer['class_name'] in ['GarNet', 'GarNetStack'])
@@ -24,8 +25,8 @@ def parse_garnet_layer(keras_layer, input_names, input_shapes, data_reader, conf
         layer['quantizer'] = TernaryQuantizer()
 
     layer['n_aggregators'] = keras_layer['config']['n_aggregators']
-    layer['n_out_features'] = keras_layer['config']['n_filters'] # number of output features
-    layer['n_propagate'] = keras_layer['config']['n_propagate'] # number of latent features
+    layer['n_out_features'] = keras_layer['config']['n_filters']  # number of output features
+    layer['n_propagate'] = keras_layer['config']['n_propagate']  # number of latent features
 
     if layer['class_name'] == 'GarNet':
         layer['n_in_features'] = input_shapes[0][2]
@@ -39,7 +40,7 @@ def parse_garnet_layer(keras_layer, input_names, input_shapes, data_reader, conf
             layer['n_in_features'].append(layer['n_out_features'][il - 1])
 
         n_out_features = layer['n_out_features'][-1]
-        
+
     if layer['collapse'] in ['mean', 'sum', 'max']:
         output_shape = [input_shapes[0][0], n_out_features]
     else:

--- a/hls4ml/converters/keras/merge.py
+++ b/hls4ml/converters/keras/merge.py
@@ -2,6 +2,8 @@ from hls4ml.converters.keras_to_hls import parse_default_keras_layer
 from hls4ml.converters.keras_to_hls import keras_handler
 
 merge_layers = ['Add', 'Subtract', 'Multiply', 'Average', 'Maximum', 'Minimum', 'Concatenate', 'Dot']
+
+
 @keras_handler(*merge_layers)
 def parse_merge_layer(keras_layer, input_names, input_shapes, data_reader, config):
     assert(keras_layer['class_name'] in merge_layers)
@@ -22,7 +24,7 @@ def parse_merge_layer(keras_layer, input_names, input_shapes, data_reader, confi
         rank = len(input_shapes[0][1:])
         if rank > 1:
             raise Exception('ERROR: Dot of tensors with rank > 1 is not yet supported.')
-        layer['op'] = layer['class_name'].lower() + '{}d'.format(rank) 
+        layer['op'] = layer['class_name'].lower() + '{}d'.format(rank)
     else:
         layer['class_name'] = 'Merge'
     if len(layer['inputs']) > 2:

--- a/hls4ml/converters/keras/pooling.py
+++ b/hls4ml/converters/keras/pooling.py
@@ -7,6 +7,8 @@ from hls4ml.converters.keras_to_hls import compute_padding_2d
 
 
 pooling_layers = ['MaxPooling1D', 'MaxPooling2D', 'AveragePooling1D', 'AveragePooling2D']
+
+
 @keras_handler(*pooling_layers)
 def parse_pooling_layer(keras_layer, input_names, input_shapes, data_reader, config):
     assert('Pooling' in keras_layer['class_name'])
@@ -18,10 +20,10 @@ def parse_pooling_layer(keras_layer, input_names, input_shapes, data_reader, con
             layer['n_in'],
             layer['n_filt']
         ) = parse_data_format(input_shapes[0], layer['data_format'])
-        
-        layer['pool_width']=keras_layer['config']['pool_size'][0]
-        layer['stride_width']=keras_layer['config']['strides'][0]
-        layer['padding']=keras_layer['config']['padding']
+
+        layer['pool_width'] = keras_layer['config']['pool_size'][0]
+        layer['stride_width'] = keras_layer['config']['strides'][0]
+        layer['padding'] = keras_layer['config']['padding']
 
         (
             layer['n_out'],
@@ -35,9 +37,9 @@ def parse_pooling_layer(keras_layer, input_names, input_shapes, data_reader, con
         )
 
         if layer['data_format'] == 'channels_last':
-            output_shape=[input_shapes[0][0], layer['n_out'], layer['n_filt']]
+            output_shape = [input_shapes[0][0], layer['n_out'], layer['n_filt']]
         elif layer['data_format'] == 'channels_first':
-            output_shape=[input_shapes[0][0], layer['n_filt'], layer['n_out']]
+            output_shape = [input_shapes[0][0], layer['n_filt'], layer['n_out']]
     elif int(layer['class_name'][-2]) == 2:
         (
             layer['in_height'],
@@ -45,11 +47,11 @@ def parse_pooling_layer(keras_layer, input_names, input_shapes, data_reader, con
             layer['n_filt']
         ) = parse_data_format(input_shapes[0], layer['data_format'])
 
-        layer['stride_height']=keras_layer['config']['strides'][0]
-        layer['stride_width']=keras_layer['config']['strides'][1]
-        layer['pool_height']=keras_layer['config']['pool_size'][0]
-        layer['pool_width']=keras_layer['config']['pool_size'][1]
-        layer['padding']=keras_layer['config']['padding']
+        layer['stride_height'] = keras_layer['config']['strides'][0]
+        layer['stride_width'] = keras_layer['config']['strides'][1]
+        layer['pool_height'] = keras_layer['config']['pool_size'][0]
+        layer['pool_width'] = keras_layer['config']['pool_size'][1]
+        layer['padding'] = keras_layer['config']['padding']
 
         (
             layer['out_height'],
@@ -69,13 +71,16 @@ def parse_pooling_layer(keras_layer, input_names, input_shapes, data_reader, con
         )
 
         if layer['data_format'] == 'channels_last':
-            output_shape=[input_shapes[0][0], layer['out_height'], layer['out_width'], layer['n_filt']]
+            output_shape = [input_shapes[0][0], layer['out_height'], layer['out_width'], layer['n_filt']]
         elif layer['data_format'] == 'channels_first':
-            output_shape=[input_shapes[0][0], layer['n_filt'], layer['out_height'], layer['out_width']]
-    
+            output_shape = [input_shapes[0][0], layer['n_filt'], layer['out_height'], layer['out_width']]
+
     return layer, output_shape
 
+
 pooling_layers = ['GlobalMaxPooling1D', 'GlobalMaxPooling2D', 'GlobalAveragePooling1D', 'GlobalAveragePooling2D']
+
+
 @keras_handler(*pooling_layers)
 def parse_global_pooling_layer(keras_layer, input_names, input_shapes, data_reader, config):
     assert('Pooling' in keras_layer['class_name'])
@@ -87,8 +92,8 @@ def parse_global_pooling_layer(keras_layer, input_names, input_shapes, data_read
             layer['n_in'],
             layer['n_filt']
         ) = parse_data_format(input_shapes[0], layer['data_format'])
-        
-        output_shape=[input_shapes[0][0], layer['n_filt']]
+
+        output_shape = [input_shapes[0][0], layer['n_filt']]
     elif int(layer['class_name'][-2]) == 2:
         (
             layer['in_height'],
@@ -96,6 +101,6 @@ def parse_global_pooling_layer(keras_layer, input_names, input_shapes, data_read
             layer['n_filt']
         ) = parse_data_format(input_shapes[0], layer['data_format'])
 
-        output_shape=[input_shapes[0][0], layer['n_filt']]
-    
+        output_shape = [input_shapes[0][0], layer['n_filt']]
+
     return layer, output_shape

--- a/hls4ml/converters/keras/qkeras.py
+++ b/hls4ml/converters/keras/qkeras.py
@@ -5,6 +5,7 @@ from qkeras.quantizers import get_quantizer
 import tensorflow as tf
 import numpy as np
 
+
 class QKerasQuantizer(Quantizer):
     def __init__(self, config):
         self.quantizer_fn = get_quantizer(config)
@@ -24,11 +25,12 @@ class QKerasQuantizer(Quantizer):
             print("Unsupported quantizer: " + config['class_name'])
             self.bits = 16
             self.hls_type = FixedPrecisionType(width=16, integer=6, signed=True)
-    
+
     def __call__(self, data):
         tf_data = tf.convert_to_tensor(data)
         return self.quantizer_fn(tf_data).numpy()
-        #return self.quantizer_fn(data)
+        # return self.quantizer_fn(data)
+
 
 class QKerasBinaryQuantizer(object):
     def __init__(self, config, xnor=False):
@@ -44,6 +46,7 @@ class QKerasBinaryQuantizer(object):
         x = tf.convert_to_tensor(data)
         y = self.quantizer_fn(x).numpy()
         return self.binary_quantizer(y)
+
 
 class QKerasPO2Quantizer(object):
     def __init__(self, config):
@@ -61,6 +64,7 @@ class QKerasPO2Quantizer(object):
             y = y.numpy()
         return y
 
+
 def get_type(quantizer_config):
     width = quantizer_config['config']['bits']
     integer = quantizer_config['config'].get('integer', 0)
@@ -74,6 +78,7 @@ def get_type(quantizer_config):
     else:
         return FixedPrecisionType(width=width, integer=integer+1, signed=True)
 
+
 def get_quantizer_from_config(keras_layer, quantizer_var):
     quantizer_config = keras_layer['config']['{}_quantizer'.format(quantizer_var)]
     if keras_layer['class_name'] == 'QBatchNormalization':
@@ -84,4 +89,3 @@ def get_quantizer_from_config(keras_layer, quantizer_var):
         return QKerasPO2Quantizer(quantizer_config)
     else:
         return QKerasQuantizer(quantizer_config)
-

--- a/hls4ml/converters/keras/qkeras_layers.py
+++ b/hls4ml/converters/keras/qkeras_layers.py
@@ -12,8 +12,7 @@ import tensorflow as tf
 
 @keras_handler('QDense')
 def parse_qdense_layer(keras_layer, input_names, input_shapes, data_reader, config):
-    
-    
+
     layer, output_shape = parse_dense_layer(keras_layer, input_names, input_shapes, data_reader, config)
 
     layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
@@ -28,7 +27,7 @@ def parse_qdense_layer(keras_layer, input_names, input_shapes, data_reader, conf
 @keras_handler('QConv1D', 'QConv2D')
 def parse_qconv_layer(keras_layer, input_names, input_shapes, data_reader, config):
     assert('QConv' in keras_layer['class_name'])
-    
+
     if '1D' in keras_layer['class_name']:
         layer, output_shape = parse_conv1d_layer(keras_layer, input_names, input_shapes, data_reader, config)
     elif '2D' in keras_layer['class_name']:
@@ -39,7 +38,7 @@ def parse_qconv_layer(keras_layer, input_names, input_shapes, data_reader, confi
         layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
     else:
         layer['bias_quantizer'] = None
-    
+
     return layer, output_shape
 
 
@@ -47,7 +46,7 @@ def parse_qconv_layer(keras_layer, input_names, input_shapes, data_reader, confi
 def parse_qactivation_layer(keras_layer, input_names, input_shapes, data_reader, config):
     assert(keras_layer['class_name'] == 'QActivation')
     supported_activations = ['quantized_relu', 'quantized_tanh', 'binary_tanh', 'ternary_tanh', 'quantized_bits', 'binary', 'ternary']
-    
+
     layer = parse_default_keras_layer(keras_layer, input_names)
 
     activation_config = keras_layer['config']['activation']
@@ -57,7 +56,7 @@ def parse_qactivation_layer(keras_layer, input_names, input_shapes, data_reader,
     if isinstance(activation_config, str):
         quantizer_obj = get_quantizer(activation_config)
         activation_config = {}
-        # some activations are classes 
+        # some activations are classes
         if hasattr(quantizer_obj, 'get_config'):
             print("Name: " + quantizer_obj.__class__.__name__)
             activation_config['class_name'] = quantizer_obj.__class__.__name__
@@ -77,10 +76,9 @@ def parse_qactivation_layer(keras_layer, input_names, input_shapes, data_reader,
                 activation_config['config']['integer'] = 2
             else:
                 activation_config['class_name'] = 'unknown'
-    
+
     if activation_config['class_name'] not in supported_activations:
         raise Exception('Unsupported QKeras activation: {}'.format(activation_config['class_name']))
-
 
     layer['class_name'] = 'Activation'
     if activation_config['class_name'] == 'quantized_bits':
@@ -88,9 +86,10 @@ def parse_qactivation_layer(keras_layer, input_names, input_shapes, data_reader,
     layer['activation'] = activation_config['class_name'].replace('quantized_', '')
     return layer, [shape for shape in input_shapes[0]]
 
+
 @keras_handler('QBatchNormalization')
 def parse_qbatchnorm_layer(keras_layer, input_names, input_shapes, data_reader, config):
-    
+
     layer, output_shape = parse_batchnorm_layer(keras_layer, input_names, input_shapes, data_reader, config)
 
     layer['mean_quantizer'] = get_quantizer_from_config(keras_layer, 'mean')

--- a/hls4ml/converters/keras/reshape.py
+++ b/hls4ml/converters/keras/reshape.py
@@ -4,15 +4,16 @@ from hls4ml.converters.keras_to_hls import parse_default_keras_layer
 from hls4ml.converters.keras_to_hls import keras_handler
 from hls4ml.converters.keras_to_hls import parse_data_format
 
+
 @keras_handler('Reshape')
 def parse_reshape_layer(keras_layer, input_names, input_shapes, data_reader, config):
     assert(keras_layer["class_name"] == 'Reshape')
 
     layer = parse_default_keras_layer(keras_layer, input_names)
-    
+
     layer['target_shape'] = keras_layer['config']['target_shape']
     output_shape = input_shapes[0][:1] + keras_layer['config']['target_shape']
-    
+
     return layer, output_shape
 
 
@@ -21,7 +22,7 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader, conf
     assert('UpSampling2D' in keras_layer['class_name'])
 
     layer = parse_default_keras_layer(keras_layer, input_names)
-    
+
     (
         layer['in_height'],
         layer['in_width'],
@@ -35,13 +36,14 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader, conf
 
     layer['out_height'] = layer['in_height'] * layer['height_factor']
     layer['out_width'] = layer['in_width'] * layer['width_factor']
-    
+
     if layer['data_format'] == 'channels_first':
         output_shape = [input_shapes[0][0], layer['n_chan'], layer['out_height'], layer['out_width']]
     else:
         output_shape = [input_shapes[0][0], layer['out_height'], layer['out_width'], layer['n_chan']]
 
     return layer, output_shape
+
 
 @keras_handler('Permute')
 def parse_permute_layer(keras_layer, input_names, input_shapes, data_reader, config):
@@ -52,7 +54,7 @@ def parse_permute_layer(keras_layer, input_names, input_shapes, data_reader, con
     layer['class_name'] = 'Transpose'
     dims = keras_layer['config']['dims']
     layer['perm'] = [dim - 1 for dim in keras_layer['config']['dims']]
-    
+
     output_shape = [input_shapes[0][0]] + [input_shapes[0][s] for s in dims]
 
     return layer, output_shape

--- a/hls4ml/converters/keras/reshaping.py
+++ b/hls4ml/converters/keras/reshaping.py
@@ -17,25 +17,26 @@ def parse_zeropadding1d_layer(keras_layer, input_names, input_shapes, data_reade
     elif isinstance(padding, collections.abc.Sequence):
         layer['pad_left'] = padding[0]
         layer['pad_right'] = padding[1]
-        
+
     if layer['data_format'] == 'channels_first':
         output_shape = [
-            input_shapes[0][0], # Batch
-            input_shapes[0][1], # Channels
+            input_shapes[0][0],  # Batch
+            input_shapes[0][1],  # Channels
             layer['pad_left'] + input_shapes[0][2] + layer['pad_right']  # Width
         ]
         layer['out_width'] = output_shape[2]
         layer['n_chan'] = output_shape[1]
     else:
         output_shape = [
-            input_shapes[0][0], # Batch
-            layer['pad_left'] + input_shapes[0][1] + layer['pad_right'], # Width
-            input_shapes[0][2] # Channels
+            input_shapes[0][0],  # Batch
+            layer['pad_left'] + input_shapes[0][1] + layer['pad_right'],  # Width
+            input_shapes[0][2]  # Channels
         ]
         layer['out_width'] = output_shape[1]
         layer['n_chan'] = output_shape[2]
 
     return layer, output_shape
+
 
 @keras_handler('ZeroPadding2D')
 def parse_zeropadding2d_layer(keras_layer, input_names, input_shapes, data_reader, config):
@@ -66,9 +67,9 @@ def parse_zeropadding2d_layer(keras_layer, input_names, input_shapes, data_reade
 
     if layer['data_format'] == 'channels_first':
         output_shape = [
-            input_shapes[0][0], # Batch
-            input_shapes[0][1], # Channels
-            layer['pad_top'] + input_shapes[0][2] + layer['pad_bottom'], # Height
+            input_shapes[0][0],  # Batch
+            input_shapes[0][1],  # Channels
+            layer['pad_top'] + input_shapes[0][2] + layer['pad_bottom'],  # Height
             layer['pad_left'] + input_shapes[0][3] + layer['pad_right']  # Width
         ]
         layer['out_height'] = output_shape[2]
@@ -76,10 +77,10 @@ def parse_zeropadding2d_layer(keras_layer, input_names, input_shapes, data_reade
         layer['n_chan'] = output_shape[1]
     else:
         output_shape = [
-            input_shapes[0][0], # Batch
-            layer['pad_top'] + input_shapes[0][1] + layer['pad_bottom'], # Height
-            layer['pad_left'] + input_shapes[0][2] + layer['pad_right'], # Width
-            input_shapes[0][3] # Channels
+            input_shapes[0][0],  # Batch
+            layer['pad_top'] + input_shapes[0][1] + layer['pad_bottom'],  # Height
+            layer['pad_left'] + input_shapes[0][2] + layer['pad_right'],  # Width
+            input_shapes[0][3]  # Channels
         ]
         layer['out_height'] = output_shape[1]
         layer['out_width'] = output_shape[2]

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -9,6 +9,7 @@ import re
 
 from hls4ml.model import HLSModel
 
+
 class PyTorchDataReader:
     def __init__(self, config):
         self.config = config
@@ -19,7 +20,7 @@ class PyTorchDataReader:
             self.torch_model = torch.load(config['PytorchModel'])
 
         self.state_dict = self.torch_model.state_dict()
-    
+
     def get_weights_data(self, layer_name, var_name):
         if var_name == 'kernel':
             var_name = 'weight'
@@ -29,10 +30,11 @@ class PyTorchDataReader:
 
         return data
 
+
 def pytorch_to_hls(yamlConfig):
 
     ######################
-    ##  Do translation
+    # Do translation
     ######################
 
     print('Interpreting Model')
@@ -43,23 +45,23 @@ def pytorch_to_hls(yamlConfig):
     activation_layers = ['ReLU', 'Sigmoid', 'Tanh', 'SELU', 'LeakyReLU', 'Softmax', 'Softplus', 'Softsign']
     supported_layers = core_layers + skip_layers + activation_layers
 
-    #This is a list of dictionaries to hold all the layer info we need to generate HLS
+    # This is a list of dictionaries to hold all the layer info we need to generate HLS
     layer_list = []
 
-    #Loop through layers
+    # Loop through layers
     print('Topology:')
     modelstr = repr(reader.torch_model).split('\n')
     for pytorch_layer in modelstr:
         layer_match = re.match(r'\((\d)\): (\w+)\((.*)\)', pytorch_layer.strip())
         if layer_match is None:
             continue
-        
-        layer_idx  = layer_match.group(1)
+
+        layer_idx = layer_match.group(1)
         layer_type = layer_match.group(2)
         layer_spec = layer_match.group(3)
 
         # #Dictionary to fill in and append to layer_list
-        layer={}
+        layer = {}
 
         #layer_type = matchname.group(1)
         if layer_type not in supported_layers:
@@ -95,9 +97,8 @@ def pytorch_to_hls(yamlConfig):
     input_layer['input_shape'] = [layer_list[0]['n_in']]
     layer_list.insert(0, input_layer)
 
-
     #################
-    ## Generate HLS
+    # Generate HLS
     #################
 
     reader = PyTorchDataReader(yamlConfig)

--- a/hls4ml/converters/tf_to_hls.py
+++ b/hls4ml/converters/tf_to_hls.py
@@ -11,6 +11,7 @@ from hls4ml.model import HLSModel
 
 MAXMULT = 4096
 
+
 class TFDataReader:
     def __init__(self, graph):
         self.graph = graph
@@ -20,7 +21,7 @@ class TFDataReader:
         tf_op = self.graph.get_operation_by_name(layer_name)
         data = None
         if tf_op is not None:
-            if tf_op.type == 'MatMul' and var_name == 'kernel': # MatMul is mapped to Dense, but there is no bias
+            if tf_op.type == 'MatMul' and var_name == 'kernel':  # MatMul is mapped to Dense, but there is no bias
                 w_tensor = tf_op.inputs[1]
                 data = self.read_variable_data(w_tensor)
 
@@ -31,9 +32,9 @@ class TFDataReader:
             if tf_op.type == 'BiasAdd':
                 b_tensor = tf_op.inputs[1]
                 data = self.read_variable_data(b_tensor)
-            
+
             if tf_op.type == 'FusedBatchNorm':
-                bn_weighs_map = { 'gamma': 1, 'beta': 2, 'moving_mean': 3, 'moving_variance': 4 }
+                bn_weighs_map = {'gamma': 1, 'beta': 2, 'moving_mean': 3, 'moving_variance': 4}
                 w_idx = bn_weighs_map[var_name]
                 w_tensor = tf_op.inputs[w_idx]
                 data = self.read_variable_data(w_tensor)
@@ -50,6 +51,7 @@ class TFDataReader:
 
         return data
 
+
 def _parse_data_format(data_format):
     if data_format == 'NCHW':
         format_str = 'channels_first'
@@ -61,28 +63,29 @@ def _parse_data_format(data_format):
         h_idx = 1
         w_idx = 2
         c_idx = 3
-    
+
     return format_str, c_idx, h_idx, w_idx
+
 
 def _compute_pads_2d(layer, in_height, in_width):
     if layer['padding'] == 'same':
-        #Height
+        # Height
         layer['out_height'] = int(math.ceil(float(in_height) / float(layer['stride_height'])))
         if (in_height % layer['stride_height'] == 0):
             pad_along_height = max(layer['filt_height'] - layer['stride_height'], 0)
         else:
             pad_along_height = max(layer['filt_height'] - (in_height % layer['stride_height']), 0)
-        layer['pad_top']  = pad_along_height // 2
-        layer['pad_bottom']  = pad_along_height - layer['pad_top']
-        #Width
+        layer['pad_top'] = pad_along_height // 2
+        layer['pad_bottom'] = pad_along_height - layer['pad_top']
+        # Width
         layer['out_width'] = int(math.ceil(float(in_width) / float(layer['stride_width'])))
         if (in_width % layer['stride_width'] == 0):
             pad_along_width = max(layer['filt_width'] - layer['stride_width'], 0)
         else:
             pad_along_width = max(layer['filt_width'] - (in_width % layer['stride_width']), 0)
-        layer['pad_left']  = pad_along_width // 2
-        layer['pad_right']  = pad_along_width - layer['pad_left']
-    elif layer['padding']=='valid':
+        layer['pad_left'] = pad_along_width // 2
+        layer['pad_right'] = pad_along_width - layer['pad_left']
+    elif layer['padding'] == 'valid':
         layer['out_width'] = int(math.ceil(float(in_width - layer['filt_width'] + 1) / float(layer['stride_width'])))
         layer['out_height'] = int(math.ceil(float(in_height - layer['filt_height'] + 1) / float(layer['stride_height'])))
         layer['pad_top'] = 0
@@ -92,6 +95,7 @@ def _compute_pads_2d(layer, in_height, in_width):
     elif layer['padding'] == 'explicit':
         #paddings = tf_op.get_attr('explicit_paddings')
         raise NotImplementedError('Explicit padding is not supported yet.')
+
 
 def _find_graph_outputs(graph):
     input_list = []
@@ -104,6 +108,7 @@ def _find_graph_outputs(graph):
 
     return [o.name.rsplit(':', 1)[0] for o in list(set(output_list) - set(input_list))]
 
+
 def _parse_tensor_names(tensors):
     if not isinstance(tensors, list):
         tensors = [tensors]
@@ -114,13 +119,14 @@ def _parse_tensor_names(tensors):
 
     return tensor_names
 
+
 def tf_to_hls(yamlConfig):
 
     ######################
-    ##  Do translation
+    # Do translation
     ######################
 
-    #This is a list of dictionaries to hold all the layer info we need to generate HLS
+    # This is a list of dictionaries to hold all the layer info we need to generate HLS
     layer_list = []
 
     if not os.path.exists(yamlConfig['TensorFlowModel']):
@@ -129,7 +135,7 @@ def tf_to_hls(yamlConfig):
     graph_def = None
     graph = None
 
-    #Extract model architecture from pb
+    # Extract model architecture from pb
     try:
         with tf.io.gfile.GFile(yamlConfig['TensorFlowModel'], "rb") as f:
             graph_def = tf.compat.v1.GraphDef()
@@ -150,7 +156,7 @@ def tf_to_hls(yamlConfig):
     except BaseException as e:
         raise Exception('Error importing the graph: {}'.format(str(e)))
 
-    #Define supported operations
+    # Define supported operations
     array_ops = ['ConcatV2', 'StridedSlice', 'Transpose']
     core_ops = ['Const', 'Identity', 'Placeholder']
     image_ops = ['ResizeNearestNeighbor']
@@ -175,7 +181,7 @@ def tf_to_hls(yamlConfig):
         layer['name'] = tf_op.name
 
         if tf_op.type == 'Placeholder':
-            if len(tf_op.inputs) == 0: # Input
+            if len(tf_op.inputs) == 0:  # Input
                 output_shape = tf_op.outputs[0].shape.as_list()
                 layer['class_name'] = 'InputLayer'
                 layer['input_shape'] = output_shape[1:]
@@ -285,7 +291,7 @@ def tf_to_hls(yamlConfig):
         elif tf_op.type == 'FusedBatchNorm':
             input_shape = tf_op.inputs[0].shape.as_list()
             output_shape = tf_op.outputs[0].shape.as_list()
-            
+
             layer['class_name'] = 'BatchNormalization'
             layer['inputs'] = _parse_tensor_names(tf_op.inputs[0])
             layer['outputs'] = _parse_tensor_names(tf_op.outputs[0])
@@ -311,7 +317,7 @@ def tf_to_hls(yamlConfig):
                 raise Exception('Unsupported number of inputs in Concat operation')
 
             layer['op'] = layer['class_name'].lower() + '{}d'.format(rank)
-            layer['axis'] = tf_op.inputs[2].op.node_def.attr['value'].tensor.int_val[0] # Urgh!
+            layer['axis'] = tf_op.inputs[2].op.node_def.attr['value'].tensor.int_val[0]  # Urgh!
 
             handled = True
 
@@ -320,11 +326,11 @@ def tf_to_hls(yamlConfig):
             layer['inputs'] = _parse_tensor_names(list(tf_op.inputs))
             layer['outputs'] = _parse_tensor_names(tf_op.outputs[0])
             output_shape = tf_op.outputs[0].shape.as_list()
-            
+
             layer['op'] = tf_op.type.lower()
             if layer['op'] == 'mul':
                 layer['op'] = 'multiply'
-            
+
             handled = True
 
         elif tf_op.type == 'Transpose':
@@ -342,7 +348,7 @@ def tf_to_hls(yamlConfig):
             layer['inputs'] = _parse_tensor_names(tf_op.inputs[0])
             layer['outputs'] = _parse_tensor_names(tf_op.outputs[0])
 
-            input_shape = tf_op.inputs[0].shape.as_list() # (B, H, W, C)
+            input_shape = tf_op.inputs[0].shape.as_list()  # (B, H, W, C)
             output_shape = tf_op.outputs[0].shape.as_list()
             layer['in_height'] = input_shape[1]
             layer['in_width'] = input_shape[2]
@@ -367,7 +373,7 @@ def tf_to_hls(yamlConfig):
         layer_list.append(layer)
 
     #################
-    ## Generate HLS
+    # Generate HLS
     #################
 
     reader = TFDataReader(graph)

--- a/hls4ml/model/optimizer/__init__.py
+++ b/hls4ml/model/optimizer/__init__.py
@@ -38,5 +38,4 @@ register_pass('broadcast_stream', BroadcastStream)
 if __qkeras_optimizers__:
     register_pass('output_rounding_saturation_mode', OutputRoundingSaturationMode)
     register_pass('qkeras_factorize_alpha', QKerasFactorizeAlpha)
-    register_pass('fuse_consecutive_batch_normalization', FuseConsecutiveBatchNormalization) 
-
+    register_pass('fuse_consecutive_batch_normalization', FuseConsecutiveBatchNormalization)

--- a/hls4ml/model/optimizer/optimizer.py
+++ b/hls4ml/model/optimizer/optimizer.py
@@ -5,27 +5,32 @@ class OptimizerPass(object):
 
     def match(self, node):
         raise NotImplementedError
-    
+
     def transform(self, model, node):
         raise NotImplementedError
 
+
 optimizer_map = {}
+
 
 def register_pass(name, opt_cls):
     if name in optimizer_map:
         raise Exception('Optimization pass {} already registered'.format(name))
-    
+
     if type(name) in [list, tuple]:
         for n in name:
             optimizer_map[n] = opt_cls
-    else:    
+    else:
         optimizer_map[name] = opt_cls
+
 
 def get_optimizer(name):
     return optimizer_map[name]()
 
+
 def get_available_passes():
     return list(optimizer_map.keys())
+
 
 def optimize_model(model, passes=None):
     if passes is None:

--- a/hls4ml/model/optimizer/passes/bn_fuse.py
+++ b/hls4ml/model/optimizer/passes/bn_fuse.py
@@ -1,5 +1,6 @@
 from hls4ml.model.optimizer import OptimizerPass
 
+
 class FuseBatchNormalization(OptimizerPass):
     def match(self, node):
         is_match = node.__class__.__name__ == 'BatchNormalization' and \

--- a/hls4ml/model/optimizer/passes/conv_same_pad.py
+++ b/hls4ml/model/optimizer/passes/conv_same_pad.py
@@ -1,5 +1,6 @@
 from hls4ml.model.optimizer import OptimizerPass
 
+
 class InsertZeroPaddingBeforeConv1D(OptimizerPass):
     def match(self, node):
         is_match = 'Conv1D' in node.__class__.__name__ and \
@@ -9,9 +10,9 @@ class InsertZeroPaddingBeforeConv1D(OptimizerPass):
 
     def transform(self, model, node):
         if model.config.backend.name != 'Vivado' or \
-            model.config.get_config_value('IOType') != 'io_stream':
+                model.config.get_config_value('IOType') != 'io_stream':
             return False
-        
+
         # Get the padding parameters from Conv1D layer
         pad_left = node.get_attr('pad_left')
         pad_right = node.get_attr('pad_right')
@@ -40,6 +41,7 @@ class InsertZeroPaddingBeforeConv1D(OptimizerPass):
 
         return True
 
+
 class InsertZeroPaddingBeforeConv2D(OptimizerPass):
     def match(self, node):
         is_match = 'Conv2D' in node.__class__.__name__ and \
@@ -49,9 +51,9 @@ class InsertZeroPaddingBeforeConv2D(OptimizerPass):
 
     def transform(self, model, node):
         if model.config.backend.name != 'Vivado' or \
-            model.config.get_config_value('IOType') != 'io_stream':
+                model.config.get_config_value('IOType') != 'io_stream':
             return False
-        
+
         # Get the padding parameters from Conv2D layer
         pad_top = node.get_attr('pad_top')
         pad_bottom = node.get_attr('pad_bottom')

--- a/hls4ml/model/optimizer/passes/fuse_biasadd.py
+++ b/hls4ml/model/optimizer/passes/fuse_biasadd.py
@@ -2,12 +2,14 @@ from hls4ml.model.optimizer import OptimizerPass
 
 from hls4ml.model import hls_model
 
+
 class FuseBiasAdd(OptimizerPass):
     ''' Fuses BiasAdd into Dense/Conv2D layer (common in TF models). '''
+
     def match(self, node):
         is_match = node.__class__.__name__ == 'BiasAdd' and \
             (node.get_input_node().__class__.__name__ == 'Dense' or
-            node.get_input_node().__class__.__name__ == 'Conv2D')
+             node.get_input_node().__class__.__name__ == 'Conv2D')
         return is_match
 
     def transform(self, model, node):

--- a/hls4ml/model/optimizer/passes/multi_dense.py
+++ b/hls4ml/model/optimizer/passes/multi_dense.py
@@ -2,13 +2,14 @@ from hls4ml.model.optimizer import OptimizerPass
 from hls4ml.model.hls_model import Dense
 import numpy as np
 
+
 class ReplaceMultidimensionalDenseWithConv(OptimizerPass):
     def match(self, node):
         return node.__class__.__name__ == 'Dense' and \
             len(node.get_input_variable().shape) > 1
 
     def transform(self, model, node):
-        dim = len(node.get_input_variable().shape) - 1        
+        dim = len(node.get_input_variable().shape) - 1
         input_shape = node.get_input_variable().shape
 
         pointwise_attrs = {
@@ -47,9 +48,9 @@ class ReplaceMultidimensionalDenseWithConv(OptimizerPass):
 
         class_name = 'PointwiseConv' + str(dim) + 'D'
         pw_node = model.make_node(class_name, node.name, pointwise_attrs, node.inputs.copy())
-        if len(node.weights['weight'].data.shape) == 2: # This can happen if we assign weights of Dense layer to 1x1 Conv2D
-            pw_node.weights['weight'].data = np.expand_dims(node.weights['weight'].data, axis=(0,1))
+        if len(node.weights['weight'].data.shape) == 2:  # This can happen if we assign weights of Dense layer to 1x1 Conv2D
+            pw_node.weights['weight'].data = np.expand_dims(node.weights['weight'].data, axis=(0, 1))
         pw_node.weights['bias'].data = node.weights['bias'].data
         model.replace_node(node, pw_node)
-        
+
         return True

--- a/hls4ml/model/optimizer/passes/nop.py
+++ b/hls4ml/model/optimizer/passes/nop.py
@@ -1,12 +1,13 @@
 from hls4ml.model.optimizer import OptimizerPass
 
+
 class EliminateLinearActivation(OptimizerPass):
     def match(self, node):
         cast = False
         if node.__class__.__name__ == 'Activation':
             cast = node.get_input_variable().type.precision != node.get_output_variable().type.precision
         return node.__class__.__name__ == 'Activation' and node.get_attr('activation') == 'linear' and not cast
-    
+
     def transform(self, model, node):
         model.remove_node(node)
         return True

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -48,12 +48,12 @@ def get_unoptimized_hlsmodel(model):
 
 def array_to_summary(x, fmt='boxplot'):
     if fmt == 'boxplot':
-        y = {'med' : np.median(x),
-             'q1' : np.percentile(x, 25),
-             'q3' : np.percentile(x, 75),
-             'whislo' : min(x),
-             'whishi' : max(x)
-        }
+        y = {'med': np.median(x),
+             'q1': np.percentile(x, 25),
+             'q3': np.percentile(x, 75),
+             'whislo': min(x),
+             'whishi': max(x)
+             }
     elif fmt == 'histogram':
         # Power of 2 bins covering data range
         high = np.ceil(np.log2(max(x))) + 1
@@ -61,14 +61,15 @@ def array_to_summary(x, fmt='boxplot'):
         bits = np.arange(low, high, 1)
         bins = 2 ** bits
         h, b = np.histogram(x, bins=bins)
-        h = h * 1. / float(sum(h)) # normalize
-        y = {'h' : h,
-             'b' : np.log2(b)}
+        h = h * 1. / float(sum(h))  # normalize
+        y = {'h': h,
+             'b': np.log2(b)}
     return y
+
 
 def boxplot(data, fmt='longform'):
     if fmt == 'longform':
-        f = plt.figure() #figsize=(3, 3))
+        f = plt.figure()  # figsize=(3, 3))
         hue = 'layer' if 'layer' in data.keys() else None
         vp = sb.boxplot(x='x', y='weight', hue=hue, data=data[data['x'] > 0], showfliers=False)
         vp.set_yticklabels(vp.get_yticklabels(), rotation=45, ha='right')
@@ -98,6 +99,7 @@ def boxplot(data, fmt='longform'):
     else:
         return None
 
+
 def histogram(data, fmt='longform'):
     f = plt.figure()
     from matplotlib.ticker import MaxNLocator
@@ -117,8 +119,10 @@ def histogram(data, fmt='longform'):
     plt.legend()
     return f
 
-plots = {'boxplot' : boxplot,
-         'histogram' : histogram}
+
+plots = {'boxplot': boxplot,
+         'histogram': histogram}
+
 
 def types_boxplot(data, fmt='longform'):
     from matplotlib.patches import PathPatch
@@ -141,9 +145,10 @@ def types_boxplot(data, fmt='longform'):
         ys = [(y, y) for y in plt.yticks()[0]]
     for irow, row in data[data['layer'] != 'model'].iterrows():
         if row['layer'] in ticks:
-            iy = np.argwhere(ticks == row['layer'])[0][0] # Determine which layer in the plot
+            iy = np.argwhere(ticks == row['layer'])[0][0]  # Determine which layer in the plot
             rectangle = Rectangle((row['low'], ys[iy][0]-0.4), row['high']-row['low'], 0.8, fill=True, color='grey', alpha=0.2)
             ax.add_patch(rectangle)
+
 
 def types_histogram(data, fmt='longform'):
     ax = plt.gca()
@@ -156,18 +161,21 @@ def types_histogram(data, fmt='longform'):
             plt.plot((row['low'], row['low']), ylim, '--', color=col)
             plt.plot((row['high'], row['high']), ylim, '--', color=col)
 
-types_plots = {'boxplot' : types_boxplot,
-               'histogram' : types_histogram}
+
+types_plots = {'boxplot': types_boxplot,
+               'histogram': types_histogram}
+
 
 def ap_fixed_WIF(dtype):
     from hls4ml.templates.vivado_template import VivadoBackend
-    dtype = VivadoBackend.convert_precision_string(None, dtype) 
+    dtype = VivadoBackend.convert_precision_string(None, dtype)
     W, I, F = dtype.width, dtype.integer, dtype.fractional
     return W, I, F
 
+
 def types_hlsmodel(model):
     suffix = ['w', 'b']
-    data = {'layer' : [], 'low' : [], 'high' : []}
+    data = {'layer': [], 'low': [], 'high': []}
     # Plot the default precision
     default_precision = model.config.model_precision['default']
     # assumes ap_fixed
@@ -188,8 +196,9 @@ def types_hlsmodel(model):
     data = pandas.DataFrame(data)
     return data
 
+
 def activation_types_hlsmodel(model):
-    data = {'layer' : [], 'low' : [], 'high' : []}
+    data = {'layer': [], 'low': [], 'high': []}
     # Get the default precision
     default_precision = model.config.model_precision['default']
     W, I, F = ap_fixed_WIF(default_precision)
@@ -205,10 +214,11 @@ def activation_types_hlsmodel(model):
     data = pandas.DataFrame(data)
     return data
 
+
 def weights_hlsmodel(model, fmt='longform', plot='boxplot'):
     suffix = ['w', 'b']
     if fmt == 'longform':
-        data = {'x' : [], 'layer' : [], 'weight' : []}
+        data = {'x': [], 'layer': [], 'weight': []}
     elif fmt == 'summary':
         data = []
 
@@ -292,7 +302,7 @@ def activations_hlsmodel(model, X, fmt='summary', plot='boxplot'):
 
 def weights_keras(model, fmt='longform', plot='boxplot'):
     if fmt == 'longform':
-        data = {'x' : [], 'layer' : [], 'weight' : []}
+        data = {'x': [], 'layer': [], 'weight': []}
     elif fmt == 'summary':
         data = []
     for layer in model.layers:
@@ -320,12 +330,13 @@ def weights_keras(model, fmt='longform', plot='boxplot'):
         data = pandas.DataFrame(data)
     return data
 
+
 def activations_keras(model, X, fmt='longform', plot='boxplot'):
     # test layer by layer on data
     if fmt == 'longform':
         # return long form pandas dataframe for
         # seaborn boxplot
-        data = {'x' : [], 'weight' : []}
+        data = {'x': [], 'weight': []}
     elif fmt == 'summary':
         # return summary statistics for matplotlib.axes.Axes.bxp
         # or histogram bin edges and heights
@@ -537,9 +548,10 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
 def _is_ignored_layer(layer):
     """Some layers need to be ingored during inference"""
     if isinstance(layer, (keras.layers.InputLayer,
-                        keras.layers.Dropout)):
+                          keras.layers.Dropout)):
         return True
     return False
+
 
 def _get_output(layer, X, model_input):
     """Get output of partial model"""
@@ -547,6 +559,7 @@ def _get_output(layer, X, model_input):
                                        outputs=layer.output)
     y = partial_model.predict(X)
     return y
+
 
 def get_ymodel_keras(keras_model, X):
     """
@@ -565,57 +578,59 @@ def get_ymodel_keras(keras_model, X):
     dictionary
         A dictionary in the form {"layer_name": ouput array of layer}
     """
-    
+
     ymodel = {}
-    
+
     for layer in keras_model.layers:
         print("Processing {} in Keras model...".format(layer.name))
         if not _is_ignored_layer(layer):
-            #If the layer has activation integrated then separate them
-            #Note that if the layer is a standalone activation layer then skip this
-            if hasattr(layer, 'activation') and not (isinstance(layer,keras.layers.Activation) or isinstance(layer, qkeras.qlayers.QActivation)):
+            # If the layer has activation integrated then separate them
+            # Note that if the layer is a standalone activation layer then skip this
+            if hasattr(layer, 'activation') and not (isinstance(layer, keras.layers.Activation) or isinstance(layer, qkeras.qlayers.QActivation)):
                 if layer.activation:
-                    
+
                     if layer.activation.__class__.__name__ == "linear":
                         ymodel[layer.name] = _get_output(layer, X, keras_model.input)
-                    
+
                     else:
                         temp_activation = layer.activation
                         layer.activation = None
-                        #Get output for layer without activation
+                        # Get output for layer without activation
                         ymodel[layer.name] = _get_output(layer, X, keras_model.input)
 
-                        #Add the activation back 
+                        # Add the activation back
                         layer.activation = temp_activation
-                        #Get ouput for activation
-                        ymodel[layer.name + "_{}".format(temp_activation.__class__.__name__)] =  _get_output(layer, X, keras_model.input)
+                        # Get ouput for activation
+                        ymodel[layer.name + "_{}".format(temp_activation.__class__.__name__)] = _get_output(layer, X, keras_model.input)
                 else:
                     ymodel[layer.name] = _get_output(layer, X, keras_model.input)
-            else:    
+            else:
                 ymodel[layer.name] = _get_output(layer, X, keras_model.input)
     print("Done taking outputs for Keras model.")
     return ymodel
 
+
 def _norm_diff(ymodel, ysim):
     """Calculate the square root of the sum of the squares of the differences"""
     diff = {}
-    
+
     for key in list(ysim.keys()):
         diff[key] = np.linalg.norm(ysim[key]-ymodel[key])
-    
-    #---Bar Plot---
+
+    # ---Bar Plot---
     f, ax = plt.subplots()
-    plt.bar(list(diff.keys()),list(diff.values()))
+    plt.bar(list(diff.keys()), list(diff.values()))
     plt.title("layer-by-layer output differences")
     ax.set_ylabel('Norm of difference vector')
     plt.xticks(rotation=90)
     plt.tight_layout()
     return f
 
+
 def _dist_diff(ymodel, ysim):
     """
     Calculate the normalized distribution of the differences of the elements
-    of the output vectors. 
+    of the output vectors.
     If difference >= original value then the normalized difference will be set to 1,
     meaning "very difference".
     If difference < original value then the normalized difference would be difference/original.
@@ -632,20 +647,20 @@ def _dist_diff(ymodel, ysim):
         abs_ymodel = np.absolute(flattened_ymodel)
 
         normalized_diff = np.zeros(diff_vector.shape)
-        normalized_diff[(diff_vector >= abs_ymodel) & (abs_ymodel>0) & (diff_vector>0)] = 1
+        normalized_diff[(diff_vector >= abs_ymodel) & (abs_ymodel > 0) & (diff_vector > 0)] = 1
 
-        #Fill out the rest
+        # Fill out the rest
         index = diff_vector < abs_ymodel
         normalized_diff[index] = diff_vector[index] / abs_ymodel[index]
 
         diff[key] = normalized_diff
 
-    #---Box Plot---
+    # ---Box Plot---
     f, ax = plt.subplots()
-    pos = np.array(range(len(list(diff.values())))) + 1            
+    pos = np.array(range(len(list(diff.values())))) + 1
     ax.boxplot(list(diff.values()), sym='k+', positions=pos)
 
-    #--formatting
+    # --formatting
     plt.title("Layer-by-layer distribution of output differences")
     ax.set_xticklabels(list(diff.keys()))
     ax.set_ylabel('Normalized difference')
@@ -655,38 +670,39 @@ def _dist_diff(ymodel, ysim):
 
     return f
 
-def compare(keras_model, hls_model, X, plot_type = "dist_diff"):
+
+def compare(keras_model, hls_model, X, plot_type="dist_diff"):
     """
     Compare each layer's output in keras and hls model. Note that the hls_model should not be compiled before using this.
 
     Parameters
     ----------
-    keras_model : 
+    keras_model :
         original keras model
     hls_model :
         converted HLSModel, with "Trace:True" in the configuration file.
-    X : array-like 
-        Input for the model. 
+    X : array-like
+        Input for the model.
     plot_type : string
         different methods to visualize the y_model and y_sim differences.
         Possible options include:
-        
-        - 'norm_diff' : square root of the sum of the squares of the differences 
-          between each output vectors 
+
+        - 'norm_diff' : square root of the sum of the squares of the differences
+          between each output vectors
         - 'dist_diff' : The normalized distribution of the differences of the elements
           between two output vectors
-        
+
     Returns
     -------
     matplotlib figure
         plot object of the histogram depicting the difference in each layer's output
     """
-    
-    #Take in output from both models
-    #Note that each y is a dictionary with structure {"layer_name": flattened ouput array}
+
+    # Take in output from both models
+    # Note that each y is a dictionary with structure {"layer_name": flattened ouput array}
     ymodel = get_ymodel_keras(keras_model, X)
     _, ysim = hls_model.trace(X)
-    
+
     print("Plotting difference...")
     f = plt.figure()
     if plot_type == "norm_diff":

--- a/hls4ml/report/vivado_report.py
+++ b/hls4ml/report/vivado_report.py
@@ -3,6 +3,7 @@ import os
 import re
 import xml.etree.ElementTree as ET
 
+
 def read_vivado_report(hls_dir, full_report=False):
     if not os.path.exists(hls_dir):
         print('Path {} does not exist. Exiting.'.format(hls_dir))
@@ -30,6 +31,7 @@ def read_vivado_report(hls_dir, full_report=False):
         print('Reports for solution "{}":\n'.format(sln))
         _find_reports(sln_dir + '/' + sln, top_func_name, full_report)
 
+
 def _parse_build_script(script_path):
     prj_dir = None
     top_func_name = None
@@ -42,6 +44,7 @@ def _parse_build_script(script_path):
                 top_func_name = line.split()[-1]
 
     return prj_dir, top_func_name
+
 
 def _find_solutions(sln_dir):
     solutions = []
@@ -58,6 +61,7 @@ def _find_solutions(sln_dir):
                 solutions.append(sln_name)
 
     return solutions
+
 
 def _find_reports(sln_dir, top_func_name, full_report=False):
     csim_file = sln_dir + '/csim/report/{}_csim.log'.format(top_func_name)
@@ -78,10 +82,12 @@ def _find_reports(sln_dir, top_func_name, full_report=False):
     else:
         print('Co-simulation report not found.')
 
+
 def _show_csim_report(csim_file):
     with open(csim_file, 'r') as f:
         print('C SIMULATION RESULT:')
         print(f.read())
+
 
 def _show_synth_report(synth_file, full_report=False):
     with open(synth_file, 'r') as f:
@@ -89,12 +95,14 @@ def _show_synth_report(synth_file, full_report=False):
         for line in f.readlines()[2:]:
             if not full_report and '* DSP48' in line:
                 break
-            print(line, end = '')
+            print(line, end='')
+
 
 def _show_cosim_report(cosim_file):
     with open(cosim_file, 'r') as f:
         print('CO-SIMULATION RESULT:')
         print(f.read())
+
 
 def parse_vivado_report(hls_dir):
     if not os.path.exists(hls_dir):
@@ -163,7 +171,7 @@ def parse_vivado_report(hls_dir):
         with open(cosim_file, 'r') as f:
             for line in f.readlines():
                 if re.search('VHDL', line) or re.search('Verilog', line):
-                    result = line[1:].split() # [1:] skips the leading '|'
+                    result = line[1:].split()  # [1:] skips the leading '|'
                     result = [res[:-1] if res[-1] == '|' else res for res in result]
                     # RTL, Status, Latency-min, Latency-avg, Latency-max, Interval-min, Interval-avg, Interval-max
                     if result[1] == 'NA':
@@ -177,4 +185,3 @@ def parse_vivado_report(hls_dir):
                         report['CosimIntervalMax'] = result[7]
 
     return report
-

--- a/hls4ml/templates/templates.py
+++ b/hls4ml/templates/templates.py
@@ -23,13 +23,16 @@ class Backend(object):
     def register_source(self, file_name, source, destination_dir='nnet_utils'):
         raise NotImplementedError
 
+
 backend_map = {}
+
 
 def register_backend(name, backend_cls):
     if name in backend_map:
         raise Exception('Backend {} already registered'.format(name))
-    
+
     backend_map[name] = backend_cls()
+
 
 def get_backend(name):
     return backend_map[name]

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -26,8 +26,7 @@
 
 namespace nnet {
 
-struct activ_config
-{
+struct activ_config {
     // IO size
     static const unsigned n_in = 10;
 
@@ -39,77 +38,80 @@ struct activ_config
     static const unsigned reuse_factor = 1;
 
     // Internal data type definitions
-    typedef ap_fixed<18,8> table_t;
+    typedef ap_fixed<18, 8> table_t;
 };
 
 // *************************************************
 //       LINEAR Activation -- See Issue 53
 // *************************************************
-template<class data_T, class res_T, typename CONFIG_T>
-void  linear(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void linear(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
         res[ii] = data[ii];
     }
 }
 
-
-
 // *************************************************
 //       RELU Activation
 // *************************************************
-template<class data_T, class res_T, typename CONFIG_T>
-void  relu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void relu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     data_T datareg;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
         datareg = data[ii];
-        if (datareg > 0) res[ii] = datareg;
-        else res[ii] = 0;
+        if (datareg > 0)
+            res[ii] = datareg;
+        else
+            res[ii] = 0;
     }
 }
 
-template<class data_T, class res_T, int MAX_INT, typename CONFIG_T>
-void  relu_max(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, int MAX_INT, typename CONFIG_T>
+void relu_max(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     data_T datareg;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
         datareg = data[ii];
-        if (datareg < 0) res[ii] = 0;
-        else if (datareg > MAX_INT) res[ii] = MAX_INT;
-        else res[ii] = datareg;
+        if (datareg < 0)
+            res[ii] = 0;
+        else if (datareg > MAX_INT)
+            res[ii] = MAX_INT;
+        else
+            res[ii] = datareg;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void  relu6(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void relu6(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
     relu_max<data_T, res_T, 6, CONFIG_T>(data, res);
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void  relu1(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void relu1(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
     relu_max<data_T, res_T, 1, CONFIG_T>(data, res);
 }
@@ -117,29 +119,29 @@ void  relu1(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 // *************************************************
 //       Sigmoid Activation
 // *************************************************
-inline float sigmoid_fcn_float(float input) {
+inline float sigmoid_fcn_float(float input)
+{
     return 1.0 / (1 + std::exp(-input));
 }
 
-template<typename CONFIG_T, int N_TABLE>
-void init_sigmoid_table(typename CONFIG_T::table_t table_out[N_TABLE])
+template <typename CONFIG_T, int N_TABLE> void init_sigmoid_table(typename CONFIG_T::table_t table_out[N_TABLE])
 {
     // Default logistic sigmoid function:
     //   result = 1/(1+e^(-x))
     for (int ii = 0; ii < N_TABLE; ii++) {
         // First, convert from table index to X-value (signed 8-bit, range -8 to +8)
-        float in_val = 2*8.0*(ii-float(N_TABLE)/2.0)/float(N_TABLE);
+        float in_val = 2 * 8.0 * (ii - float(N_TABLE) / 2.0) / float(N_TABLE);
         // Next, compute lookup table function
         typename CONFIG_T::table_t real_val = sigmoid_fcn_float(in_val);
-        //std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
+        // std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
         table_out[ii] = real_val;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void  sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    // Initialize the lookup table
+// Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
     typename CONFIG_T::table_t sigmoid_table[CONFIG_T::table_size];
@@ -152,22 +154,24 @@ void  sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     // Index into the lookup table based on data
     int data_round;
     int index;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
-        data_round = data[ii]*CONFIG_T::table_size/16;
-        index = data_round + 8*CONFIG_T::table_size/16;
-        if (index < 0)   index = 0;
-        if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;
-        res[ii] = (res_T) sigmoid_table[index];
+        data_round = data[ii] * CONFIG_T::table_size / 16;
+        index = data_round + 8 * CONFIG_T::table_size / 16;
+        if (index < 0)
+            index = 0;
+        if (index > CONFIG_T::table_size - 1)
+            index = CONFIG_T::table_size - 1;
+        res[ii] = (res_T)sigmoid_table[index];
     }
 }
 
@@ -175,33 +179,39 @@ void  sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 //       Softmax Activation
 // *************************************************
 
-enum class softmax_implementation {latency=0, legacy=1, stable=2};
+enum class softmax_implementation {
+    latency = 0,
+    legacy = 1,
+    stable = 2
+};
 
-inline float exp_fcn_float(float input) {
+inline float exp_fcn_float(float input)
+{
     return std::exp(input);
 }
 
-template<class data_T, typename CONFIG_T>
-inline float softmax_real_val_from_idx(unsigned i){
+template <class data_T, typename CONFIG_T> inline float softmax_real_val_from_idx(unsigned i)
+{
     // Treat the index as the top N bits
     static constexpr int N = ceillog2(CONFIG_T::table_size); // number of address bits for table
     data_T x(0);
-    x(x.width-1, x.width-N) = i;
-    return (float) x;
+    x(x.width - 1, x.width - N) = i;
+    return (float)x;
 }
 
-template<class data_T, typename CONFIG_T>
-inline unsigned softmax_idx_from_real_val(data_T x){
+template <class data_T, typename CONFIG_T> inline unsigned softmax_idx_from_real_val(data_T x)
+{
     // Slice the top N bits to get an index into the table
     static constexpr int N = ceillog2(CONFIG_T::table_size); // number of address bits for table
-    ap_uint<N> y = x(x.width-1, x.width-N); // slice the top N bits of input
-    return (unsigned) y(N-1, 0);
+    ap_uint<N> y = x(x.width - 1, x.width - N);              // slice the top N bits of input
+    return (unsigned)y(N - 1, 0);
 }
 
-template<class data_T, typename CONFIG_T>
-void init_exp_table(typename CONFIG_T::exp_table_t table_out[CONFIG_T::table_size]){
+template <class data_T, typename CONFIG_T>
+void init_exp_table(typename CONFIG_T::exp_table_t table_out[CONFIG_T::table_size])
+{
     // The template data_T is the data type used to address the table
-    for(unsigned i = 0; i < CONFIG_T::table_size; i++){
+    for (unsigned i = 0; i < CONFIG_T::table_size; i++) {
         // Slicing bits for address is going to round towards 0, so take the central value
         float x = softmax_real_val_from_idx<data_T, CONFIG_T>(i);
         typename CONFIG_T::exp_table_t exp_x = exp_fcn_float(x);
@@ -209,10 +219,11 @@ void init_exp_table(typename CONFIG_T::exp_table_t table_out[CONFIG_T::table_siz
     }
 }
 
-template<class data_T, typename CONFIG_T>
-void init_invert_table(typename CONFIG_T::inv_table_t table_out[CONFIG_T::table_size]){
+template <class data_T, typename CONFIG_T>
+void init_invert_table(typename CONFIG_T::inv_table_t table_out[CONFIG_T::table_size])
+{
     // The template data_T is the data type used to address the table
-    for(unsigned i = 0; i < CONFIG_T::table_size; i++){
+    for (unsigned i = 0; i < CONFIG_T::table_size; i++) {
         float x = softmax_real_val_from_idx<data_T, CONFIG_T>(i);
         typename CONFIG_T::inv_table_t inv_x = 1 / x;
         table_out[i] = inv_x;
@@ -220,9 +231,10 @@ void init_invert_table(typename CONFIG_T::inv_table_t table_out[CONFIG_T::table_
 }
 
 template <class data_T, class res_T, typename CONFIG_T>
-void softmax_latency(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
-    #pragma HLS pipeline
-    // Initialize the lookup tables
+void softmax_latency(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+{
+#pragma HLS pipeline
+// Initialize the lookup tables
 #ifdef __HLS_SYN__
     bool initialized = false;
     typename CONFIG_T::exp_table_t exp_table[CONFIG_T::table_size];
@@ -243,30 +255,33 @@ void softmax_latency(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
 
     // Calculate all the e^x's
     typename CONFIG_T::exp_table_t exp_res[CONFIG_T::n_in];
-	#pragma HLS array_partition variable=exp_res complete
+    #pragma HLS array_partition variable=exp_res complete
     typename CONFIG_T::exp_table_t exp_sum(0);
-    for(unsigned i = 0; i < CONFIG_T::n_in; i++){
+    for (unsigned i = 0; i < CONFIG_T::n_in; i++) {
         #pragma HLS unroll
-    	unsigned x = softmax_idx_from_real_val<data_T, CONFIG_T>(data[i]);
+        unsigned x = softmax_idx_from_real_val<data_T, CONFIG_T>(data[i]);
         exp_res[i] = exp_table[x];
     }
 
     // Explicitly sum the results with an adder tree.
     // Rounding & Saturation mode, which improve accuracy, prevent Vivado from expression balancing
     Op_add<typename CONFIG_T::exp_table_t> op_add;
-    exp_sum = reduce<typename CONFIG_T::exp_table_t, CONFIG_T::n_in, Op_add<typename CONFIG_T::exp_table_t>>(exp_res, op_add);
+    exp_sum = reduce<typename CONFIG_T::exp_table_t, CONFIG_T::n_in, Op_add<typename CONFIG_T::exp_table_t> >(exp_res,
+                                                                                                              op_add);
 
-    typename CONFIG_T::inv_table_t inv_exp_sum = invert_table[softmax_idx_from_real_val<typename CONFIG_T::exp_table_t,CONFIG_T>(exp_sum)];
-    for(unsigned i = 0; i < CONFIG_T::n_in; i++){
+    typename CONFIG_T::inv_table_t inv_exp_sum =
+        invert_table[softmax_idx_from_real_val<typename CONFIG_T::exp_table_t, CONFIG_T>(exp_sum)];
+    for (unsigned i = 0; i < CONFIG_T::n_in; i++) {
         #pragma HLS unroll
         res[i] = exp_res[i] * inv_exp_sum;
     }
 }
 
 template <class data_T, class res_T, typename CONFIG_T>
-void softmax_stable(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
-    #pragma HLS pipeline
-    // Initialize the lookup tables
+void softmax_stable(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+{
+#pragma HLS pipeline
+// Initialize the lookup tables
 #ifdef __HLS_SYN__
     bool initialized = false;
     typename CONFIG_T::exp_table_t exp_table[CONFIG_T::table_size];
@@ -287,68 +302,70 @@ void softmax_stable(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
 
     // Find the max and compute all delta(x_i, x_max)
     Op_max<data_T> op_max;
-    data_T x_max = reduce<data_T, CONFIG_T::n_in, Op_max<data_T>>(data, op_max);
+    data_T x_max = reduce<data_T, CONFIG_T::n_in, Op_max<data_T> >(data, op_max);
 
     // For the diffs, use the same type as the input but force rounding and saturation
-    ap_fixed<data_T::width, data_T::iwidth,AP_RND,AP_SAT> d_xi_xmax[CONFIG_T::n_in];
-    for(unsigned i = 0; i < CONFIG_T::n_in; i++){
+    ap_fixed<data_T::width, data_T::iwidth, AP_RND, AP_SAT> d_xi_xmax[CONFIG_T::n_in];
+    for (unsigned i = 0; i < CONFIG_T::n_in; i++) {
         #pragma HLS unroll
         d_xi_xmax[i] = data[i] - x_max;
     }
 
     // Calculate all the e^x's
     typename CONFIG_T::exp_table_t exp_res[CONFIG_T::n_in];
-	#pragma HLS array_partition variable=exp_res complete
+    #pragma HLS array_partition variable=exp_res complete
     typename CONFIG_T::exp_table_t exp_sum(0);
-    for(unsigned i = 0; i < CONFIG_T::n_in; i++){
+    for (unsigned i = 0; i < CONFIG_T::n_in; i++) {
         #pragma HLS unroll
-    	unsigned x = softmax_idx_from_real_val<data_T, CONFIG_T>(d_xi_xmax[i]);
+        unsigned x = softmax_idx_from_real_val<data_T, CONFIG_T>(d_xi_xmax[i]);
         exp_res[i] = exp_table[x];
     }
 
     // Explicitly sum the results with an adder tree.
     // Rounding & Saturation mode, which improve accuracy, prevent Vivado from expression balancing
     Op_add<typename CONFIG_T::exp_table_t> op_add;
-    exp_sum = reduce<typename CONFIG_T::exp_table_t, CONFIG_T::n_in, Op_add<typename CONFIG_T::exp_table_t>>(exp_res, op_add);
+    exp_sum = reduce<typename CONFIG_T::exp_table_t, CONFIG_T::n_in, Op_add<typename CONFIG_T::exp_table_t> >(exp_res,
+                                                                                                              op_add);
 
-    typename CONFIG_T::inv_table_t inv_exp_sum = invert_table[softmax_idx_from_real_val<typename CONFIG_T::exp_table_t,CONFIG_T>(exp_sum)];
-    for(unsigned i = 0; i < CONFIG_T::n_in; i++){
+    typename CONFIG_T::inv_table_t inv_exp_sum =
+        invert_table[softmax_idx_from_real_val<typename CONFIG_T::exp_table_t, CONFIG_T>(exp_sum)];
+    for (unsigned i = 0; i < CONFIG_T::n_in; i++) {
         #pragma HLS unroll
         res[i] = exp_res[i] * inv_exp_sum;
     }
 }
 
-template<typename CONFIG_T, int N_TABLE>
-void init_exp_table_legacy(typename CONFIG_T::table_t table_out[N_TABLE])
+template <typename CONFIG_T, int N_TABLE> void init_exp_table_legacy(typename CONFIG_T::table_t table_out[N_TABLE])
 {
     for (int ii = 0; ii < N_TABLE; ii++) {
         // First, convert from table index to X-value (signed 8-bit, range -8 to +8)
-        float in_val = 2*8.0*(ii-float(N_TABLE)/2.0)/float(N_TABLE);
+        float in_val = 2 * 8.0 * (ii - float(N_TABLE) / 2.0) / float(N_TABLE);
         // Next, compute lookup table function
         typename CONFIG_T::table_t real_val = exp_fcn_float(in_val);
-        //std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
+        // std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
         table_out[ii] = real_val;
     }
 }
 
-template<typename CONFIG_T, int N_TABLE>
-void init_invert_table_legacy(typename CONFIG_T::table_t table_out[N_TABLE])
+template <typename CONFIG_T, int N_TABLE> void init_invert_table_legacy(typename CONFIG_T::table_t table_out[N_TABLE])
 {
     // Inversion function:
     //   result = 1/x
     for (int ii = 0; ii < N_TABLE; ii++) {
-      // First, convert from table index to X-value (signed 8-bit, range 0 to +64)
-	float in_val = 64.0*ii/float(N_TABLE);
+        // First, convert from table index to X-value (signed 8-bit, range 0 to +64)
+        float in_val = 64.0 * ii / float(N_TABLE);
         // Next, compute lookup table function
-	if (in_val > 0.0) table_out[ii] = 1.0/in_val;
-	else table_out[ii] = 0.0;
+        if (in_val > 0.0)
+            table_out[ii] = 1.0 / in_val;
+        else
+            table_out[ii] = 0.0;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void  softmax_legacy(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_legacy(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    // Initialize the lookup table
+// Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
     typename CONFIG_T::table_t exp_table[CONFIG_T::table_size];
@@ -364,53 +381,58 @@ void  softmax_legacy(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         // Note: This is going to be a resource hog to run with pipeline, but hey, whatever
         #pragma HLS PIPELINE
     }
 
     // Index into the lookup table based on data for exponentials
-    typename CONFIG_T::table_t exp_res[CONFIG_T::n_in];// different, independent, fixed point precision
-    typename CONFIG_T::table_t exp_diff_res;// different, independent, fixed point precision
+    typename CONFIG_T::table_t exp_res[CONFIG_T::n_in]; // different, independent, fixed point precision
+    typename CONFIG_T::table_t exp_diff_res;            // different, independent, fixed point precision
     data_T data_cache[CONFIG_T::n_in];
     int data_round;
     int index;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-      data_cache[ii] = data[ii];
-      exp_res[ii] = 0;
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        data_cache[ii] = data[ii];
+        exp_res[ii] = 0;
     }
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-      if (CONFIG_T::io_type == io_serial){
-          #pragma HLS PIPELINE
-      }
-      for (int jj=0; jj<CONFIG_T::n_in; jj++) {
-	if (ii==jj) exp_diff_res = 1;
-	else {
-	  data_round = (data_cache[jj]-data_cache[ii])*CONFIG_T::table_size/16;
-	  index = data_round + 8*CONFIG_T::table_size/16;
-	  if (index < 0)   index = 0;
-	  if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;
-	  exp_diff_res = exp_table[index];
-	}
-	exp_res[ii] += exp_diff_res;
-      }
-    }
-
-    //Second loop to invert
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-      int exp_res_index = exp_res[ii]*CONFIG_T::table_size/64;
-      if (exp_res_index < 0)   exp_res_index = 0;
-      if (exp_res_index > CONFIG_T::table_size-1) exp_res_index = CONFIG_T::table_size-1;
-      //typename CONFIG_T::table_t exp_res_invert = invert_table[exp_res_index];
-      res[ii] = (res_T) invert_table[exp_res_index];
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
+            #pragma HLS PIPELINE
+        }
+        for (int jj = 0; jj < CONFIG_T::n_in; jj++) {
+            if (ii == jj)
+                exp_diff_res = 1;
+            else {
+                data_round = (data_cache[jj] - data_cache[ii]) * CONFIG_T::table_size / 16;
+                index = data_round + 8 * CONFIG_T::table_size / 16;
+                if (index < 0)
+                    index = 0;
+                if (index > CONFIG_T::table_size - 1)
+                    index = CONFIG_T::table_size - 1;
+                exp_diff_res = exp_table[index];
+            }
+            exp_res[ii] += exp_diff_res;
+        }
     }
 
+    // Second loop to invert
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        int exp_res_index = exp_res[ii] * CONFIG_T::table_size / 64;
+        if (exp_res_index < 0)
+            exp_res_index = 0;
+        if (exp_res_index > CONFIG_T::table_size - 1)
+            exp_res_index = CONFIG_T::table_size - 1;
+        // typename CONFIG_T::table_t exp_res_invert = invert_table[exp_res_index];
+        res[ii] = (res_T)invert_table[exp_res_index];
+    }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+{
     #pragma HLS inline
-    switch(CONFIG_T::implementation){
+    switch (CONFIG_T::implementation) {
     case softmax_implementation::latency:
         softmax_latency<data_T, res_T, CONFIG_T>(data, res);
         break;
@@ -420,31 +442,30 @@ void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
     case softmax_implementation::legacy:
         softmax_legacy<data_T, res_T, CONFIG_T>(data, res);
         break;
-    }    
+    }
 }
 
 // *************************************************
 //       TanH Activation
 // *************************************************
-template<typename CONFIG_T, int N_TABLE>
-void init_tanh_table(typename CONFIG_T::table_t table_out[N_TABLE])
+template <typename CONFIG_T, int N_TABLE> void init_tanh_table(typename CONFIG_T::table_t table_out[N_TABLE])
 {
     // Implement tanh lookup
     for (int ii = 0; ii < N_TABLE; ii++) {
         // First, convert from table index to X-value (signed 8-bit, range -4 to +4)
-        float in_val = 2*4.0*(ii-float(N_TABLE)/2.0)/float(N_TABLE);
+        float in_val = 2 * 4.0 * (ii - float(N_TABLE) / 2.0) / float(N_TABLE);
         // Next, compute lookup table function
         typename CONFIG_T::table_t real_val = tanh(in_val);
-        //std::cout << "Tanh:  Lookup table Index: " <<  ii<< " In Value: " << in_val << " Result: " << real_val << std::endl;
+        // std::cout << "Tanh:  Lookup table Index: " <<  ii<< " In Value: " << in_val << " Result: " << real_val <<
+        // std::endl;
         table_out[ii] = real_val;
     }
 }
 
-
-template<class data_T, class res_T, typename CONFIG_T>
-void  tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    // Initialize the lookup table
+// Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
     typename CONFIG_T::table_t tanh_table[CONFIG_T::table_size];
@@ -457,46 +478,50 @@ void  tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     // Index into the lookup table based on data
     int data_round;
     int index;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
-        data_round = data[ii]*CONFIG_T::table_size/8;
-        index = data_round + 4*CONFIG_T::table_size/8;
-        //std::cout << "Input: "  << data[ii] << " Round: " << data_round << " Index: " << index << std::endl;
-        if (index < 0)   index = 0;
-        if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;
-        res[ii] = (res_T) tanh_table[index];
+        data_round = data[ii] * CONFIG_T::table_size / 8;
+        index = data_round + 4 * CONFIG_T::table_size / 8;
+        // std::cout << "Input: "  << data[ii] << " Round: " << data_round << " Index: " << index << std::endl;
+        if (index < 0)
+            index = 0;
+        if (index > CONFIG_T::table_size - 1)
+            index = CONFIG_T::table_size - 1;
+        res[ii] = (res_T)tanh_table[index];
     }
 }
 
 // *************************************************
 //       Hard sigmoid Activation
 // *************************************************
-template<class data_T, class res_T, typename CONFIG_T>
-void  hard_sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void hard_sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     data_T datareg;
-    data_T slope = (data_T) 0.2;
-    data_T shift = (data_T) 0.5;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    data_T slope = (data_T)0.2;
+    data_T shift = (data_T)0.5;
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
         datareg = slope * data[ii] + shift;
-        if (datareg > 1) datareg = 1;
-        else if (datareg < 0) datareg = 0;
+        if (datareg > 1)
+            datareg = 1;
+        else if (datareg < 0)
+            datareg = 0;
         res[ii] = datareg;
     }
 }
@@ -504,71 +529,75 @@ void  hard_sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 // *************************************************
 //       Leaky RELU Activation
 // *************************************************
-template<class data_T, class res_T, typename CONFIG_T>
-void  leaky_relu(data_T data[CONFIG_T::n_in], data_T alpha, res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void leaky_relu(data_T data[CONFIG_T::n_in], data_T alpha, res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     data_T datareg;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
         datareg = data[ii];
-        if (datareg > 0) res[ii] = datareg;
-        else res[ii] = alpha * datareg;
+        if (datareg > 0)
+            res[ii] = datareg;
+        else
+            res[ii] = alpha * datareg;
     }
 }
 
 // *************************************************
 //       Thresholded RELU Activation
 // *************************************************
-template<class data_T, class res_T, typename CONFIG_T>
-void  thresholded_relu(data_T data[CONFIG_T::n_in], data_T theta, res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void thresholded_relu(data_T data[CONFIG_T::n_in], data_T theta, res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     data_T datareg;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
         datareg = data[ii];
-        if (datareg > theta) res[ii] = datareg;
-        else res[ii] = 0;
+        if (datareg > theta)
+            res[ii] = datareg;
+        else
+            res[ii] = 0;
     }
 }
 
 // *************************************************
 //       Softplus Activation
 // *************************************************
-inline float softplus_fcn_float(float input) {
+inline float softplus_fcn_float(float input)
+{
     return std::log(std::exp(input) + 1.);
 }
 
-template<typename CONFIG_T, int N_TABLE>
-void init_softplus_table(typename CONFIG_T::table_t table_out[N_TABLE])
+template <typename CONFIG_T, int N_TABLE> void init_softplus_table(typename CONFIG_T::table_t table_out[N_TABLE])
 {
     // Default softplus function:
     //   result = log(exp(x) + 1)
     for (int ii = 0; ii < N_TABLE; ii++) {
         // First, convert from table index to X-value (signed 8-bit, range -8 to +8)
-        float in_val = 2*8.0*(ii-float(N_TABLE)/2.0)/float(N_TABLE);
+        float in_val = 2 * 8.0 * (ii - float(N_TABLE) / 2.0) / float(N_TABLE);
         // Next, compute lookup table function
         typename CONFIG_T::table_t real_val = softplus_fcn_float(in_val);
-        //std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
+        // std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
         table_out[ii] = real_val;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void  softplus(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void softplus(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    // Initialize the lookup table
+// Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
     typename CONFIG_T::table_t softplus_table[CONFIG_T::table_size];
@@ -581,51 +610,53 @@ void  softplus(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     // Index into the lookup table based on data
     int data_round;
     int index;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
-        data_round = data[ii]*CONFIG_T::table_size/16;
-        index = data_round + 8*CONFIG_T::table_size/16;
-        if (index < 0)   index = 0;
-        if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;
-        res[ii] = (res_T) softplus_table[index];
+        data_round = data[ii] * CONFIG_T::table_size / 16;
+        index = data_round + 8 * CONFIG_T::table_size / 16;
+        if (index < 0)
+            index = 0;
+        if (index > CONFIG_T::table_size - 1)
+            index = CONFIG_T::table_size - 1;
+        res[ii] = (res_T)softplus_table[index];
     }
 }
 
 // *************************************************
 //       Softsign Activation
 // *************************************************
-inline float softsign_fcn_float(float input) {
+inline float softsign_fcn_float(float input)
+{
     return input / (std::abs(input) + 1.);
 }
 
-template<typename CONFIG_T, int N_TABLE>
-void init_softsign_table(typename CONFIG_T::table_t table_out[N_TABLE])
+template <typename CONFIG_T, int N_TABLE> void init_softsign_table(typename CONFIG_T::table_t table_out[N_TABLE])
 {
     // Default softsign function:
     //   result = x / (abs(x) + 1)
     for (int ii = 0; ii < N_TABLE; ii++) {
         // First, convert from table index to X-value (signed 8-bit, range -8 to +8)
-        float in_val = 2*8.0*(ii-float(N_TABLE)/2.0)/float(N_TABLE);
+        float in_val = 2 * 8.0 * (ii - float(N_TABLE) / 2.0) / float(N_TABLE);
         // Next, compute lookup table function
         typename CONFIG_T::table_t real_val = softsign_fcn_float(in_val);
-        //std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
+        // std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
         table_out[ii] = real_val;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void  softsign(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void softsign(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    // Initialize the lookup table
+// Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
     typename CONFIG_T::table_t softsign_table[CONFIG_T::table_size];
@@ -638,51 +669,53 @@ void  softsign(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     // Index into the lookup table based on data
     int data_round;
     int index;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
-        data_round = data[ii]*CONFIG_T::table_size/16;
-        index = data_round + 8*CONFIG_T::table_size/16;
-        if (index < 0)   index = 0;
-        if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;
-        res[ii] = (res_T) softsign_table[index];
+        data_round = data[ii] * CONFIG_T::table_size / 16;
+        index = data_round + 8 * CONFIG_T::table_size / 16;
+        if (index < 0)
+            index = 0;
+        if (index > CONFIG_T::table_size - 1)
+            index = CONFIG_T::table_size - 1;
+        res[ii] = (res_T)softsign_table[index];
     }
 }
 
 // *************************************************
 //       ELU Activation
 // *************************************************
-inline float elu_fcn_float(float input) {
+inline float elu_fcn_float(float input)
+{
     return std::exp(input) - 1.;
 }
 
-template<typename CONFIG_T, int N_TABLE>
-void init_elu_table(typename CONFIG_T::table_t table_out[N_TABLE])
+template <typename CONFIG_T, int N_TABLE> void init_elu_table(typename CONFIG_T::table_t table_out[N_TABLE])
 {
     // Default ELU function:
     //   result = alpha * (e^(x) - 1)
     for (int ii = 0; ii < N_TABLE; ii++) {
         // First, convert from table index to X-value (signed 8-bit, range -8 to 0)
-        float in_val = -8.0*ii/float(N_TABLE);
+        float in_val = -8.0 * ii / float(N_TABLE);
         // Next, compute lookup table function
         typename CONFIG_T::table_t real_val = elu_fcn_float(in_val);
-        //std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
+        // std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
         table_out[ii] = real_val;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void  elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_in])
 {
-    // Initialize the lookup table
+// Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
     typename CONFIG_T::table_t elu_table[CONFIG_T::table_size];
@@ -695,60 +728,60 @@ void  elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     data_T datareg;
     // Index into the lookup table based on data
     int index;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
         datareg = data[ii];
         if (datareg >= 0) {
             res[ii] = datareg;
         } else {
-            index = datareg*CONFIG_T::table_size/-8;
-            if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;
+            index = datareg * CONFIG_T::table_size / -8;
+            if (index > CONFIG_T::table_size - 1)
+                index = CONFIG_T::table_size - 1;
             res[ii] = alpha * elu_table[index];
         }
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void  elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T> void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-	elu<data_T, res_T, CONFIG_T>(data, 1.0, res);
+    elu<data_T, res_T, CONFIG_T>(data, 1.0, res);
 }
 
 // *************************************************
 //       SELU Activation
 // *************************************************
-inline float selu_fcn_float(float input) {
+inline float selu_fcn_float(float input)
+{
     return 1.0507009873554804934193349852946 * (1.6732632423543772848170429916717 * (std::exp(input) - 1.));
 }
 
-template<typename CONFIG_T, int N_TABLE>
-void init_selu_table(typename CONFIG_T::table_t table_out[N_TABLE])
+template <typename CONFIG_T, int N_TABLE> void init_selu_table(typename CONFIG_T::table_t table_out[N_TABLE])
 {
     // Default SELU function:
     //   result = 1.05 * (1.673 * (e^(x) - 1))
     for (int ii = 0; ii < N_TABLE; ii++) {
         // First, convert from table index to X-value (signed 8-bit, range -8 to 0)
-        float in_val = -8.0*ii/float(N_TABLE);
+        float in_val = -8.0 * ii / float(N_TABLE);
         // Next, compute lookup table function
         typename CONFIG_T::table_t real_val = selu_fcn_float(in_val);
-        //std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
+        // std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
         table_out[ii] = real_val;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void  selu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void selu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    // Initialize the lookup table
+// Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
     typename CONFIG_T::table_t selu_table[CONFIG_T::table_size];
@@ -761,23 +794,24 @@ void  selu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     data_T datareg;
     // Index into the lookup table based on data
     int index;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
         datareg = data[ii];
         if (datareg >= 0) {
             res[ii] = res_T(1.0507009873554804934193349852946) * datareg;
         } else {
-            index = datareg*CONFIG_T::table_size/-8;
-            if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;
+            index = datareg * CONFIG_T::table_size / -8;
+            if (index > CONFIG_T::table_size - 1)
+                index = CONFIG_T::table_size - 1;
             res[ii] = selu_table[index];
         }
     }
@@ -786,81 +820,83 @@ void  selu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 // *************************************************
 //       PReLU Activation
 // *************************************************
-template<class data_T, class res_T, typename CONFIG_T>
-void  prelu(data_T data[CONFIG_T::n_in], data_T alpha[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void prelu(data_T data[CONFIG_T::n_in], data_T alpha[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         #pragma HLS PIPELINE
     }
 
     data_T datareg;
-    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
         datareg = data[ii];
-        if (datareg > 0) res[ii] = datareg;
-        else res[ii] = alpha[ii] * datareg;
+        if (datareg > 0)
+            res[ii] = datareg;
+        else
+            res[ii] = alpha[ii] * datareg;
     }
 }
 
 // *************************************************
 //       Binary TanH Activation
 // *************************************************
-template<class data_T, class res_T, typename CONFIG_T>
-void  binary_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void binary_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
 
- if (CONFIG_T::io_type == io_parallel){
-     #pragma HLS PIPELINE
- }
-  
- data_T datareg;   
- res_T cache; 
- for (int ii=0; ii<CONFIG_T::n_in; ii++) {
+    if (CONFIG_T::io_type == io_parallel) {
+        #pragma HLS PIPELINE
+    }
 
-  if (CONFIG_T::io_type == io_serial){
-      #pragma HLS PIPELINE
-  }
-  datareg = data[ii];	 
-  if( datareg > 0 ) cache = 1;
-  else cache = -1;
-  
-  res[ii] = (res_T) cache;
- 
- }
- 
+    data_T datareg;
+    res_T cache;
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+
+        if (CONFIG_T::io_type == io_serial) {
+            #pragma HLS PIPELINE
+        }
+        datareg = data[ii];
+        if (datareg > 0)
+            cache = 1;
+        else
+            cache = -1;
+
+        res[ii] = (res_T)cache;
+    }
 }
 
 // *************************************************
 //       Ternary TanH Activation
 // *************************************************
-template<class data_T, class res_T, typename CONFIG_T>
-void  ternary_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+template <class data_T, class res_T, typename CONFIG_T>
+void ternary_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
 
- if (CONFIG_T::io_type == io_parallel){
-     #pragma HLS PIPELINE
- }
-  
- data_T datareg;   
- res_T cache; 
- for (int ii=0; ii<CONFIG_T::n_in; ii++) {
+    if (CONFIG_T::io_type == io_parallel) {
+        #pragma HLS PIPELINE
+    }
 
-  if (CONFIG_T::io_type == io_serial){
-      #pragma HLS PIPELINE
-  }
-  datareg = 2*data[ii];	 
-  if( datareg > 1 ) cache = 1;
-  else if( datareg > -1 && datareg <= 1) cache=0;
-  else cache = -1;
-  
-  res[ii] = (res_T) cache;
- 
- }
- 
+    data_T datareg;
+    res_T cache;
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+
+        if (CONFIG_T::io_type == io_serial) {
+            #pragma HLS PIPELINE
+        }
+        datareg = 2 * data[ii];
+        if (datareg > 1)
+            cache = 1;
+        else if (datareg > -1 && datareg <= 1)
+            cache = 0;
+        else
+            cache = -1;
+
+        res[ii] = (res_T)cache;
+    }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_array.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_array.h
@@ -9,14 +9,12 @@ struct transpose_config {
     static const unsigned height = 10;
     static const unsigned width = 10;
     static const unsigned depth = 10;
-    static constexpr unsigned perm[3] = {2, 0, 1};
+    static constexpr unsigned perm[3] = { 2, 0, 1 };
 };
 
-template<class data_T, typename CONFIG_T>
-void transpose_2d(
-    data_T data[CONFIG_T::height * CONFIG_T::width],
-    data_T data_t[CONFIG_T::height * CONFIG_T::width]
-) {
+template <class data_T, typename CONFIG_T>
+void transpose_2d(data_T data[CONFIG_T::height * CONFIG_T::width], data_T data_t[CONFIG_T::height * CONFIG_T::width])
+{
     #pragma HLS PIPELINE
 
     for (int i = 0; i < CONFIG_T::height; i++) {
@@ -26,18 +24,17 @@ void transpose_2d(
     }
 }
 
-template<class data_T, typename CONFIG_T>
-void transpose_3d(
-    data_T data[CONFIG_T::depth * CONFIG_T::height * CONFIG_T::width],
-    data_T data_t[CONFIG_T::depth * CONFIG_T::height * CONFIG_T::width]
-) {
+template <class data_T, typename CONFIG_T>
+void transpose_3d(data_T data[CONFIG_T::depth * CONFIG_T::height * CONFIG_T::width],
+                  data_T data_t[CONFIG_T::depth * CONFIG_T::height * CONFIG_T::width])
+{
     unsigned dims[3] = { CONFIG_T::depth, CONFIG_T::height, CONFIG_T::width };
     unsigned dims_t[3];
     dims_t[0] = dims[CONFIG_T::perm[0]];
     dims_t[1] = dims[CONFIG_T::perm[1]];
     dims_t[2] = dims[CONFIG_T::perm[2]];
 
-    int idx[3] = {0}, idx_t[3] = {0};
+    int idx[3] = { 0 }, idx_t[3] = { 0 };
     for (idx[0] = 0; idx[0] < dims[0]; idx[0]++) {
         for (idx[1] = 0; idx[1] < dims[1]; idx[1]++) {
             for (idx[2] = 0; idx[2] < dims[2]; idx[2]++) {
@@ -45,12 +42,12 @@ void transpose_3d(
                 idx_t[1] = idx[CONFIG_T::perm[1]];
                 idx_t[2] = idx[CONFIG_T::perm[2]];
 
-                data_t[idx_t[0] * dims_t[1] * dims_t[2] + idx_t[1] * dims_t[2] + idx_t[2]] = data[idx[0] * dims[1] * dims[2] + idx[1] * dims[2] + idx[2]];
+                data_t[idx_t[0] * dims_t[1] * dims_t[2] + idx_t[1] * dims_t[2] + idx_t[2]] =
+                    data[idx[0] * dims[1] * dims[2] + idx[1] * dims[2] + idx[2]];
             }
         }
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm_stream.h
@@ -31,36 +31,39 @@ namespace nnet {
 //       Streaming Batch Normalization
 // ****************************************************
 
-template<class data_T, class res_T, typename CONFIG_T>
-void normalize(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
-    typename CONFIG_T::scale_t scale[CONFIG_T::n_in],
-    typename CONFIG_T::bias_t  bias[CONFIG_T::n_in]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void normalize(hls::stream<data_T> &data, hls::stream<res_T> &res, typename CONFIG_T::scale_t scale[CONFIG_T::n_in],
+               typename CONFIG_T::bias_t bias[CONFIG_T::n_in])
+{
     #pragma HLS ARRAY_PARTITION variable=scale complete
     #pragma HLS ARRAY_PARTITION variable=bias complete
 
     constexpr unsigned multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_in, CONFIG_T::reuse_factor);
     constexpr unsigned ii = CONFIG_T::n_in / multiplier_limit;
-    CONFIG_T::template product<typename data_T::value_type, typename CONFIG_T::scale_t, typename res_T::value_type>::limit(multiplier_limit);
+    CONFIG_T::template product<typename data_T::value_type, typename CONFIG_T::scale_t,
+                               typename res_T::value_type>::limit(multiplier_limit);
 
-    BatchNormLoop: for (int i = 0; i < CONFIG_T::n_in / data_T::size; i++) {
+BatchNormLoop:
+    for (int i = 0; i < CONFIG_T::n_in / data_T::size; i++) {
         #pragma HLS PIPELINE II=ii
 
         data_T in_data = data.read();
         res_T out_data;
-        #pragma HLS DATA_PACK variable=out_data
+    #pragma HLS DATA_PACK variable=out_data
 
-        BatchNormpack: for (int j = 0; j < data_T::size; j++) {
+    BatchNormpack:
+        for (int j = 0; j < data_T::size; j++) {
             #pragma HLS UNROLL
             int norm_index;
-            if (CONFIG_T::n_filt==-1) {
+            if (CONFIG_T::n_filt == -1) {
                 norm_index = i * data_T::size + j;
             } else {
                 norm_index = j % CONFIG_T::n_filt;
             }
-            out_data[j] = CONFIG_T::template product<typename data_T::value_type, typename CONFIG_T::scale_t, typename res_T::value_type>::product(in_data[j], scale[norm_index]) + bias[norm_index];
+            out_data[j] =
+                CONFIG_T::template product<typename data_T::value_type, typename CONFIG_T::scale_t,
+                                           typename res_T::value_type>::product(in_data[j], scale[norm_index]) +
+                bias[norm_index];
         }
 
         res.write(out_data);
@@ -70,22 +73,22 @@ void normalize(
 // ****************************************************
 //       Merged Batch Normalization and Quantized Tanh
 // ****************************************************
-template<class data_T, typename CONFIG_T>
-void normalize_binary_tanh(
-    hls::stream<data_T> &data,
-    hls::stream<nnet::array<ap_uint<1>, CONFIG_T::n_in>> &res,
-    typename data_T::value_type threshold[CONFIG_T::n_in]
-) {
-    #pragma HLS ARRAY_PARTITION variable=threshold complete
+template <class data_T, typename CONFIG_T>
+void normalize_binary_tanh(hls::stream<data_T> &data, hls::stream<nnet::array<ap_uint<1>, CONFIG_T::n_in> > &res,
+                           typename data_T::value_type threshold[CONFIG_T::n_in])
+{
+#pragma HLS ARRAY_PARTITION variable=threshold complete
 
-    BinaryNormLoop: for (int i = 0; i < CONFIG_T::n_in / data_T::size; i++) {
+BinaryNormLoop:
+    for (int i = 0; i < CONFIG_T::n_in / data_T::size; i++) {
         #pragma HLS PIPELINE
 
         data_T in_data = data.read();
         nnet::array<ap_uint<1>, CONFIG_T::n_in> out_data;
-        #pragma HLS DATA_PACK variable=out_data
+    #pragma HLS DATA_PACK variable=out_data
 
-        BatchNormPack: for (int j = 0; j < data_T::size; j++) {
+    BatchNormPack:
+        for (int j = 0; j < data_T::size; j++) {
             #pragma HLS UNROLL
             out_data[j] = (in_data[j] > threshold[i * data_T::size + j]) ? 1 : 0;
         }
@@ -94,26 +97,26 @@ void normalize_binary_tanh(
     }
 }
 
-template<class data_T, typename CONFIG_T>
-void normalize_ternary_tanh(
-    hls::stream<data_T> &data,
-    hls::stream<nnet::array<ap_int<2>, CONFIG_T::n_in>> &res,
-    typename data_T::value_type threshold_hi[CONFIG_T::n_in],
-    typename data_T::value_type threshold_lo[CONFIG_T::n_in]
-) {
-    #pragma HLS ARRAY_PARTITION variable=threshold_hi complete
-    #pragma HLS ARRAY_PARTITION variable=threshold_lo complete
+template <class data_T, typename CONFIG_T>
+void normalize_ternary_tanh(hls::stream<data_T> &data, hls::stream<nnet::array<ap_int<2>, CONFIG_T::n_in> > &res,
+                            typename data_T::value_type threshold_hi[CONFIG_T::n_in],
+                            typename data_T::value_type threshold_lo[CONFIG_T::n_in])
+{
+#pragma HLS ARRAY_PARTITION variable=threshold_hi complete
+#pragma HLS ARRAY_PARTITION variable=threshold_lo complete
 
-    TernaryNormLoop: for (int i = 0; i < CONFIG_T::n_in / data_T::size; i++) {
+TernaryNormLoop:
+    for (int i = 0; i < CONFIG_T::n_in / data_T::size; i++) {
         #pragma HLS PIPELINE
 
         data_T in_data = data.read();
         nnet::array<ap_int<2>, CONFIG_T::n_in> out_data;
-        #pragma HLS DATA_PACK variable=out_data
+    #pragma HLS DATA_PACK variable=out_data
 
-        BatchNormPack: for (int j = 0; j < data_T::size; j++) {
+    BatchNormPack:
+        for (int j = 0; j < data_T::size; j++) {
             #pragma HLS UNROLL
-            
+
             int norm_index = i * data_T::size + j;
 
             if (in_data[j] > threshold_hi[norm_index]) {
@@ -128,7 +131,6 @@ void normalize_ternary_tanh(
         res.write(out_data);
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_common.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_common.h
@@ -23,78 +23,83 @@
 #include "ap_fixed.h"
 
 // This is a substitute for "ceil(n/(float)d)".
-#define DIV_ROUNDUP(n,d) ((n + d - 1) / d)
-#define MIN(n,d) (n > d ? d : n)
-#define MAX(n,d) (n > d ? n : d)
+#define DIV_ROUNDUP(n, d) ((n + d - 1) / d)
+#define MIN(n, d) (n > d ? d : n)
+#define MAX(n, d) (n > d ? n : d)
 
 namespace nnet {
 
 // Common type definitions
-enum io_type {io_parallel = 0, io_serial, io_stream};
-enum strategy { latency, resource };
+enum io_type {
+    io_parallel = 0,
+    io_serial,
+    io_stream
+};
+enum strategy {
+    latency,
+    resource
+};
 
- /* ---
-  * Balanced tree reduce implementation.
-  * For use in scenarios where Vivado cannot expression balance
-  * Reduces an array of inputs to a single value using the template binary operator 'Op',
-  * for example summing all elements with Op_add, or finding the maximum with Op_max
-  * Use only when the input array is fully unrolled. Or, slice out a fully unrolled section
-  * before applying and accumulate the result over the rolled dimension.
-  * --- */
- template<class T, int N, class Op>
- T reduce(const T* x, Op op)
- {
-     static constexpr int leftN = pow2(floorlog2(N - 1)) > 0 ? pow2(floorlog2(N - 1)) : 0;
-     static constexpr int rightN = N - leftN > 0 ? N - leftN : 0;
-     if (N == 1){
-         return x[0];
-     }
-     if (N == 2){
-         return op(x[0],x[1]);
-     }
-     return op(reduce<T,leftN,Op>(x, op), reduce<T,rightN,Op>(x+leftN, op));
- } 
+/* ---
+ * Balanced tree reduce implementation.
+ * For use in scenarios where Vivado cannot expression balance
+ * Reduces an array of inputs to a single value using the template binary operator 'Op',
+ * for example summing all elements with Op_add, or finding the maximum with Op_max
+ * Use only when the input array is fully unrolled. Or, slice out a fully unrolled section
+ * before applying and accumulate the result over the rolled dimension.
+ * --- */
+template <class T, int N, class Op> T reduce(const T *x, Op op)
+{
+    static constexpr int leftN = pow2(floorlog2(N - 1)) > 0 ? pow2(floorlog2(N - 1)) : 0;
+    static constexpr int rightN = N - leftN > 0 ? N - leftN : 0;
+    if (N == 1) {
+        return x[0];
+    }
+    if (N == 2) {
+        return op(x[0], x[1]);
+    }
+    return op(reduce<T, leftN, Op>(x, op), reduce<T, rightN, Op>(x + leftN, op));
+}
 
- template<class T>
- class Op_add{
- public:
-	 T operator()(T a, T b){
-		 return a + b;
-	 }
- };
+template <class T> class Op_add {
+  public:
+    T operator()(T a, T b)
+    {
+        return a + b;
+    }
+};
 
- template<class T>
- class Op_and{
- public:
-	 T operator()(T a, T b){
-		 return a && b;
-	 }
- };
+template <class T> class Op_and {
+  public:
+    T operator()(T a, T b)
+    {
+        return a && b;
+    }
+};
 
- template<class T>
- class Op_or{
- public:
-	 T operator()(T a, T b){
-		 return a || b;
-	 }
- };
+template <class T> class Op_or {
+  public:
+    T operator()(T a, T b)
+    {
+        return a || b;
+    }
+};
 
- template<class T>
- class Op_max{
- public:
-     T operator()(T a, T b){
+template <class T> class Op_max {
+  public:
+    T operator()(T a, T b)
+    {
         return a >= b ? a : b;
-     }
- };
+    }
+};
 
- template<class T>
- class Op_min{
- public:
-     T operator()(T a, T b){
+template <class T> class Op_min {
+  public:
+    T operator()(T a, T b)
+    {
         return a <= b ? a : b;
-     }
- };
-
+    }
+};
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv1d.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv1d.h
@@ -27,8 +27,7 @@
 
 namespace nnet {
 
-struct conv1d_config
-{
+struct conv1d_config {
     // Internal data type definitions
     typedef float bias_t;
     typedef float weight_t;
@@ -44,19 +43,18 @@ struct conv1d_config
     static const unsigned n_filt = 1;
     static const unsigned stride_width = 1;
     static const unsigned dilation = 1;
-    static const unsigned out_width = 10; //(N_IN + PAD_LEFT * PAD_RIGHT - (DILATION * (FILT_WIDTH - 1) + 1)) / STRIDE + 1
+    static const unsigned out_width =
+        10; //(N_IN + PAD_LEFT * PAD_RIGHT - (DILATION * (FILT_WIDTH - 1) + 1)) / STRIDE + 1
 
     static const unsigned reuse_factor = 1;
     static const bool store_weights_in_bram = false;
     static const unsigned n_zeros = 0; // not used yet
 };
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_1d_cl(
-    data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_1d_cl(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan], res_T res[CONFIG_T::out_width * CONFIG_T::n_filt],
+                typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     if (CONFIG_T::strategy == nnet::latency) {
         conv_1d_latency_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);
@@ -65,6 +63,6 @@ void conv_1d_cl(
     }
 }
 
-}//end namespace
+} // end namespace
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv1d_latency.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv1d_latency.h
@@ -6,47 +6,44 @@
 
 namespace nnet {
 
-//Computes multiplier limit
-//This function should not be synthesized into firmware
-template<typename CONFIG_T>
+// Computes multiplier limit
+// This function should not be synthesized into firmware
+template <typename CONFIG_T>
 int compute_multiplier_limit(
-    typename CONFIG_T::weight_t  weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt]
-)
+    typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt])
 {
     int n_mult = 0;
-    for(int ii = 0; ii < CONFIG_T::out_width; ii++) {
-        for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
-            for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-                for(int jj = 0; jj < CONFIG_T::filt_width; jj++){
+    for (int ii = 0; ii < CONFIG_T::out_width; ii++) {
+        for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+                for (int jj = 0; jj < CONFIG_T::filt_width; jj++) {
 
-                    int index_weight = jj*CONFIG_T::n_chan*CONFIG_T::n_filt + cc*CONFIG_T::n_filt + ff;
+                    int index_weight = jj * CONFIG_T::n_chan * CONFIG_T::n_filt + cc * CONFIG_T::n_filt + ff;
 
-                    if((ii*CONFIG_T::stride_width+jj) < CONFIG_T::pad_left || (ii*CONFIG_T::stride_width+jj) >= (CONFIG_T::pad_left + CONFIG_T::in_width)){
-                        //padded -- do nothing
+                    if ((ii * CONFIG_T::stride_width + jj) < CONFIG_T::pad_left ||
+                        (ii * CONFIG_T::stride_width + jj) >= (CONFIG_T::pad_left + CONFIG_T::in_width)) {
+                        // padded -- do nothing
                         continue;
                     } else {
-                        //need to tune this cut?
-                        if( weights[index_weight] > 1e-20 || weights[index_weight] < -1e-20 ){
+                        // need to tune this cut?
+                        if (weights[index_weight] > 1e-20 || weights[index_weight] < -1e-20) {
                             n_mult++;
-                        }//end if nonzero weight
-                    }//end not padding
-                }//end loop accross filter
-            }//end channel loop
-        }//end filter loop
-    }//end output loop
+                        } // end if nonzero weight
+                    } // end not padding
+                } // end loop accross filter
+            } // end channel loop
+        } // end filter loop
+    } // end output loop
 
-    return ceil( float(n_mult) / float(CONFIG_T::reuse_factor) );
+    return ceil(float(n_mult) / float(CONFIG_T::reuse_factor));
 
-}//end compute_n_mult
+} // end compute_n_mult
 
-
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_1d_latency_cl(
-    data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt]
-)
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_1d_latency_cl(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
+                        res_T res[CONFIG_T::out_width * CONFIG_T::n_filt],
+                        typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                        typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
 
     typename CONFIG_T::accum_t mult[CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::filt_width];
@@ -64,66 +61,72 @@ void conv_1d_latency_cl(
 
     // Limit multipliers to control parallelization
     const int multiplier_limit = compute_multiplier_limit<CONFIG_T>(weights);
-    #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
+#pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
 
-    // Convolve, saving all multiplication results to accumulate later
-    ConvOut: for(int ii = 0; ii < CONFIG_T::out_width; ii++) {
-        ConvFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
-            ConvChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-                ConvMult: for(int jj = 0; jj < CONFIG_T::filt_width; jj++){
+// Convolve, saving all multiplication results to accumulate later
+ConvOut:
+    for (int ii = 0; ii < CONFIG_T::out_width; ii++) {
+    ConvFilt:
+        for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+        ConvChan:
+            for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+            ConvMult:
+                for (int jj = 0; jj < CONFIG_T::filt_width; jj++) {
 
-                    int index_mult   = ii*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_width + ff*CONFIG_T::n_chan*CONFIG_T::filt_width + cc*CONFIG_T::filt_width + jj;
-                    int index_weight = jj*CONFIG_T::n_chan*CONFIG_T::n_filt + cc*CONFIG_T::n_filt + ff;
-                    int index_data   = (ii*CONFIG_T::stride_width+jj-CONFIG_T::pad_left) * CONFIG_T::n_chan + cc;
+                    int index_mult = ii * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::filt_width +
+                                     ff * CONFIG_T::n_chan * CONFIG_T::filt_width + cc * CONFIG_T::filt_width + jj;
+                    int index_weight = jj * CONFIG_T::n_chan * CONFIG_T::n_filt + cc * CONFIG_T::n_filt + ff;
+                    int index_data = (ii * CONFIG_T::stride_width + jj - CONFIG_T::pad_left) * CONFIG_T::n_chan + cc;
 
-                    if((ii*CONFIG_T::stride_width+jj) < CONFIG_T::pad_left || (ii*CONFIG_T::stride_width+jj) >= (CONFIG_T::pad_left + CONFIG_T::in_width)){
+                    if ((ii * CONFIG_T::stride_width + jj) < CONFIG_T::pad_left ||
+                        (ii * CONFIG_T::stride_width + jj) >= (CONFIG_T::pad_left + CONFIG_T::in_width)) {
                         mult[index_mult] = 0;
-                    }
-                    else {
+                    } else {
                         mult[index_mult] = data[index_data] * weights[index_weight];
                     }
                 }
-            }//end channel loop
-        }//end filter loop
-    }//end output loop
-
+            } // end channel loop
+        } // end filter loop
+    } // end output loop
 
     // Initialize accumulator with input biases
-    for(int ii = 0; ii < CONFIG_T::out_width; ii++) {
-        for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-            acc[ii][ff]=biases[ff];
+    for (int ii = 0; ii < CONFIG_T::out_width; ii++) {
+        for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            acc[ii][ff] = biases[ff];
         }
     }
 
-
-    // Accumulate multiplication result
-    AccumOut: for(int ii = 0; ii < CONFIG_T::out_width; ii++) {
-        AccumFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-            //Do "dot product" sum within filter and sum over channels
-            AccumChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-                AccumDot: for(int jj = 0; jj < CONFIG_T::filt_width; jj++){
-                    int index_mult = ii*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_width + ff*CONFIG_T::n_chan*CONFIG_T::filt_width + cc*CONFIG_T::filt_width + jj;
+// Accumulate multiplication result
+AccumOut:
+    for (int ii = 0; ii < CONFIG_T::out_width; ii++) {
+    AccumFilt:
+        for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+        // Do "dot product" sum within filter and sum over channels
+        AccumChan:
+            for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+            AccumDot:
+                for (int jj = 0; jj < CONFIG_T::filt_width; jj++) {
+                    int index_mult = ii * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::filt_width +
+                                     ff * CONFIG_T::n_chan * CONFIG_T::filt_width + cc * CONFIG_T::filt_width + jj;
                     acc[ii][ff] += mult[index_mult];
-                }//end dot product loop
-            }//end channel loop
-        }//end filter loop
-    }//end output loop
-
+                } // end dot product loop
+            } // end channel loop
+        } // end filter loop
+    } // end output loop
 
     // Cast to "res_t" type
-    for(int ii = 0; ii < CONFIG_T::out_width; ii++) {
-        for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+    for (int ii = 0; ii < CONFIG_T::out_width; ii++) {
+        for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
             res[ii * CONFIG_T::n_filt + ff] = (res_T)(acc[ii][ff]);
         }
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void pointwise_conv_1d_cl(
-    data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void pointwise_conv_1d_cl(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
+                          res_T res[CONFIG_T::out_width * CONFIG_T::n_filt],
+                          typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
+                          typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     assert(CONFIG_T::filt_width == 1);
 
@@ -142,54 +145,56 @@ void pointwise_conv_1d_cl(
 
     // Limit multipliers to control parallelization
     const int multiplier_limit = compute_multiplier_limit<CONFIG_T>(weights);
-    #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
+#pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
 
-    // Convolve, saving all multiplication results to accumulate later
-    ConvOut: for(int ii = 0; ii < CONFIG_T::out_width; ii++) {
-        ConvFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-            ConvChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++) {
-                int index_mult   = ii*CONFIG_T::n_filt*CONFIG_T::n_chan + ff*CONFIG_T::n_chan + cc;
-                int index_weight = cc*CONFIG_T::n_filt + ff;
-                int index_data   = (ii*CONFIG_T::stride_width-CONFIG_T::pad_left) * CONFIG_T::n_chan + cc;
+// Convolve, saving all multiplication results to accumulate later
+ConvOut:
+    for (int ii = 0; ii < CONFIG_T::out_width; ii++) {
+    ConvFilt:
+        for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+        ConvChan:
+            for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+                int index_mult = ii * CONFIG_T::n_filt * CONFIG_T::n_chan + ff * CONFIG_T::n_chan + cc;
+                int index_weight = cc * CONFIG_T::n_filt + ff;
+                int index_data = (ii * CONFIG_T::stride_width - CONFIG_T::pad_left) * CONFIG_T::n_chan + cc;
 
-                if((ii*CONFIG_T::stride_width) < CONFIG_T::pad_left || (ii*CONFIG_T::stride_width) >= (CONFIG_T::pad_left + CONFIG_T::in_width)){
+                if ((ii * CONFIG_T::stride_width) < CONFIG_T::pad_left ||
+                    (ii * CONFIG_T::stride_width) >= (CONFIG_T::pad_left + CONFIG_T::in_width)) {
                     mult[index_mult] = 0;
-                }
-                else {
+                } else {
                     mult[index_mult] = data[index_data] * weights[index_weight];
                 }
-            }//end channel loop
-        }//end filter loop
-    }//end output loop
-
+            } // end channel loop
+        } // end filter loop
+    } // end output loop
 
     // Initialize accumulator with input biases
-    for(int ii = 0; ii < CONFIG_T::out_width; ii++) {
-        for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-            acc[ii][ff]=biases[ff];
+    for (int ii = 0; ii < CONFIG_T::out_width; ii++) {
+        for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            acc[ii][ff] = biases[ff];
         }
     }
 
-
-    // Accumulate multiplication result
-    AccumOut: for(int ii = 0; ii < CONFIG_T::out_width; ii++) {
-        AccumFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-            //Do "dot product" sum within filter and sum over channels
-            AccumChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++) {
-                int index_mult = ii*CONFIG_T::n_filt*CONFIG_T::n_chan + ff*CONFIG_T::n_chan + cc;
+// Accumulate multiplication result
+AccumOut:
+    for (int ii = 0; ii < CONFIG_T::out_width; ii++) {
+    AccumFilt:
+        for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+        // Do "dot product" sum within filter and sum over channels
+        AccumChan:
+            for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+                int index_mult = ii * CONFIG_T::n_filt * CONFIG_T::n_chan + ff * CONFIG_T::n_chan + cc;
                 acc[ii][ff] += mult[index_mult];
-            }//end channel loop
-        }//end filter loop
-    }//end output loop
-
+            } // end channel loop
+        } // end filter loop
+    } // end output loop
 
     // Cast to "res_t" type
-    for(int ii = 0; ii < CONFIG_T::out_width; ii++) {
-        for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+    for (int ii = 0; ii < CONFIG_T::out_width; ii++) {
+        for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
             res[ii * CONFIG_T::n_filt + ff] = (res_T)(acc[ii][ff]);
         }
     }
 }
-
 }
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv1d_resource.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv1d_resource.h
@@ -6,42 +6,41 @@
 
 namespace nnet {
 
-template<class data_T, typename CONFIG_T>
-void im2col_1d(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan], data_T data_col[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::out_width]) {
-    //int index = 0;
+template <class data_T, typename CONFIG_T>
+void im2col_1d(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
+               data_T data_col[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::out_width])
+{
+    // int index = 0;
     for (int channel = CONFIG_T::n_chan; channel--; data += CONFIG_T::in_width) {
         #pragma HLS PIPELINE II=1 rewind
-		for (int kernel_col = 0; kernel_col < CONFIG_T::filt_width; kernel_col++) {
+        for (int kernel_col = 0; kernel_col < CONFIG_T::filt_width; kernel_col++) {
             #pragma HLS UNROLL
             int input_col = -CONFIG_T::pad_left + kernel_col * CONFIG_T::dilation;
             for (int output_col = CONFIG_T::out_width; output_col; output_col--) {
                 #pragma HLS UNROLL
                 if (input_col >= 0 && input_col < CONFIG_T::in_width) {
                     *(data_col++) = data[input_col];
-                    //data_col[index] = data[input_col];
+                    // data_col[index] = data[input_col];
                 } else {
                     *(data_col++) = 0;
-                    //data_col[index] = 0;
+                    // data_col[index] = 0;
                 }
-                //index++;
+                // index++;
                 input_col += CONFIG_T::stride_width;
             }
         }
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_1d_full(
-    data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt]
-)
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_1d_full(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan], res_T res[CONFIG_T::out_width * CONFIG_T::n_filt],
+                  typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                  typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     data_T data_conv[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::out_width];
     data_T data_col[CONFIG_T::filt_width * CONFIG_T::n_chan];
     res_T res_col[CONFIG_T::n_filt];
-    
+
     //#pragma HLS ARRAY_PARTITION variable=data_conv complete
     #pragma HLS ARRAY_PARTITION variable=data_col complete
     #pragma HLS ARRAY_PARTITION variable=res_col complete
@@ -55,19 +54,21 @@ void conv_1d_full(
         }
         dense_resource<data_T, res_T, typename CONFIG_T::mult_config>(data_col, res_col, weights, biases);
         for (int j = 0; j < CONFIG_T::n_filt; j++) {
-            //res[i * CONFIG_T::n_filt + j] = res_col[j];
+            // res[i * CONFIG_T::n_filt + j] = res_col[j];
             res[j * CONFIG_T::out_width + i] = res_col[j]; // Transposed order
         }
     }
 }
 
-template<class data_T, typename CONFIG_T>
-void im2col_1d_cf_idx(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan], data_T data_col[CONFIG_T::filt_width * CONFIG_T::n_chan], const int col) {
-    ChannelLoop:
+template <class data_T, typename CONFIG_T>
+void im2col_1d_cf_idx(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
+                      data_T data_col[CONFIG_T::filt_width * CONFIG_T::n_chan], const int col)
+{
+ChannelLoop:
     for (int channel = 0; channel < CONFIG_T::n_chan; channel++) {
-		//#pragma HLS UNROLL
-        #pragma HLS PIPELINE II=1 rewind
-        KernelLoop:
+    //#pragma HLS UNROLL
+    #pragma HLS PIPELINE II=1 rewind
+    KernelLoop:
         for (int kernel_col = 0; kernel_col < CONFIG_T::filt_width; kernel_col++) {
             #pragma HLS UNROLL
             int input_col = -CONFIG_T::pad_left + kernel_col * CONFIG_T::dilation + col * CONFIG_T::stride_width;
@@ -82,13 +83,15 @@ void im2col_1d_cf_idx(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan], data_T
     }
 }
 
-template<class data_T, typename CONFIG_T>
-void im2col_1d_cf(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan], data_T data_col[CONFIG_T::n_chan * CONFIG_T::filt_width], const int col) {
+template <class data_T, typename CONFIG_T>
+void im2col_1d_cf(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
+                  data_T data_col[CONFIG_T::n_chan * CONFIG_T::filt_width], const int col)
+{
     int index = 0;
-    ChannelLoop:
+ChannelLoop:
     for (int channel = CONFIG_T::n_chan; channel--; data += CONFIG_T::in_width) {
-		#pragma HLS UNROLL
-        KernelLoop:
+    #pragma HLS UNROLL
+    KernelLoop:
         for (int kernel_col = 0; kernel_col < CONFIG_T::filt_width; kernel_col++) {
             int input_col = -CONFIG_T::pad_left + kernel_col * CONFIG_T::dilation + col * CONFIG_T::stride_width;
             if (input_col >= 0 && input_col < CONFIG_T::in_width) {
@@ -103,49 +106,51 @@ void im2col_1d_cf(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan], data_T dat
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_1d_resource_cf(
-    data_T data[CONFIG_T::n_chan * CONFIG_T::in_width],
-    res_T  res[CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt]
-)
+template <class data_T, class res_T, typename CONFIG_T>
+void
+conv_1d_resource_cf(data_T data[CONFIG_T::n_chan * CONFIG_T::in_width],
+                    res_T res[CONFIG_T::out_width * CONFIG_T::n_filt],
+                    typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                    typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     const int nin = CONFIG_T::n_chan * CONFIG_T::filt_width;
     const int nout = CONFIG_T::n_filt;
     const int rufactor = CONFIG_T::reuse_factor;
-    const int block_factor = DIV_ROUNDUP(nin*nout, rufactor);
+    const int block_factor = DIV_ROUNDUP(nin * nout, rufactor);
 
     //#pragma HLS function_instantiate variable=weights,biases
-    //#pragma HLS RESOURCE         variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to choose correctly
+    //#pragma HLS RESOURCE         variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to
+    ///choose correctly
     //#pragma HLS ARRAY_RESHAPE   variable=weights block factor=block_factor
     //#pragma HLS ARRAY_PARTITION variable=biases complete
 
     data_T data_col[CONFIG_T::filt_width * CONFIG_T::n_chan];
     res_T res_col[CONFIG_T::n_filt];
 
-    #pragma HLS ARRAY_PARTITION variable=data_col complete
-    #pragma HLS ARRAY_PARTITION variable=res_col complete
+#pragma HLS ARRAY_PARTITION variable=data_col complete
+#pragma HLS ARRAY_PARTITION variable=res_col complete
 
-    ColLoop:
+ColLoop:
     for (int i = 0; i < CONFIG_T::out_width; i++) {
         #pragma HLS PIPELINE
         im2col_1d_cf<data_T, CONFIG_T>(data, data_col, i);
         dense_resource<data_T, res_T, typename CONFIG_T::mult_config>(data_col, res_col, weights, biases);
         for (int j = 0; j < CONFIG_T::n_filt; j++) {
-            //res[i * CONFIG_T::n_filt + j] = res_col[j];
+            // res[i * CONFIG_T::n_filt + j] = res_col[j];
             res[j * CONFIG_T::out_width + i] = res_col[j]; // Transposed order
         }
     }
 }
 
-template<class data_T, typename CONFIG_T>
-void im2col_1d_cl(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan], data_T data_col[CONFIG_T::filt_width * CONFIG_T::n_chan], const int col) {
+template <class data_T, typename CONFIG_T>
+void im2col_1d_cl(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
+                  data_T data_col[CONFIG_T::filt_width * CONFIG_T::n_chan], const int col)
+{
     int index = 0;
-    ChannelLoop:
+ChannelLoop:
     for (int channel = CONFIG_T::n_chan; channel--; data++) {
-		#pragma HLS UNROLL
-        KernelLoop:
+    #pragma HLS UNROLL
+    KernelLoop:
         for (int kernel_col = 0; kernel_col < CONFIG_T::filt_width; kernel_col++) {
             int input_col = -CONFIG_T::pad_left + kernel_col * CONFIG_T::dilation + col * CONFIG_T::stride_width;
             if (input_col >= 0 && input_col < CONFIG_T::in_width) {
@@ -160,41 +165,40 @@ void im2col_1d_cl(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan], data_T dat
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_1d_resource_cl(
-    data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt]
-)
+template <class data_T, class res_T, typename CONFIG_T>
+void
+conv_1d_resource_cl(data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],
+                    res_T res[CONFIG_T::out_width * CONFIG_T::n_filt],
+                    typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                    typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     const int nin = CONFIG_T::n_chan * CONFIG_T::filt_width;
     const int nout = CONFIG_T::n_filt;
     const int rufactor = CONFIG_T::reuse_factor;
-    const int block_factor = DIV_ROUNDUP(nin*nout, rufactor);
+    const int block_factor = DIV_ROUNDUP(nin * nout, rufactor);
 
     //#pragma HLS function_instantiate variable=weights,biases
-    //#pragma HLS RESOURCE         variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to choose correctly
+    //#pragma HLS RESOURCE         variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to
+    ///choose correctly
     //#pragma HLS ARRAY_RESHAPE   variable=weights block factor=block_factor
     //#pragma HLS ARRAY_PARTITION variable=biases complete
 
     data_T data_col[CONFIG_T::filt_width * CONFIG_T::n_chan];
     res_T res_col[CONFIG_T::n_filt];
 
-    #pragma HLS ARRAY_PARTITION variable=data_col complete
-    #pragma HLS ARRAY_PARTITION variable=res_col complete
+#pragma HLS ARRAY_PARTITION variable=data_col complete
+#pragma HLS ARRAY_PARTITION variable=res_col complete
 
-    ColLoop:
+ColLoop:
     for (int i = 0; i < CONFIG_T::out_width; i++) {
         #pragma HLS PIPELINE
         im2col_1d_cl<data_T, CONFIG_T>(data, data_col, i);
         dense_resource<data_T, res_T, typename CONFIG_T::mult_config>(data_col, res_col, weights, biases);
         for (int j = 0; j < CONFIG_T::n_filt; j++) {
             res[i * CONFIG_T::n_filt + j] = res_col[j];
-            //res[j * CONFIG_T::out_width + i] = res_col[j]; // Transposed order
+            // res[j * CONFIG_T::out_width + i] = res_col[j]; // Transposed order
         }
     }
 }
-
 }
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv2d.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv2d.h
@@ -27,8 +27,7 @@
 
 namespace nnet {
 
-struct conv2d_config
-{
+struct conv2d_config {
     // Internal data type definitions
     typedef float bias_t;
     typedef float weight_t;
@@ -58,12 +57,12 @@ struct conv2d_config
     static const unsigned n_zeros = 0; // not used yet
 };
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_2d_cf(
-    data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_2d_cf(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
+                res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
+                typename CONFIG_T::weight_t weights
+                    [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     if (CONFIG_T::strategy == nnet::latency) {
         conv_2d_latency_cf<data_T, res_T, CONFIG_T>(data, res, weights, biases);
@@ -72,12 +71,12 @@ void conv_2d_cf(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_2d_cl(
-    data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_2d_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
+                res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
+                typename CONFIG_T::weight_t weights
+                    [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     if (CONFIG_T::strategy == nnet::latency) {
         conv_2d_latency_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);
@@ -86,6 +85,6 @@ void conv_2d_cl(
     }
 }
 
-}//end namespace
+} // end namespace
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv2d_latency.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv2d_latency.h
@@ -6,59 +6,57 @@
 
 namespace nnet {
 
-//Computes multiplier limit
-//This function should not be synthesized into firmware
-template<typename CONFIG_T>
-    int compute_multiplier_limit_conv2d(
-    typename CONFIG_T::weight_t  weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt]
-)
+// Computes multiplier limit
+// This function should not be synthesized into firmware
+template <typename CONFIG_T>
+int compute_multiplier_limit_conv2d(typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width *
+                                                                        CONFIG_T::n_chan * CONFIG_T::n_filt])
 {
     int n_mult = 0;
 
-    for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-            for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
-                for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-                    for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
-                        for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+                    for (int fh = 0; fh < CONFIG_T::filt_height; fh++) {
+                        for (int fw = 0; fw < CONFIG_T::filt_width; fw++) {
 
-                                int index_weight = fh*CONFIG_T::filt_width*CONFIG_T::n_chan*CONFIG_T::n_filt
-                                                 + fw*CONFIG_T::n_chan*CONFIG_T::n_filt
-                                                 + cc*CONFIG_T::n_filt
-                                                  + ff;
+                            int index_weight = fh * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt +
+                                               fw * CONFIG_T::n_chan * CONFIG_T::n_filt + cc * CONFIG_T::n_filt + ff;
 
-                                if ((oh*CONFIG_T::stride_height+fh) < CONFIG_T::pad_top
-                                || (oh*CONFIG_T::stride_height+fh) >= (CONFIG_T::pad_top+CONFIG_T::in_height)
-                                || (ow*CONFIG_T::stride_width+fw) < CONFIG_T::pad_left
-                                || (ow*CONFIG_T::stride_width+fw) >= (CONFIG_T::pad_left+CONFIG_T::in_width)) {
-                                    //padded - do nothing
-                                    continue;
-                                } else {
-                                    if (weights[index_weight] > 1e-20 || weights[index_weight] < -1e-20) {
-                                          n_mult++;
-                                    }
+                            if ((oh * CONFIG_T::stride_height + fh) < CONFIG_T::pad_top ||
+                                (oh * CONFIG_T::stride_height + fh) >= (CONFIG_T::pad_top + CONFIG_T::in_height) ||
+                                (ow * CONFIG_T::stride_width + fw) < CONFIG_T::pad_left ||
+                                (ow * CONFIG_T::stride_width + fw) >= (CONFIG_T::pad_left + CONFIG_T::in_width)) {
+                                // padded - do nothing
+                                continue;
+                            } else {
+                                if (weights[index_weight] > 1e-20 || weights[index_weight] < -1e-20) {
+                                    n_mult++;
                                 }
+                            }
 
-                        }//end mult loop
-                    }//end channel loop
-                }//end filter width loop
-            }//end filter height loop
-        }//end output width loop
-    }//end output height loop
+                        } // end mult loop
+                    } // end channel loop
+                } // end filter width loop
+            } // end filter height loop
+        } // end output width loop
+    } // end output height loop
 
-    return ceil( float(n_mult) / float(CONFIG_T::reuse_factor) );
+    return ceil(float(n_mult) / float(CONFIG_T::reuse_factor));
 
-}//end compute_n_mult
+} // end compute_n_mult
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_2d_latency_cf(
-    data_T data[CONFIG_T::in_height*CONFIG_T::in_width*CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_height*CONFIG_T::out_width*CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_2d_latency_cf(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
+                        res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
+                        typename CONFIG_T::weight_t weights
+                            [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                        typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
 
-    typename CONFIG_T::accum_t mult[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::filt_height * CONFIG_T::filt_width];
+    typename CONFIG_T::accum_t mult[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan *
+                                    CONFIG_T::filt_height * CONFIG_T::filt_width];
     typename CONFIG_T::accum_t acc[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt];
 
     #pragma HLS ARRAY_PARTITION variable=mult complete dim=0
@@ -73,108 +71,118 @@ void conv_2d_latency_cf(
 
     // Limit multipliers to control parallelization
     const int multiplier_limit = compute_multiplier_limit_conv2d<CONFIG_T>(weights);
-    #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
+#pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
 
-    // Convolve, saving all multiplication results to accumulate later
-    ConvOutHeight: for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        ConvOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-            ConvFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
-                ConvChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-                    ConvFiltHeight: for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
-                        ConvFiltWidth: for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
+// Convolve, saving all multiplication results to accumulate later
+ConvOutHeight:
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+    ConvOutWidth:
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+        ConvFilt:
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            ConvChan:
+                for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+                ConvFiltHeight:
+                    for (int fh = 0; fh < CONFIG_T::filt_height; fh++) {
+                    ConvFiltWidth:
+                        for (int fw = 0; fw < CONFIG_T::filt_width; fw++) {
 
-                            int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + ow*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + ff*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + cc*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + fh*CONFIG_T::filt_width
-                                           + fw;
+                            int index_mult = oh * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan *
+                                                 CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             ow * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::filt_height *
+                                                 CONFIG_T::filt_width +
+                                             ff * CONFIG_T::n_chan * CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             cc * CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             fh * CONFIG_T::filt_width + fw;
 
-                                int index_weight = fh*CONFIG_T::filt_width*CONFIG_T::n_chan*CONFIG_T::n_filt
-                                                 + fw*CONFIG_T::n_chan*CONFIG_T::n_filt
-                                                 + cc*CONFIG_T::n_filt
-                                                 + ff;
+                            int index_weight = fh * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt +
+                                               fw * CONFIG_T::n_chan * CONFIG_T::n_filt + cc * CONFIG_T::n_filt + ff;
 
-                                if ((oh*CONFIG_T::stride_height+fh) < CONFIG_T::pad_top
-                                || (oh*CONFIG_T::stride_height+fh) >= (CONFIG_T::pad_top+CONFIG_T::in_height)
-                                || (ow*CONFIG_T::stride_width+fw) < CONFIG_T::pad_left
-                                || (ow*CONFIG_T::stride_width+fw) >= (CONFIG_T::pad_left+CONFIG_T::in_width)) {
-                                    mult[index_mult] = 0;
-                                } else {
-                                    int index_data = cc*CONFIG_T::in_height*CONFIG_T::in_width
-                                                   + (oh*CONFIG_T::stride_height+fh-CONFIG_T::pad_top)*CONFIG_T::in_width
-                                                   + (ow*CONFIG_T::stride_width+fw-CONFIG_T::pad_left);
-                                    mult[index_mult] = data[index_data] * weights[index_weight];
-                                }
+                            if ((oh * CONFIG_T::stride_height + fh) < CONFIG_T::pad_top ||
+                                (oh * CONFIG_T::stride_height + fh) >= (CONFIG_T::pad_top + CONFIG_T::in_height) ||
+                                (ow * CONFIG_T::stride_width + fw) < CONFIG_T::pad_left ||
+                                (ow * CONFIG_T::stride_width + fw) >= (CONFIG_T::pad_left + CONFIG_T::in_width)) {
+                                mult[index_mult] = 0;
+                            } else {
+                                int index_data =
+                                    cc * CONFIG_T::in_height * CONFIG_T::in_width +
+                                    (oh * CONFIG_T::stride_height + fh - CONFIG_T::pad_top) * CONFIG_T::in_width +
+                                    (ow * CONFIG_T::stride_width + fw - CONFIG_T::pad_left);
+                                mult[index_mult] = data[index_data] * weights[index_weight];
+                            }
 
-                        }//end mult loop
-                    }//end channel loop
-                  }//end filter width loop
-            }//end filter height loop
-        }//end output width loop
-    }//end output height loop
-
+                        } // end mult loop
+                    } // end channel loop
+                } // end filter width loop
+            } // end filter height loop
+        } // end output width loop
+    } // end output height loop
 
     // Initialize accumulator with input biases
-    for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-            for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-                acc[oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff]=biases[ff];
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                acc[oh * CONFIG_T::out_width * CONFIG_T::n_filt + ow * CONFIG_T::n_filt + ff] = biases[ff];
             }
         }
     }
 
+// Accumulate multiplication result
+AccumOutHeight:
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+    AccumOutWidth:
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+        AccumFilt:
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            // Do "dot product" sum within filter and sum over channels
+            AccumChan:
+                for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+                AccumDotHeight:
+                    for (int fh = 0; fh < CONFIG_T::filt_height; fh++) {
+                    AccumDotWidth:
+                        for (int fw = 0; fw < CONFIG_T::filt_width; fw++) {
 
-    // Accumulate multiplication result
-    AccumOutHeight: for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        AccumOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-            AccumFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-                //Do "dot product" sum within filter and sum over channels
-                AccumChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-                    AccumDotHeight: for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
-                        AccumDotWidth: for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
-
-                            int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + ow*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + ff*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + cc*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + fh*CONFIG_T::filt_width
-                                           + fw;
-                            int index_acc = oh*CONFIG_T::out_width*CONFIG_T::n_filt
-                                          + ow*CONFIG_T::n_filt
-                                          + ff;
+                            int index_mult = oh * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan *
+                                                 CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             ow * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::filt_height *
+                                                 CONFIG_T::filt_width +
+                                             ff * CONFIG_T::n_chan * CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             cc * CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             fh * CONFIG_T::filt_width + fw;
+                            int index_acc = oh * CONFIG_T::out_width * CONFIG_T::n_filt + ow * CONFIG_T::n_filt + ff;
 
                             acc[index_acc] += mult[index_mult];
 
-                        }//end dot product filter width loop
-                    }//end dot product filter height loop
-                }//end n channel loop
-            }//end n filter loop
-        }//end output width loop
-    }//end output height loop
+                        } // end dot product filter width loop
+                    } // end dot product filter height loop
+                } // end n channel loop
+            } // end n filter loop
+        } // end output width loop
+    } // end output height loop
 
     // Cast to "res_t" type
-    for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-        for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-            for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-                int res_index = ff*CONFIG_T::out_height*CONFIG_T::out_width + oh*CONFIG_T::out_width + ow;
-                int acc_index = oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff;
+    for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+        for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+            for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+                int res_index = ff * CONFIG_T::out_height * CONFIG_T::out_width + oh * CONFIG_T::out_width + ow;
+                int acc_index = oh * CONFIG_T::out_width * CONFIG_T::n_filt + ow * CONFIG_T::n_filt + ff;
                 res[res_index] = acc[acc_index];
             }
         }
     }
 
-}//end conv2d
+} // end conv2d
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_2d_latency_cl(
-    data_T data[CONFIG_T::in_height*CONFIG_T::in_width*CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_height*CONFIG_T::out_width*CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_2d_latency_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
+                        res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
+                        typename CONFIG_T::weight_t weights
+                            [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                        typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
 
-    typename CONFIG_T::accum_t mult[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::filt_height * CONFIG_T::filt_width];
+    typename CONFIG_T::accum_t mult[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan *
+                                    CONFIG_T::filt_height * CONFIG_T::filt_width];
     typename CONFIG_T::accum_t acc[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt];
 
     #pragma HLS ARRAY_PARTITION variable=mult complete dim=0
@@ -189,104 +197,112 @@ void conv_2d_latency_cl(
 
     // Limit multipliers to control parallelization
     const int multiplier_limit = compute_multiplier_limit_conv2d<CONFIG_T>(weights);
-    #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
+#pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
 
-    // Convolve, saving all multiplication results to accumulate later
-    ConvOutHeight: for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        ConvOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-            ConvFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
-                ConvChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-                    ConvFiltHeight: for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
-                        ConvFiltWidth: for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
+// Convolve, saving all multiplication results to accumulate later
+ConvOutHeight:
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+    ConvOutWidth:
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+        ConvFilt:
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            ConvChan:
+                for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+                ConvFiltHeight:
+                    for (int fh = 0; fh < CONFIG_T::filt_height; fh++) {
+                    ConvFiltWidth:
+                        for (int fw = 0; fw < CONFIG_T::filt_width; fw++) {
 
-                            int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + ow*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + ff*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + cc*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + fh*CONFIG_T::filt_width
-                                           + fw;
+                            int index_mult = oh * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan *
+                                                 CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             ow * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::filt_height *
+                                                 CONFIG_T::filt_width +
+                                             ff * CONFIG_T::n_chan * CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             cc * CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             fh * CONFIG_T::filt_width + fw;
 
-                                int index_weight = fh*CONFIG_T::filt_width*CONFIG_T::n_chan*CONFIG_T::n_filt
-                                                 + fw*CONFIG_T::n_chan*CONFIG_T::n_filt
-                                                 + cc*CONFIG_T::n_filt
-                                                 + ff;
+                            int index_weight = fh * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt +
+                                               fw * CONFIG_T::n_chan * CONFIG_T::n_filt + cc * CONFIG_T::n_filt + ff;
 
-                                if ((oh*CONFIG_T::stride_height+fh) < CONFIG_T::pad_top
-                                || (oh*CONFIG_T::stride_height+fh) >= (CONFIG_T::pad_top+CONFIG_T::in_height)
-                                || (ow*CONFIG_T::stride_width+fw) < CONFIG_T::pad_left
-                                || (ow*CONFIG_T::stride_width+fw) >= (CONFIG_T::pad_left+CONFIG_T::in_width)) {
-                                    mult[index_mult] = 0;
-                                } else {
-                                    int index_data = (oh*CONFIG_T::stride_height+fh-CONFIG_T::pad_top)*CONFIG_T::in_width*CONFIG_T::n_chan
-                                                   + (ow*CONFIG_T::stride_width+fw-CONFIG_T::pad_left)*CONFIG_T::n_chan
-                                                   + cc;
-                                    mult[index_mult] = data[index_data] * weights[index_weight];
-                                }
+                            if ((oh * CONFIG_T::stride_height + fh) < CONFIG_T::pad_top ||
+                                (oh * CONFIG_T::stride_height + fh) >= (CONFIG_T::pad_top + CONFIG_T::in_height) ||
+                                (ow * CONFIG_T::stride_width + fw) < CONFIG_T::pad_left ||
+                                (ow * CONFIG_T::stride_width + fw) >= (CONFIG_T::pad_left + CONFIG_T::in_width)) {
+                                mult[index_mult] = 0;
+                            } else {
+                                int index_data =
+                                    (oh * CONFIG_T::stride_height + fh - CONFIG_T::pad_top) * CONFIG_T::in_width *
+                                        CONFIG_T::n_chan +
+                                    (ow * CONFIG_T::stride_width + fw - CONFIG_T::pad_left) * CONFIG_T::n_chan + cc;
+                                mult[index_mult] = data[index_data] * weights[index_weight];
+                            }
 
-                        }//end mult loop
-                    }//end channel loop
-                  }//end filter width loop
-            }//end filter height loop
-        }//end output width loop
-    }//end output height loop
-
+                        } // end mult loop
+                    } // end channel loop
+                } // end filter width loop
+            } // end filter height loop
+        } // end output width loop
+    } // end output height loop
 
     // Initialize accumulator with input biases
-    for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-            for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-                acc[oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff]=biases[ff];
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                acc[oh * CONFIG_T::out_width * CONFIG_T::n_filt + ow * CONFIG_T::n_filt + ff] = biases[ff];
             }
         }
     }
 
+// Accumulate multiplication result
+AccumOutHeight:
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+    AccumOutWidth:
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+        AccumFilt:
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            // Do "dot product" sum within filter and sum over channels
+            AccumChan:
+                for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+                AccumDotHeight:
+                    for (int fh = 0; fh < CONFIG_T::filt_height; fh++) {
+                    AccumDotWidth:
+                        for (int fw = 0; fw < CONFIG_T::filt_width; fw++) {
 
-    // Accumulate multiplication result
-    AccumOutHeight: for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        AccumOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-            AccumFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-                //Do "dot product" sum within filter and sum over channels
-                AccumChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-                    AccumDotHeight: for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
-                        AccumDotWidth: for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
-
-                            int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + ow*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + ff*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + cc*CONFIG_T::filt_height*CONFIG_T::filt_width
-                                           + fh*CONFIG_T::filt_width
-                                           + fw;
-                            int index_acc = oh*CONFIG_T::out_width*CONFIG_T::n_filt
-                                          + ow*CONFIG_T::n_filt
-                                          + ff;
+                            int index_mult = oh * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan *
+                                                 CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             ow * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::filt_height *
+                                                 CONFIG_T::filt_width +
+                                             ff * CONFIG_T::n_chan * CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             cc * CONFIG_T::filt_height * CONFIG_T::filt_width +
+                                             fh * CONFIG_T::filt_width + fw;
+                            int index_acc = oh * CONFIG_T::out_width * CONFIG_T::n_filt + ow * CONFIG_T::n_filt + ff;
 
                             acc[index_acc] += mult[index_mult];
 
-                        }//end dot product filter width loop
-                    }//end dot product filter height loop
-                }//end n channel loop
-            }//end n filter loop
-        }//end output width loop
-    }//end output height loop
+                        } // end dot product filter width loop
+                    } // end dot product filter height loop
+                } // end n channel loop
+            } // end n filter loop
+        } // end output width loop
+    } // end output height loop
 
     // Cast to "res_t" type
-    for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-              for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-                int index = oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff;
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                int index = oh * CONFIG_T::out_width * CONFIG_T::n_filt + ow * CONFIG_T::n_filt + ff;
                 res[index] = (res_T)(acc[index]);
             }
         }
     }
 
-}//end conv2d
+} // end conv2d
 
-template<class data_T, class res_T, typename CONFIG_T>
-void pointwise_conv_2d_cl(
-    data_T data[CONFIG_T::in_height*CONFIG_T::in_width*CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_height*CONFIG_T::out_width*CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void pointwise_conv_2d_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
+                          res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
+                          typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
+                          typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
 
     typename CONFIG_T::accum_t mult[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan];
@@ -304,82 +320,79 @@ void pointwise_conv_2d_cl(
 
     // Limit multipliers to control parallelization
     const int multiplier_limit = compute_multiplier_limit_conv2d<CONFIG_T>(weights);
-    #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
+#pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
 
-    // Convolve, saving all multiplication results to accumulate later
-    ConvOutHeight: for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        ConvOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-            ConvFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-                ConvChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+// Convolve, saving all multiplication results to accumulate later
+ConvOutHeight:
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+    ConvOutWidth:
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+        ConvFilt:
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            ConvChan:
+                for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
 
-                    int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan
-                                   + ow*CONFIG_T::n_filt*CONFIG_T::n_chan
-                                   + ff*CONFIG_T::n_chan
-                                   + cc;
+                    int index_mult = oh * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan +
+                                     ow * CONFIG_T::n_filt * CONFIG_T::n_chan + ff * CONFIG_T::n_chan + cc;
 
-                    int index_weight = cc*CONFIG_T::n_filt + ff;
+                    int index_weight = cc * CONFIG_T::n_filt + ff;
 
-                    if ((oh*CONFIG_T::stride_height) < CONFIG_T::pad_top
-                    || (oh*CONFIG_T::stride_height) >= (CONFIG_T::pad_top+CONFIG_T::in_height)
-                    || (ow*CONFIG_T::stride_width) < CONFIG_T::pad_left
-                    || (ow*CONFIG_T::stride_width) >= (CONFIG_T::pad_left+CONFIG_T::in_width)) {
+                    if ((oh * CONFIG_T::stride_height) < CONFIG_T::pad_top ||
+                        (oh * CONFIG_T::stride_height) >= (CONFIG_T::pad_top + CONFIG_T::in_height) ||
+                        (ow * CONFIG_T::stride_width) < CONFIG_T::pad_left ||
+                        (ow * CONFIG_T::stride_width) >= (CONFIG_T::pad_left + CONFIG_T::in_width)) {
                         mult[index_mult] = 0;
                     } else {
-                        int index_data = (oh*CONFIG_T::stride_height-CONFIG_T::pad_top)*CONFIG_T::in_width*CONFIG_T::n_chan
-                                       + (ow*CONFIG_T::stride_width-CONFIG_T::pad_left)*CONFIG_T::n_chan
-                                       + cc;
+                        int index_data =
+                            (oh * CONFIG_T::stride_height - CONFIG_T::pad_top) * CONFIG_T::in_width * CONFIG_T::n_chan +
+                            (ow * CONFIG_T::stride_width - CONFIG_T::pad_left) * CONFIG_T::n_chan + cc;
                         mult[index_mult] = data[index_data] * weights[index_weight];
                     }
-
                 }
             }
         }
     }
 
-
     // Initialize accumulator with input biases
-    for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-            for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-                acc[oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff]=biases[ff];
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                acc[oh * CONFIG_T::out_width * CONFIG_T::n_filt + ow * CONFIG_T::n_filt + ff] = biases[ff];
             }
         }
     }
 
+// Accumulate multiplication result
+AccumOutHeight:
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+    AccumOutWidth:
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+        AccumFilt:
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            // Do "dot product" sum within filter and sum over channels
+            AccumChan:
+                for (int cc = 0; cc < CONFIG_T::n_chan; cc++) {
 
-    // Accumulate multiplication result
-    AccumOutHeight: for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        AccumOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-            AccumFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-                //Do "dot product" sum within filter and sum over channels
-                AccumChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++) {
-
-                    int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan
-                                    + ow*CONFIG_T::n_filt*CONFIG_T::n_chan
-                                    + ff*CONFIG_T::n_chan
-                                    + cc;
-                    int index_acc = oh*CONFIG_T::out_width*CONFIG_T::n_filt
-                                    + ow*CONFIG_T::n_filt
-                                    + ff;
+                    int index_mult = oh * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan +
+                                     ow * CONFIG_T::n_filt * CONFIG_T::n_chan + ff * CONFIG_T::n_chan + cc;
+                    int index_acc = oh * CONFIG_T::out_width * CONFIG_T::n_filt + ow * CONFIG_T::n_filt + ff;
 
                     acc[index_acc] += mult[index_mult];
-
                 }
             }
         }
     }
 
     // Cast to "res_t" type
-    for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-              for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-                int index = oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff;
+    for (int oh = 0; oh < CONFIG_T::out_height; oh++) {
+        for (int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                int index = oh * CONFIG_T::out_width * CONFIG_T::n_filt + ow * CONFIG_T::n_filt + ff;
                 res[index] = (res_T)(acc[index]);
             }
         }
     }
 
-}//end conv2d
-
+} // end conv2d
 }
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv2d_resource.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv2d_resource.h
@@ -6,15 +6,19 @@
 
 namespace nnet {
 
-template<class data_T, typename CONFIG_T>
-void im2col_2d(
-    data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
-    data_T data_col[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::out_height * CONFIG_T::out_width])
+template <class data_T, typename CONFIG_T>
+void im2col_2d(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
+               data_T data_col[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::out_height *
+                               CONFIG_T::out_width])
 {
     const int output_h = (CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom -
-        (CONFIG_T::dilation_height * (CONFIG_T::filt_height - 1) + 1)) / CONFIG_T::stride_height + 1;
+                          (CONFIG_T::dilation_height * (CONFIG_T::filt_height - 1) + 1)) /
+                             CONFIG_T::stride_height +
+                         1;
     const int output_w = (CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right -
-        (CONFIG_T::dilation_width * (CONFIG_T::filt_width - 1) + 1)) / CONFIG_T::stride_width + 1;
+                          (CONFIG_T::dilation_width * (CONFIG_T::filt_width - 1) + 1)) /
+                             CONFIG_T::stride_width +
+                         1;
     const int channel_size = CONFIG_T::in_height * CONFIG_T::in_width;
 
     for (int channel = CONFIG_T::n_chan; channel--; data += channel_size) {
@@ -44,15 +48,15 @@ void im2col_2d(
     }
 }
 
-
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_2d_full(
-    data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_2d_full(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
+                  res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
+                  typename CONFIG_T::weight_t weights
+                      [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                  typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
-    data_T data_conv[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::out_height * CONFIG_T::out_width];
+    data_T data_conv
+        [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::out_height * CONFIG_T::out_width];
     data_T data_col[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan];
     res_T res_col[CONFIG_T::n_filt];
 
@@ -68,18 +72,16 @@ void conv_2d_full(
         }
         dense<data_T, res_T, typename CONFIG_T::mult_config>(data_col, res_col, weights, biases);
         for (int j = 0; j < CONFIG_T::n_filt; j++) {
-            //res[i * CONFIG_T::n_filt + j] = res_col[j];
+            // res[i * CONFIG_T::n_filt + j] = res_col[j];
             res[j * CONFIG_T::out_height * CONFIG_T::out_width + i] = res_col[j]; // Transposed order
         }
     }
 }
 
-template<class data_T, typename CONFIG_T>
-void im2col_2d_cf(
-    data_T data[CONFIG_T::n_chan * CONFIG_T::in_height * CONFIG_T::in_width],
-    data_T data_col[CONFIG_T::n_chan * CONFIG_T::filt_height * CONFIG_T::filt_width],
-    const int row,
-    const int col)
+template <class data_T, typename CONFIG_T>
+void im2col_2d_cf(data_T data[CONFIG_T::n_chan * CONFIG_T::in_height * CONFIG_T::in_width],
+                  data_T data_col[CONFIG_T::n_chan * CONFIG_T::filt_height * CONFIG_T::filt_width], const int row,
+                  const int col)
 {
     const int channel_size = CONFIG_T::in_height * CONFIG_T::in_width;
     int index = 0;
@@ -91,7 +93,8 @@ void im2col_2d_cf(
                 if (input_row < 0 || input_row > CONFIG_T::in_height) {
                     data_col[index++] = 0;
                 } else {
-                    int input_col = -CONFIG_T::pad_left + kernel_col * CONFIG_T::dilation_width + col * CONFIG_T::stride_width;
+                    int input_col =
+                        -CONFIG_T::pad_left + kernel_col * CONFIG_T::dilation_width + col * CONFIG_T::stride_width;
                     if (input_col >= 0 && input_col < CONFIG_T::in_width) {
                         //*(data_col++) = data[input_row * CONFIG_T::in_width + input_col];
                         data_col[index++] = data[input_row * CONFIG_T::in_width + input_col];
@@ -107,51 +110,51 @@ void im2col_2d_cf(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_2d_resource_cf(
-    data_T data[CONFIG_T::n_chan * CONFIG_T::in_height * CONFIG_T::in_width],
-    res_T  res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_2d_resource_cf(data_T data[CONFIG_T::n_chan * CONFIG_T::in_height * CONFIG_T::in_width],
+                         res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
+                         typename CONFIG_T::weight_t weights
+                             [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                         typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     const int nin = CONFIG_T::n_chan * CONFIG_T::filt_width;
     const int nout = CONFIG_T::n_filt;
     const int rufactor = CONFIG_T::reuse_factor;
-    const int block_factor = DIV_ROUNDUP(nin*nout, rufactor);
+    const int block_factor = DIV_ROUNDUP(nin * nout, rufactor);
 
     //#pragma HLS function_instantiate variable=weights,biases
-    //#pragma HLS RESOURCE         variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to choose correctly
+    //#pragma HLS RESOURCE         variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to
+    ///choose correctly
     //#pragma HLS ARRAY_RESHAPE   variable=weights block factor=block_factor
     //#pragma HLS ARRAY_PARTITION variable=biases complete
 
     data_T data_col[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan];
     res_T res_col[CONFIG_T::n_filt];
 
-    #pragma HLS ARRAY_PARTITION variable=data_col complete
-    #pragma HLS ARRAY_PARTITION variable=res_col complete
-    
-    HeightLoop:
+#pragma HLS ARRAY_PARTITION variable=data_col complete
+#pragma HLS ARRAY_PARTITION variable=res_col complete
+
+HeightLoop:
     for (int i = 0; i < CONFIG_T::out_height; i++) {
-        WidthLoop:
+    WidthLoop:
         for (int j = 0; j < CONFIG_T::out_width; j++) {
             #pragma HLS PIPELINE
             im2col_2d_cf<data_T, CONFIG_T>(data, data_col, i, j);
             dense<data_T, res_T, typename CONFIG_T::mult_config>(data_col, res_col, weights, biases);
-            FiltLoop:
+        FiltLoop:
             for (int k = 0; k < CONFIG_T::n_filt; k++) {
-                //res[i * CONFIG_T::out_width * CONFIG_T::n_filt + j * CONFIG_T::n_filt + k] = res_col[k];
-                res[k * CONFIG_T::out_height * CONFIG_T::out_width + i * CONFIG_T::out_width + j] = res_col[k]; // Transposed order
+                // res[i * CONFIG_T::out_width * CONFIG_T::n_filt + j * CONFIG_T::n_filt + k] = res_col[k];
+                res[k * CONFIG_T::out_height * CONFIG_T::out_width + i * CONFIG_T::out_width + j] =
+                    res_col[k]; // Transposed order
             }
         }
     }
 }
 
-template<class data_T, typename CONFIG_T>
-void im2col_2d_cl(
-    data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
-    data_T data_col[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan],
-    const int row,
-    const int col)
+template <class data_T, typename CONFIG_T>
+void im2col_2d_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
+                  data_T data_col[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan], const int row,
+                  const int col)
 {
     int index = 0;
     for (int channel = CONFIG_T::n_chan; channel--; data++) {
@@ -162,10 +165,13 @@ void im2col_2d_cl(
                 if (input_row < 0 || input_row >= CONFIG_T::in_height) {
                     data_col[index++] = 0;
                 } else {
-                    int input_col = -CONFIG_T::pad_left + kernel_col * CONFIG_T::dilation_width + col * CONFIG_T::stride_width;
+                    int input_col =
+                        -CONFIG_T::pad_left + kernel_col * CONFIG_T::dilation_width + col * CONFIG_T::stride_width;
                     if (input_col >= 0 && input_col < CONFIG_T::in_width) {
-                        //*(data_col++) = data[input_row * CONFIG_T::in_width * CONFIG_T::n_chan + input_col * CONFIG_T::n_chan];
-                        data_col[index++] = data[input_row * CONFIG_T::in_width * CONFIG_T::n_chan + input_col * CONFIG_T::n_chan];
+                        //*(data_col++) = data[input_row * CONFIG_T::in_width * CONFIG_T::n_chan + input_col *
+                        //CONFIG_T::n_chan];
+                        data_col[index++] =
+                            data[input_row * CONFIG_T::in_width * CONFIG_T::n_chan + input_col * CONFIG_T::n_chan];
                     } else {
                         //*(data_col++) = 0;
                         data_col[index++] = 0;
@@ -176,44 +182,45 @@ void im2col_2d_cl(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_2d_resource_cl(
-    data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
-    res_T  res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_2d_resource_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],
+                         res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt],
+                         typename CONFIG_T::weight_t weights
+                             [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                         typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     const int nin = CONFIG_T::n_chan * CONFIG_T::filt_width;
     const int nout = CONFIG_T::n_filt;
     const int rufactor = CONFIG_T::reuse_factor;
-    const int block_factor = DIV_ROUNDUP(nin*nout, rufactor);
+    const int block_factor = DIV_ROUNDUP(nin * nout, rufactor);
 
     //#pragma HLS function_instantiate variable=weights,biases
-    //#pragma HLS RESOURCE         variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to choose correctly
+    //#pragma HLS RESOURCE         variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to
+    ///choose correctly
     //#pragma HLS ARRAY_RESHAPE   variable=weights block factor=block_factor
     //#pragma HLS ARRAY_PARTITION variable=biases complete
 
     data_T data_col[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan];
     res_T res_col[CONFIG_T::n_filt];
 
-    #pragma HLS ARRAY_PARTITION variable=data_col complete
-    #pragma HLS ARRAY_PARTITION variable=res_col complete
-    
-    HeightLoop:
+#pragma HLS ARRAY_PARTITION variable=data_col complete
+#pragma HLS ARRAY_PARTITION variable=res_col complete
+
+HeightLoop:
     for (int i = 0; i < CONFIG_T::out_height; i++) {
-        WidthLoop:
+    WidthLoop:
         for (int j = 0; j < CONFIG_T::out_width; j++) {
             #pragma HLS PIPELINE
             im2col_2d_cl<data_T, CONFIG_T>(data, data_col, i, j);
             dense<data_T, res_T, typename CONFIG_T::mult_config>(data_col, res_col, weights, biases);
-            FiltLoop:
+        FiltLoop:
             for (int k = 0; k < CONFIG_T::n_filt; k++) {
                 res[i * CONFIG_T::out_width * CONFIG_T::n_filt + j * CONFIG_T::n_filt + k] = res_col[k];
-                //res[k * CONFIG_T::out_height * CONFIG_T::out_width + i * CONFIG_T::out_width + j] = res_col[k]; // Transposed order
+                // res[k * CONFIG_T::out_height * CONFIG_T::out_width + i * CONFIG_T::out_width + j] = res_col[k]; //
+                // Transposed order
             }
         }
     }
 }
-
 }
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv2d_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv2d_stream.h
@@ -8,16 +8,15 @@
 
 namespace nnet {
 
-template<class data_T, typename CONFIG_T>
-void compute_scaled_indices_2d(
-    const unsigned h_idx,
-    const unsigned w_idx,
-    ap_uint<CONFIG_T::filt_height * CONFIG_T::filt_width> *pixel_idx
-) {
+template <class data_T, typename CONFIG_T>
+void compute_scaled_indices_2d(const unsigned h_idx, const unsigned w_idx,
+                               ap_uint<CONFIG_T::filt_height *CONFIG_T::filt_width> *pixel_idx)
+{
     const unsigned sh_idx = scale_index<CONFIG_T::filt_height, CONFIG_T::stride_height, CONFIG_T::in_height>(h_idx);
     unsigned wp_idx = w_idx * (data_T::size / CONFIG_T::n_chan);
 
-    ComputeIndex: for (unsigned p = 0; p < data_T::size / CONFIG_T::n_chan; p++) {
+ComputeIndex:
+    for (unsigned p = 0; p < data_T::size / CONFIG_T::n_chan; p++) {
         #pragma HLS UNROLL
 
         unsigned sw_idx = scale_index<CONFIG_T::filt_width, CONFIG_T::stride_width, CONFIG_T::in_width>(wp_idx + p);
@@ -25,17 +24,17 @@ void compute_scaled_indices_2d(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void conv_2d_encoded_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void conv_2d_encoded_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                        typename CONFIG_T::weight_t weights
+                            [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                        typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     assert(CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
     assert(CONFIG_T::filt_height == CONFIG_T::filt_width);
 
-    hls::stream<typename data_T::value_type> data_window[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan];
+    hls::stream<typename data_T::value_type> data_window
+        [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan];
     const int win_depth = CONFIG_T::filt_height * CONFIG_T::out_width;
     for (unsigned i_out = 0; i_out < CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan; i_out++) {
         #pragma HLS STREAM variable=data_window[i_out] depth=win_depth
@@ -47,38 +46,43 @@ void conv_2d_encoded_cl(
     #pragma HLS DATA_PACK variable=res_pack
     unsigned outputs_ready = 0;
 
-    ap_uint<CONFIG_T::filt_height * CONFIG_T::filt_width> pixel_idx[data_T::size / CONFIG_T::n_chan];
-    #pragma HLS ARRAY_PARTITION variable=pixel_idx complete
+    ap_uint<CONFIG_T::filt_height *CONFIG_T::filt_width> pixel_idx[data_T::size / CONFIG_T::n_chan];
+#pragma HLS ARRAY_PARTITION variable=pixel_idx complete
 
-    ReadInputHeight: for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
-        ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_chan); i_iw++) {
+ReadInputHeight:
+    for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
+    ReadInputWidth:
+        for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_chan); i_iw++) {
             #pragma HLS LOOP_FLATTEN
             if (CONFIG_T::strategy == nnet::latency && data_T::size / CONFIG_T::n_chan == 1) {
                 #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
             }
             compute_scaled_indices_2d<data_T, CONFIG_T>(i_ih, i_iw, pixel_idx);
-            compute_output_encoded<data_T, res_T, CONFIG_T>(data.read(), data_window, res, res_pack, outputs_ready, weights, biases, pixel_idx);
+            compute_output_encoded<data_T, res_T, CONFIG_T>(data.read(), data_window, res, res_pack, outputs_ready,
+                                                            weights, biases, pixel_idx);
         }
     }
 }
 
 // Line Buffer
 template <class data_T, class res_T, typename CONFIG_T>
-void conv_2d_buffer_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+void conv_2d_buffer_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                       typename CONFIG_T::weight_t weights
+                           [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                       typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     assert(CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
 
-    static ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[MAX(CONFIG_T::filt_height - 1,1)][CONFIG_T::n_chan];
-    #pragma HLS ARRAY_PARTITION variable = line_buffer complete dim = 2
+    static ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[MAX(CONFIG_T::filt_height - 1, 1)]
+                                                                                    [CONFIG_T::n_chan];
+#pragma HLS ARRAY_PARTITION variable = line_buffer complete dim = 2
 
-    ReadInputHeight: for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
-        ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width; i_iw++) {
+ReadInputHeight:
+    for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
+    ReadInputWidth:
+        for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width; i_iw++) {
             #pragma HLS LOOP_FLATTEN
-            if(CONFIG_T::strategy == nnet::latency) {
+            if (CONFIG_T::strategy == nnet::latency) {
                 #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
             }
             if (CONFIG_T::filt_height > 1) {
@@ -91,22 +95,20 @@ void conv_2d_buffer_cl(
 }
 
 template <class data_T, class res_T, typename CONFIG_T>
-void conv_2d_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+void conv_2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                typename CONFIG_T::weight_t weights
+                    [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     #pragma HLS inline region
-    switch(CONFIG_T::implementation){
-        case conv_implementation::linebuffer:
-            conv_2d_buffer_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);
-            break;
-        case conv_implementation::encoded:
-            conv_2d_encoded_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);
-            break;
-    }  
+    switch (CONFIG_T::implementation) {
+    case conv_implementation::linebuffer:
+        conv_2d_buffer_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);
+        break;
+    case conv_implementation::encoded:
+        conv_2d_encoded_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);
+        break;
+    }
 }
-
 }
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv_stream.h
@@ -7,20 +7,23 @@
 
 namespace nnet {
 
-enum class conv_implementation { linebuffer=0, encoded=1};
+enum class conv_implementation {
+    linebuffer = 0,
+    encoded = 1
+};
 
 // *************************************************
 //       Encoded Implementation (Vlad's)
 // *************************************************
-template<unsigned K, unsigned S, unsigned W>
-unsigned scale_index_K_gte_S(const unsigned idx) {
+template <unsigned K, unsigned S, unsigned W> unsigned scale_index_K_gte_S(const unsigned idx)
+{
     #pragma HLS INLINE
 
     if (idx < K - S) {
         return idx;
     }
 
-    constexpr unsigned nW = ((W - K) / S) * S + K; // Nearest W without unused pixels on the right
+    constexpr unsigned nW = ((W - K) / S) * S + K;           // Nearest W without unused pixels on the right
     constexpr unsigned sW = (DIV_ROUNDUP(K, S) - 1) * S + K; // Scaled W that behaves like original W
     if (idx >= nW) {
         return sW;
@@ -34,15 +37,15 @@ unsigned scale_index_K_gte_S(const unsigned idx) {
     return K - S + (idx - (K - S)) % S;
 }
 
-template<unsigned K, unsigned S, unsigned W>
-unsigned scale_index_K_lt_S(const unsigned idx) {
+template <unsigned K, unsigned S, unsigned W> unsigned scale_index_K_lt_S(const unsigned idx)
+{
     #pragma HLS INLINE
 
     if (idx < S - K) {
         return idx;
     }
 
-    constexpr unsigned nW = ((W - K) / S) * S + K; // Nearest W without unused pixels on the right
+    constexpr unsigned nW = ((W - K) / S) * S + K;           // Nearest W without unused pixels on the right
     constexpr unsigned sW = (DIV_ROUNDUP(S, K) - 1) * S + K; // Scaled W that behaves like original W
     if (idx >= nW) {
         return sW;
@@ -56,10 +59,10 @@ unsigned scale_index_K_lt_S(const unsigned idx) {
     return S - K + (idx - (S - K)) % S;
 }
 
-template<unsigned K, unsigned S, unsigned W>
-unsigned scale_index(const unsigned idx) {
+template <unsigned K, unsigned S, unsigned W> unsigned scale_index(const unsigned idx)
+{
     #pragma HLS INLINE
-    
+
     if (K >= S) {
         return scale_index_K_gte_S<K, S, W>(idx);
     } else {
@@ -67,35 +70,36 @@ unsigned scale_index(const unsigned idx) {
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void mult_buffer(
-    hls::stream<typename data_T::value_type> data_window[CONFIG_T::kernel_size * CONFIG_T::n_chan],
-    res_T& res_pack,
-    hls::stream<res_T>& res_stream,
-    unsigned & outputs_ready,
-    typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t biases[CONFIG_T::n_filt]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void mult_buffer(hls::stream<typename data_T::value_type> data_window[CONFIG_T::kernel_size * CONFIG_T::n_chan],
+                 res_T &res_pack, hls::stream<res_T> &res_stream, unsigned &outputs_ready,
+                 typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                 typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
+{
     #pragma HLS INLINE
 
     typename data_T::value_type data[CONFIG_T::kernel_size * CONFIG_T::n_chan];
     #pragma HLS ARRAY_PARTITION variable=data complete
     typename res_T::value_type res[CONFIG_T::n_filt];
-    #pragma HLS ARRAY_PARTITION variable=res complete
+#pragma HLS ARRAY_PARTITION variable=res complete
 
-    InitData: for (int id = 0; id < CONFIG_T::kernel_size * CONFIG_T::n_chan; id++) {
+InitData:
+    for (int id = 0; id < CONFIG_T::kernel_size * CONFIG_T::n_chan; id++) {
         #pragma HLS UNROLL
         data[id] = data_window[id].read();
     }
 
     #pragma HLS INLINE region
     if (CONFIG_T::strategy == nnet::latency) {
-        dense_latency<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(data, res, weights, biases);
+        dense_latency<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(
+            data, res, weights, biases);
     } else {
-        dense_resource<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(data, res, weights, biases);
+        dense_resource<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(
+            data, res, weights, biases);
     }
 
-    CastLoop: for (unsigned jj = 0; jj < CONFIG_T::n_filt; jj++) {
+CastLoop:
+    for (unsigned jj = 0; jj < CONFIG_T::n_filt; jj++) {
         #pragma HLS UNROLL
         if (res_T::size / CONFIG_T::n_filt == 1) {
             res_pack[jj] = res[jj];
@@ -116,26 +120,27 @@ void mult_buffer(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void compute_output_encoded(
-    const data_T& in_elem,
-    hls::stream<typename data_T::value_type> data_window[CONFIG_T::kernel_size * CONFIG_T::n_chan],
-    hls::stream<res_T> &res,
-    res_T &res_pack,
-    unsigned &outputs_ready,
-    typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t biases[CONFIG_T::n_filt],
-    ap_uint<CONFIG_T::kernel_size> *pixel_idx
-) {
-    #pragma HLS INLINE
+template <class data_T, class res_T, typename CONFIG_T>
+void
+compute_output_encoded(const data_T &in_elem,
+                       hls::stream<typename data_T::value_type> data_window[CONFIG_T::kernel_size * CONFIG_T::n_chan],
+                       hls::stream<res_T> &res, res_T &res_pack, unsigned &outputs_ready,
+                       typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan * CONFIG_T::n_filt],
+                       typename CONFIG_T::bias_t biases[CONFIG_T::n_filt], ap_uint<CONFIG_T::kernel_size> *pixel_idx)
+{
+#pragma HLS INLINE
 
-    MultLoop: for (unsigned p = 0; p < data_T::size / CONFIG_T::n_chan; p++) {
-        #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
-        CopyDataFilt: for (unsigned f = 0; f < CONFIG_T::kernel_size; f++) {
-            #pragma HLS UNROLL
-            CopyDataChan: for (unsigned c = 0; c < CONFIG_T::n_chan; c++) {
+MultLoop:
+    for (unsigned p = 0; p < data_T::size / CONFIG_T::n_chan; p++) {
+    #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
+    CopyDataFilt:
+        for (unsigned f = 0; f < CONFIG_T::kernel_size; f++) {
+        #pragma HLS UNROLL
+        CopyDataChan:
+            for (unsigned c = 0; c < CONFIG_T::n_chan; c++) {
                 #pragma HLS UNROLL
-                if (pixel_idx[p][f]) data_window[f * CONFIG_T::n_chan + c].write(in_elem[p * CONFIG_T::n_chan + c]);
+                if (pixel_idx[p][f])
+                    data_window[f * CONFIG_T::n_chan + c].write(in_elem[p * CONFIG_T::n_chan + c]);
             }
         }
         if (pixel_idx[p][CONFIG_T::kernel_size - 1]) {
@@ -144,24 +149,23 @@ void compute_output_encoded(
     }
 }
 
-
-
 // *************************************************
 //       Line Buffer Implementation (Phil's)
 // *************************************************
 template <class data_T, typename CONFIG_T>
-void kernel_shift_1d(
-    const data_T& in_elem,
-    typename data_T::value_type kernel_window[CONFIG_T::filt_width * CONFIG_T::n_chan]
-) {
+void kernel_shift_1d(const data_T &in_elem,
+                     typename data_T::value_type kernel_window[CONFIG_T::filt_width * CONFIG_T::n_chan])
+{
     #pragma HLS inline
     #pragma HLS PIPELINE II = 1
-    
+
     // Shift kernel_window by one step to the left (manual shift operation)
     static const int filt_width = CONFIG_T::filt_width - 1;
-    KernelShiftWidth: for (int i_iw = 0; i_iw < filt_width; i_iw++) {
-        #pragma HLS UNROLL
-        KernelShiftChannel: for (unsigned i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
+KernelShiftWidth:
+    for (int i_iw = 0; i_iw < filt_width; i_iw++) {
+    #pragma HLS UNROLL
+    KernelShiftChannel:
+        for (unsigned i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
             // Shift every element in kernel_window to the left
             kernel_window[i_iw * CONFIG_T::n_chan + i_ic] = kernel_window[(i_iw + 1) * CONFIG_T::n_chan + i_ic];
         }
@@ -169,7 +173,8 @@ void kernel_shift_1d(
 
     // Insert shift_buffer column into right-most column of kernel
     static const int lastheight = (CONFIG_T::filt_width - 1) * CONFIG_T::n_chan;
-    KernelPushChannel: for (int i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
+KernelPushChannel:
+    for (int i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
         #pragma HLS UNROLL
         kernel_window[lastheight + i_ic] = in_elem[i_ic];
     }
@@ -178,70 +183,84 @@ void kernel_shift_1d(
 template <class data_T, typename CONFIG_T>
 void kernel_shift_2d(
     typename data_T::value_type shift_buffer[CONFIG_T::filt_height][CONFIG_T::n_chan],
-    typename data_T::value_type kernel_window[CONFIG_T::filt_width * CONFIG_T::filt_height * CONFIG_T::n_chan]
-) {
+    typename data_T::value_type kernel_window[CONFIG_T::filt_width * CONFIG_T::filt_height * CONFIG_T::n_chan])
+{
     #pragma HLS inline
-        
+
     // Shift kernel_window by one step to the left (manual shift operation)
     static const int filt_width = CONFIG_T::filt_width - 1;
-    KernelShiftWidth: for (int i_iw = 0; i_iw < filt_width; i_iw++) {
-        #pragma HLS PIPELINE II = 1
-        KernelShiftHeight: for (unsigned i_ih = 0; i_ih < CONFIG_T::filt_height; i_ih++) {
-            KernelShiftChannel: for (unsigned i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
-            // Shift every element in kernel_window to the left
-                kernel_window[i_ih * CONFIG_T::filt_width * CONFIG_T::n_chan + i_iw * CONFIG_T::n_chan + i_ic] = kernel_window[i_ih * CONFIG_T::filt_width * CONFIG_T::n_chan + (i_iw + 1) * CONFIG_T::n_chan + i_ic];
+KernelShiftWidth:
+    for (int i_iw = 0; i_iw < filt_width; i_iw++) {
+    #pragma HLS PIPELINE II = 1
+    KernelShiftHeight:
+        for (unsigned i_ih = 0; i_ih < CONFIG_T::filt_height; i_ih++) {
+        KernelShiftChannel:
+            for (unsigned i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
+                // Shift every element in kernel_window to the left
+                kernel_window[i_ih * CONFIG_T::filt_width * CONFIG_T::n_chan + i_iw * CONFIG_T::n_chan + i_ic] =
+                    kernel_window
+                        [i_ih * CONFIG_T::filt_width * CONFIG_T::n_chan + (i_iw + 1) * CONFIG_T::n_chan + i_ic];
             }
         }
     }
 
     // Insert shift_buffer column into right-most column of kernel
     static const int lastheight = (CONFIG_T::filt_width - 1) * CONFIG_T::n_chan;
-    KernelPushHeight: for (int i_ih = 0; i_ih < CONFIG_T::filt_height; i_ih++) {
-        #pragma HLS UNROLL
-        KernelPushChannel: for (int i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
-            kernel_window[lastheight + i_ih * CONFIG_T::filt_width * CONFIG_T::n_chan + i_ic] = shift_buffer[i_ih][i_ic];
+KernelPushHeight:
+    for (int i_ih = 0; i_ih < CONFIG_T::filt_height; i_ih++) {
+    #pragma HLS UNROLL
+    KernelPushChannel:
+        for (int i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
+            kernel_window[lastheight + i_ih * CONFIG_T::filt_width * CONFIG_T::n_chan + i_ic] =
+                shift_buffer[i_ih][i_ic];
         }
     }
 }
 
 template <class data_T, typename CONFIG_T>
-void shift_line_buffer(const data_T& in_elem, 
-                    ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[MAX(CONFIG_T::filt_height - 1,1)][CONFIG_T::n_chan],
-                    typename data_T::value_type kernel_window[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan]
-) {
-    
+void shift_line_buffer(
+    const data_T &in_elem, ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer
+                               [MAX(CONFIG_T::filt_height - 1, 1)][CONFIG_T::n_chan],
+    typename data_T::value_type kernel_window[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan])
+{
+
     #pragma HLS PIPELINE
 
     // Temporary buffer for popped (shifted) elements
     typename data_T::value_type shift_buffer[CONFIG_T::filt_height][CONFIG_T::n_chan];
-    #pragma HLS ARRAY_PARTITION variable = shift_buffer complete dim = 0
+#pragma HLS ARRAY_PARTITION variable = shift_buffer complete dim = 0
 
-    UpdateBuffer: for (int i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
+UpdateBuffer:
+    for (int i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
         #pragma HLS UNROLL
 
         // Insert pixel(s) at end of shift buffer
         shift_buffer[CONFIG_T::filt_height - 1][i_ic] = in_elem[i_ic];
     }
 
-    LineBufferDataIn: for (int i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
-        // Shift the shift buffer into the line buffer
-        LineBufferShift: for (unsigned i_ih = 1; i_ih < CONFIG_T::filt_height; i_ih++) {
+LineBufferDataIn:
+    for (int i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
+    // Shift the shift buffer into the line buffer
+    LineBufferShift:
+        for (unsigned i_ih = 1; i_ih < CONFIG_T::filt_height; i_ih++) {
             #pragma HLS UNROLL
-            typename data_T::value_type pop_elem = line_buffer[i_ih - 1][i_ic].shift(shift_buffer[CONFIG_T::filt_height - i_ih][i_ic]); // Shift the line buffer, return the popped pixel
-            shift_buffer[CONFIG_T::filt_height - i_ih - 1][i_ic] = pop_elem; // Popped element placed back into shift_buffer, one row up.
+            typename data_T::value_type pop_elem = line_buffer[i_ih - 1][i_ic].shift(
+                shift_buffer[CONFIG_T::filt_height - i_ih][i_ic]); // Shift the line buffer, return the popped pixel
+            shift_buffer[CONFIG_T::filt_height - i_ih - 1][i_ic] =
+                pop_elem; // Popped element placed back into shift_buffer, one row up.
         }
     }
     kernel_shift_2d<data_T, CONFIG_T>(shift_buffer, kernel_window);
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class res_T, typename CONFIG_T>
 void compute_output_buffer_2d(
-    const data_T& in_elem,
-    ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[MAX(CONFIG_T::filt_height - 1,1)][CONFIG_T::n_chan],
+    const data_T &in_elem, ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer
+                               [MAX(CONFIG_T::filt_height - 1, 1)][CONFIG_T::n_chan],
     hls::stream<res_T> &res_stream,
     typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t biases[CONFIG_T::n_filt]
-) {
+    typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
+{
     #pragma HLS INLINE
 
     // Thresholds
@@ -268,18 +287,21 @@ void compute_output_buffer_2d(
     nnet::shift_line_buffer<data_T, CONFIG_T>(in_elem, line_buffer, kernel_data);
 
     // Check to see if we have a full kernel
-    if ( (sX - lShiftX) == 0 && (sY - lShiftY) == 0 && pY > lShiftY - 1 && pX > lShiftX - 1) {
-        
+    if ((sX - lShiftX) == 0 && (sY - lShiftY) == 0 && pY > lShiftY - 1 && pX > lShiftX - 1) {
+
         // Dense multiply
         #pragma HLS INLINE region
         if (CONFIG_T::strategy == nnet::latency) {
-            dense_latency<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(kernel_data, res_out, weights, biases);
+            dense_latency<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(
+                kernel_data, res_out, weights, biases);
         } else {
-            dense_resource<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(kernel_data, res_out, weights, biases);
+            dense_resource<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(
+                kernel_data, res_out, weights, biases);
         }
 
-        // Pack output
-        CastLoop: for (unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
+    // Pack output
+    CastLoop:
+        for (unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
             #pragma HLS UNROLL
             res_pack[i_ic] = res_out[i_ic];
         }
@@ -289,33 +311,32 @@ void compute_output_buffer_2d(
     }
 
     // Counter Housekeeping
-    if (pX + 1 == CONFIG_T::in_width)  // Includes padding, end of line (padded)
+    if (pX + 1 == CONFIG_T::in_width) // Includes padding, end of line (padded)
     {
-        pX = 0; 
+        pX = 0;
         sX = 0;
-        if (pY + 1 == CONFIG_T::in_height) {  // Reached bottom of image
-            pY = 0; 
+        if (pY + 1 == CONFIG_T::in_height) { // Reached bottom of image
+            pY = 0;
             sY = 0;
         } else {
             pY = pY + 1;
             // Update stride (threshold) ? subtract stride : increment stride
-            sY = ((sY - lShiftY) == 0) ? sY - CONFIG_T::stride_height + 1 : sY + 1; 
+            sY = ((sY - lShiftY) == 0) ? sY - CONFIG_T::stride_height + 1 : sY + 1;
         }
     } else {
         pX = pX + 1;
         // Update stride (threshold) ? subtract stride : increment stride
-        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1; 
+        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1;
     }
 }
 
 // Conv 1D compute output
-template<class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class res_T, typename CONFIG_T>
 void compute_output_buffer_1d(
-    const data_T& in_elem,
-    hls::stream<res_T> &res_stream,
+    const data_T &in_elem, hls::stream<res_T> &res_stream,
     typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t biases[CONFIG_T::n_filt]
-) {
+    typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
+{
     #pragma HLS INLINE
 
     // Thresholds
@@ -338,18 +359,21 @@ void compute_output_buffer_1d(
     nnet::kernel_shift_1d<data_T, CONFIG_T>(in_elem, kernel_data);
 
     // Check to see if we have a full kernel
-    if ( (sX - lShiftX) == 0 && pX > lShiftX - 1 ) {
-        
+    if ((sX - lShiftX) == 0 && pX > lShiftX - 1) {
+
         // Dense multiply
         #pragma HLS INLINE region
         if (CONFIG_T::strategy == nnet::latency) {
-            dense_latency<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(kernel_data, res_out, weights, biases);
+            dense_latency<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(
+                kernel_data, res_out, weights, biases);
         } else {
-            dense_resource<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(kernel_data, res_out, weights, biases);
+            dense_resource<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(
+                kernel_data, res_out, weights, biases);
         }
 
-        // Pack output
-        CastLoop: for (unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
+    // Pack output
+    CastLoop:
+        for (unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
             #pragma HLS UNROLL
             res_pack[i_ic] = res_out[i_ic];
         }
@@ -359,16 +383,15 @@ void compute_output_buffer_1d(
     }
 
     // Counter Housekeeping
-    if (pX + 1 == CONFIG_T::in_width)  // Includes padding, end of line (padded)
+    if (pX + 1 == CONFIG_T::in_width) // Includes padding, end of line (padded)
     {
         pX = 0;
         sX = 0;
     } else {
         pX = pX + 1;
         // Update stride (threshold) ? subtract stride : increment stride
-        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1; 
+        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1;
     }
 }
-
 }
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense.h
@@ -11,8 +11,7 @@
 
 namespace nnet {
 
-struct dense_config
-{
+struct dense_config {
     // Internal data type definitions
     typedef float bias_t;
     typedef float weight_t;
@@ -24,22 +23,19 @@ struct dense_config
 
     // Resource reuse info
     static const unsigned io_type = io_parallel;
-    static const unsigned strategy = latency; 
+    static const unsigned strategy = latency;
     static const unsigned reuse_factor = 1;
     static const bool store_weights_in_bram = false;
     static const unsigned n_zeros = 0;
     // partitioning arrays cyclically to go with roll factors?
     // Product function to use
-    template<class x_T, class y_T, class res_T>
-    using product = nnet::product::mult<x_T, y_T, res_T>;
+    template <class x_T, class y_T, class res_T> using product = nnet::product::mult<x_T, y_T, res_T>;
 };
 
-template<class data_T, class res_T, typename CONFIG_T>
-void dense(
-    data_T    data[CONFIG_T::n_in],
-    res_T     res[CONFIG_T::n_out],
-    typename CONFIG_T::weight_t  weights[CONFIG_T::n_in*CONFIG_T::n_out],
-    typename CONFIG_T::bias_t    biases[CONFIG_T::n_out])
+template <class data_T, class res_T, typename CONFIG_T>
+void dense(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
+           typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+           typename CONFIG_T::bias_t biases[CONFIG_T::n_out])
 {
     #pragma HLS inline
     if (CONFIG_T::strategy == nnet::latency) {
@@ -48,7 +44,6 @@ void dense(
         dense_resource<data_T, res_T, CONFIG_T>(data, res, weights, biases);
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense_compressed.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense_compressed.h
@@ -27,83 +27,83 @@
 
 namespace nnet {
 
-template<typename CONFIG_T>
-void fill_mult(typename CONFIG_T::index_t index,
-        typename CONFIG_T::accum_t mult[CONFIG_T::n_out],
-        typename CONFIG_T::accum_t weight) {
-    for(unsigned  k = 0; k < CONFIG_T::n_out; k++) {
+template <typename CONFIG_T>
+void fill_mult(typename CONFIG_T::index_t index, typename CONFIG_T::accum_t mult[CONFIG_T::n_out],
+               typename CONFIG_T::accum_t weight)
+{
+    for (unsigned k = 0; k < CONFIG_T::n_out; k++) {
         #pragma HLS UNROLL
-        if (k == index) mult[k] += weight;
+        if (k == index)
+            mult[k] += weight;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void dense_compressed(
-        data_T    data[CONFIG_T::n_in],
-        res_T     res[CONFIG_T::n_out],
-        typename CONFIG_T::weight_t  weights[CONFIG_T::n_nonzeros],
-        typename CONFIG_T::bias_t    biases[CONFIG_T::n_out])
+template <class data_T, class res_T, typename CONFIG_T>
+void dense_compressed(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
+                      typename CONFIG_T::weight_t weights[CONFIG_T::n_nonzeros],
+                      typename CONFIG_T::bias_t biases[CONFIG_T::n_out])
 {
 
     const int multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_nonzeros, CONFIG_T::reuse_factor);
 
-    typename CONFIG_T::accum_t acc [CONFIG_T::n_out];
-    #pragma HLS ARRAY_PARTITION variable=acc    complete
-    #pragma HLS ARRAY_PARTITION variable=biases complete
-    #pragma HLS ARRAY_RESHAPE   variable=weights block factor=multiplier_limit
-    //if (CONFIG_T::store_weights_in_bram){
-    //#pragma HLS RESOURCE variable=weights core=ROM_1P_BRAM
-    #pragma HLS data_pack variable=weights struct_level
-    //}
+    typename CONFIG_T::accum_t acc[CONFIG_T::n_out];
+#pragma HLS ARRAY_PARTITION variable=acc    complete
+#pragma HLS ARRAY_PARTITION variable=biases complete
+#pragma HLS ARRAY_RESHAPE   variable=weights block factor=multiplier_limit
+// if (CONFIG_T::store_weights_in_bram){
+//#pragma HLS RESOURCE variable=weights core=ROM_1P_BRAM
+#pragma HLS data_pack variable=weights struct_level
+//}
 
-    InitAccum:
-    for(unsigned i = 0; i < CONFIG_T::n_out; i++) {
+InitAccum:
+    for (unsigned i = 0; i < CONFIG_T::n_out; i++) {
         #pragma HLS UNROLL
-        acc[i] = (typename CONFIG_T::accum_t) (biases[i]);
+        acc[i] = (typename CONFIG_T::accum_t)(biases[i]);
     }
 
     // Do the compressed matrix-multiply
     const int rufactor = CONFIG_T::reuse_factor;
-    ReuseLoop:
-    for(unsigned ir = 0; ir < rufactor; ir++) {
+ReuseLoop:
+    for (unsigned ir = 0; ir < rufactor; ir++) {
         #pragma HLS PIPELINE  II=1 rewind
 
         typename CONFIG_T::accum_t mult[CONFIG_T::n_out];
-        #pragma HLS ARRAY_PARTITION variable=mult complete
+    #pragma HLS ARRAY_PARTITION variable=mult complete
 
-        ResetMult:
-        for(int imult = 0; imult < CONFIG_T::n_out; imult++) {
+    ResetMult:
+        for (int imult = 0; imult < CONFIG_T::n_out; imult++) {
             #pragma HLS UNROLL
             mult[imult] = 0;
         }
 
-        CompressedMultLoop:
-        for(unsigned im = 0; im < multiplier_limit; im++) {
+    CompressedMultLoop:
+        for (unsigned im = 0; im < multiplier_limit; im++) {
             #pragma HLS UNROLL
             unsigned w = im * rufactor + ir;
             auto row = weights[w].row_index;
             auto col = weights[w].col_index;
             auto weight_cache = weights[w].weight;
-            data_T  data_cache = data[row];
-            //mult[col] += weight_cache * data_cache;
-            typename CONFIG_T::accum_t prod = CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(data_cache, weight_cache);
+            data_T data_cache = data[row];
+            // mult[col] += weight_cache * data_cache;
+            typename CONFIG_T::accum_t prod =
+                CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(
+                    data_cache, weight_cache);
             fill_mult<CONFIG_T>(col, mult, prod);
         }
 
-        for (int im = 0; im < CONFIG_T::n_out; im++){
+        for (int im = 0; im < CONFIG_T::n_out; im++) {
             acc[im] += mult[im];
         }
     }
 
-    // Cast to "res_t" type
-    ResultLoop:
-    for(unsigned i = 0; i < CONFIG_T::n_out; i++){
+// Cast to "res_t" type
+ResultLoop:
+    for (unsigned i = 0; i < CONFIG_T::n_out; i++) {
         #pragma HLS UNROLL
-        //res[i] = (res_T) (acc[i]);
+        // res[i] = (res_T) (acc[i]);
         res[i] = cast<data_T, res_T, CONFIG_T>(acc[i]);
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense_latency.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense_latency.h
@@ -28,35 +28,36 @@
 
 namespace nnet {
 
-template<class data_T, class res_T, typename CONFIG_T>
-void dense_latency(
-    data_T    data[CONFIG_T::n_in],
-    res_T     res[CONFIG_T::n_out],
-    typename CONFIG_T::weight_t  weights[CONFIG_T::n_in*CONFIG_T::n_out],
-    typename CONFIG_T::bias_t    biases[CONFIG_T::n_out])
+template <class data_T, class res_T, typename CONFIG_T>
+void dense_latency(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
+                   typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                   typename CONFIG_T::bias_t biases[CONFIG_T::n_out])
 {
     data_T cache;
-    typename CONFIG_T::accum_t mult[CONFIG_T::n_in*CONFIG_T::n_out];
+    typename CONFIG_T::accum_t mult[CONFIG_T::n_in * CONFIG_T::n_out];
     typename CONFIG_T::accum_t acc[CONFIG_T::n_out];
 
     // Use a function_instantiate in case it helps to explicitly optimize unchanging weights/biases
     #pragma HLS function_instantiate variable=weights,biases
 
-    if (CONFIG_T::io_type == io_parallel || CONFIG_T::io_type == io_stream){
+    if (CONFIG_T::io_type == io_parallel || CONFIG_T::io_type == io_stream) {
         // For parallel inputs:
         //   - completely partition arrays -- target fabric
         //   - if we have an unroll factor, limit number of multipliers
         #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
-        // #pragma HLS ARRAY_PARTITION variable=weights complete // remove this line for now, it breaks compression sometimes
+        // #pragma HLS ARRAY_PARTITION variable=weights complete // remove this line for now, it breaks compression
+        // sometimes
         #pragma HLS ARRAY_PARTITION variable=biases complete
         #pragma HLS ARRAY_PARTITION variable=mult complete
         #pragma HLS ARRAY_PARTITION variable=acc complete
 
-        int multiplier_limit  = ceil(float(CONFIG_T::n_in*CONFIG_T::n_out) / float(CONFIG_T::reuse_factor)) - floor(float(CONFIG_T::n_zeros) / float(CONFIG_T::reuse_factor));
-        CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::limit(multiplier_limit);
+        int multiplier_limit = ceil(float(CONFIG_T::n_in * CONFIG_T::n_out) / float(CONFIG_T::reuse_factor)) -
+                               floor(float(CONFIG_T::n_zeros) / float(CONFIG_T::reuse_factor));
+        CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::limit(
+            multiplier_limit);
 
-    } else if (CONFIG_T::io_type == io_serial){
+    } else if (CONFIG_T::io_type == io_serial) {
         // Only reduce cycle_factor if n_out is evenly divisible by reuse_factor
         // Otherwise, HLS wont be happy
         int cycle_factor = CONFIG_T::n_out / CONFIG_T::reuse_factor;
@@ -76,56 +77,64 @@ void dense_latency(
         #pragma HLS DATAFLOW
         #pragma HLS STREAM variable=mult depth=1
         #pragma HLS STREAM variable=acc depth=1
-        if (CONFIG_T::store_weights_in_bram){
+        if (CONFIG_T::store_weights_in_bram) {
             #pragma HLS RESOURCE variable=weights core=ROM_2P_BRAM
         }
     }
 
-    // Do the matrix-multiply
-    Product1: for(int ii = 0; ii < CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+// Do the matrix-multiply
+Product1:
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
         cache = data[ii];
-        Product2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
+    Product2:
+        for (int jj = 0; jj < CONFIG_T::n_out; jj++) {
             if (CONFIG_T::io_type == io_serial) {
-                int multiplier_limit  = ceil(float(CONFIG_T::n_out) / float(CONFIG_T::reuse_factor));
-                CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::limit(multiplier_limit);
+                int multiplier_limit = ceil(float(CONFIG_T::n_out) / float(CONFIG_T::reuse_factor));
+                CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::limit(
+                    multiplier_limit);
             }
-        int index = ii*CONFIG_T::n_out+jj;
-        mult[index] = CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(cache, weights[index]);
+            int index = ii * CONFIG_T::n_out + jj;
+            mult[index] =
+                CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(
+                    cache, weights[index]);
         }
     }
 
-    // Initialize accumulator with input biases
-    ResetAccum: for(int iacc = 0; iacc < CONFIG_T::n_out; iacc++) {
-        if (CONFIG_T::io_type == io_serial){
+// Initialize accumulator with input biases
+ResetAccum:
+    for (int iacc = 0; iacc < CONFIG_T::n_out; iacc++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS UNROLL
         }
-        acc[iacc] = (typename CONFIG_T::accum_t) biases[iacc];
+        acc[iacc] = (typename CONFIG_T::accum_t)biases[iacc];
     }
 
-    // Accumulate multiplication result
-    Accum1: for(int ii = 0; ii < CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
+// Accumulate multiplication result
+Accum1:
+    for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS PIPELINE
         }
-        Accum2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
-        int index = ii*CONFIG_T::n_out+jj;
-        acc[jj] += mult[index];
+    Accum2:
+        for (int jj = 0; jj < CONFIG_T::n_out; jj++) {
+            int index = ii * CONFIG_T::n_out + jj;
+            acc[jj] += mult[index];
         }
     }
 
-    // Cast to "res_t" type
-    Result: for(int ires = 0; ires < CONFIG_T::n_out; ires++){
-        if (CONFIG_T::io_type == io_serial){
+// Cast to "res_t" type
+Result:
+    for (int ires = 0; ires < CONFIG_T::n_out; ires++) {
+        if (CONFIG_T::io_type == io_serial) {
             #pragma HLS UNROLL
         }
-        //res[ires] = (res_T) (acc[ires]);
+        // res[ires] = (res_T) (acc[ires]);
         res[ires] = cast<data_T, res_T, CONFIG_T>(acc[ires]);
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense_resource.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense_resource.h
@@ -28,18 +28,17 @@
 
 namespace nnet {
 
-template<class data_T, class res_T, typename CONFIG_T>
-void dense_resource_rf_leq_nin(
-    data_T data[CONFIG_T::n_in],
-    res_T  res[CONFIG_T::n_out],
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_in*CONFIG_T::n_out],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_out]) {
+template <class data_T, class res_T, typename CONFIG_T>
+void dense_resource_rf_leq_nin(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
+                               typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                               typename CONFIG_T::bias_t biases[CONFIG_T::n_out])
+{
 
     const int rufactor = CONFIG_T::reuse_factor;
-    const int multfactor = MIN(CONFIG_T::n_in,CONFIG_T::reuse_factor);
-    const int multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_in*CONFIG_T::n_out, multfactor);
-    const int block_factor = DIV_ROUNDUP(CONFIG_T::n_in*CONFIG_T::n_out, CONFIG_T::reuse_factor);
-    const int multscale = multiplier_limit/CONFIG_T::n_out;
+    const int multfactor = MIN(CONFIG_T::n_in, CONFIG_T::reuse_factor);
+    const int multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_in * CONFIG_T::n_out, multfactor);
+    const int block_factor = DIV_ROUNDUP(CONFIG_T::n_in * CONFIG_T::n_out, CONFIG_T::reuse_factor);
+    const int multscale = multiplier_limit / CONFIG_T::n_out;
     const int nin = CONFIG_T::n_in;
     const int nout = CONFIG_T::n_out;
 
@@ -47,20 +46,21 @@ void dense_resource_rf_leq_nin(
     assert((multiplier_limit == block_factor) && "This function is correct only for RF <= N_IN");
 
     #pragma HLS function_instantiate variable=weights,biases
-    //#pragma HLS RESOURCE variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to choose correctly
+    //#pragma HLS RESOURCE variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to choose
+    ///correctly
     #pragma HLS ARRAY_RESHAPE   variable=weights block factor=block_factor
     #pragma HLS ARRAY_PARTITION variable=biases complete
 
     typename CONFIG_T::accum_t acc[CONFIG_T::n_out];
-    #pragma HLS ARRAY_PARTITION variable=acc complete
+#pragma HLS ARRAY_PARTITION variable=acc complete
 
-    InitAccum:
+InitAccum:
     for (int iacc = 0; iacc < nout; iacc++) {
         #pragma HLS UNROLL
-        acc[iacc] = (typename CONFIG_T::accum_t) biases[iacc];
+        acc[iacc] = (typename CONFIG_T::accum_t)biases[iacc];
     }
 
-    ReuseLoop:
+ReuseLoop:
     for (int ir = 0; ir < rufactor; ir++) {
         #pragma HLS PIPELINE II=1 rewind
 
@@ -69,11 +69,13 @@ void dense_resource_rf_leq_nin(
         int out_index = 0;
         int acc_step = 0;
 
-        MultLoop:
+    MultLoop:
         for (int im = 0; im < block_factor; im++) {
             #pragma HLS UNROLL
 
-            acc[out_index] += CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(data[in_index], weights[w_index]);
+            acc[out_index] +=
+                CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(
+                    data[in_index], weights[w_index]);
 
             // Increment w_index
             w_index += rufactor;
@@ -92,26 +94,25 @@ void dense_resource_rf_leq_nin(
         }
     }
 
-    // Cast to "res_t" type
-    Result:
+// Cast to "res_t" type
+Result:
     for (int ires = 0; ires < CONFIG_T::n_out; ires++) {
         #pragma HLS UNROLL
         res[ires] = cast<data_T, res_T, CONFIG_T>(acc[ires]);
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void dense_resource_rf_gt_nin_rem0(
-    data_T data[CONFIG_T::n_in],
-    res_T  res[CONFIG_T::n_out],
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_in*CONFIG_T::n_out],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_out]) {
+template <class data_T, class res_T, typename CONFIG_T>
+void dense_resource_rf_gt_nin_rem0(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
+                                   typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                                   typename CONFIG_T::bias_t biases[CONFIG_T::n_out])
+{
 
     const int rufactor = MIN(CONFIG_T::reuse_factor, CONFIG_T::n_in * CONFIG_T::n_out);
-    const int multfactor = MIN(CONFIG_T::n_in,CONFIG_T::reuse_factor);
-    const int multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_in*CONFIG_T::n_out, multfactor);
-    const int block_factor = DIV_ROUNDUP(CONFIG_T::n_in*CONFIG_T::n_out, CONFIG_T::reuse_factor);
-    const int multscale = multiplier_limit/CONFIG_T::n_out;
+    const int multfactor = MIN(CONFIG_T::n_in, CONFIG_T::reuse_factor);
+    const int multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_in * CONFIG_T::n_out, multfactor);
+    const int block_factor = DIV_ROUNDUP(CONFIG_T::n_in * CONFIG_T::n_out, CONFIG_T::reuse_factor);
+    const int multscale = multiplier_limit / CONFIG_T::n_out;
     const int nin = CONFIG_T::n_in;
     const int nout = CONFIG_T::n_out;
 
@@ -119,17 +120,18 @@ void dense_resource_rf_gt_nin_rem0(
     assert((rufactor > nin && rufactor % nin == 0) && "This function is correct only for RF > N_IN && RF % N_IN == 0");
 
     #pragma HLS function_instantiate variable=weights,biases
-    //#pragma HLS RESOURCE variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to choose correctly
+    //#pragma HLS RESOURCE variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to choose
+    ///correctly
     #pragma HLS ARRAY_RESHAPE   variable=weights block factor=block_factor
     #pragma HLS ARRAY_PARTITION variable=biases complete
 
     typename CONFIG_T::accum_t acc[CONFIG_T::n_out];
-    #pragma HLS ARRAY_PARTITION variable=acc complete
+#pragma HLS ARRAY_PARTITION variable=acc complete
 
-    InitAccum:
+InitAccum:
     for (int iacc = 0; iacc < nout; iacc++) {
         #pragma HLS UNROLL
-        acc[iacc] = (typename CONFIG_T::accum_t) biases[iacc];
+        acc[iacc] = (typename CONFIG_T::accum_t)biases[iacc];
     }
 
     int w_index;
@@ -139,7 +141,7 @@ void dense_resource_rf_gt_nin_rem0(
     const int outscale = rufactor / nin;
 
     int outidx[rufactor];
-    IndexLoop:
+IndexLoop:
     for (int ir = 0; ir < rufactor; ir++) {
         outidx[ir] = outstep;
         if ((ir + 1) % nin == 0) {
@@ -147,50 +149,53 @@ void dense_resource_rf_gt_nin_rem0(
         }
     }
 
-    ReuseLoop:
+ReuseLoop:
     for (int ir = 0; ir < rufactor; ir++) {
         #pragma HLS PIPELINE II=1 rewind
 
         w_index = ir;
-        out_index = outidx[ir]/*outstep*/;
+        out_index = outidx[ir] /*outstep*/;
 
-        MultLoop:
+    MultLoop:
         for (int im = 0; im < block_factor; im++) {
             #pragma HLS UNROLL
-            acc[out_index] += CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(data[in_index], weights[w_index]);
+            acc[out_index] +=
+                CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(
+                    data[in_index], weights[w_index]);
 
             w_index += rufactor;
-            if (w_index >= CONFIG_T::n_in * CONFIG_T::n_out) break; // check out of bounds
+            if (w_index >= CONFIG_T::n_in * CONFIG_T::n_out)
+                break; // check out of bounds
             out_index += outscale;
         }
 
         in_index++;
         if (in_index >= nin) {
             in_index = 0;
-            //outstep++; // This causes a huge increase in scheduling and RTL generation times, hence the above workaround.
+            // outstep++; // This causes a huge increase in scheduling and RTL generation times, hence the above
+            // workaround.
         }
     }
 
-    // Cast to "res_t" type
-    Result:
+// Cast to "res_t" type
+Result:
     for (int ires = 0; ires < CONFIG_T::n_out; ires++) {
         #pragma HLS UNROLL
         res[ires] = cast<data_T, res_T, CONFIG_T>(acc[ires]);
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void dense_resource_rf_gt_nin(
-    data_T data[CONFIG_T::n_in],
-    res_T  res[CONFIG_T::n_out],
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_in*CONFIG_T::n_out],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_out]) {
+template <class data_T, class res_T, typename CONFIG_T>
+void dense_resource_rf_gt_nin(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
+                              typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                              typename CONFIG_T::bias_t biases[CONFIG_T::n_out])
+{
 
     const int rufactor = CONFIG_T::reuse_factor;
-    const int multfactor = MIN(CONFIG_T::n_in,CONFIG_T::reuse_factor);
-    const int multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_in*CONFIG_T::n_out, multfactor);
-    const int block_factor = DIV_ROUNDUP(CONFIG_T::n_in*CONFIG_T::n_out, CONFIG_T::reuse_factor);
-    const int multscale = multiplier_limit/CONFIG_T::n_out;
+    const int multfactor = MIN(CONFIG_T::n_in, CONFIG_T::reuse_factor);
+    const int multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_in * CONFIG_T::n_out, multfactor);
+    const int block_factor = DIV_ROUNDUP(CONFIG_T::n_in * CONFIG_T::n_out, CONFIG_T::reuse_factor);
+    const int multscale = multiplier_limit / CONFIG_T::n_out;
     const int nin = CONFIG_T::n_in;
     const int nout = CONFIG_T::n_out;
 
@@ -198,75 +203,79 @@ void dense_resource_rf_gt_nin(
     assert((rufactor > nin) && "This function is correct only for RF > N_IN");
 
     #pragma HLS function_instantiate variable=weights,biases
-    //#pragma HLS RESOURCE variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to choose correctly
+    //#pragma HLS RESOURCE variable=weights core=RAM_2P_BRAM Commenting out the deisgnation HLS seems to choose
+    ///correctly
     #pragma HLS ARRAY_RESHAPE   variable=weights block factor=block_factor
     #pragma HLS ARRAY_PARTITION variable=biases complete
 
     typename CONFIG_T::accum_t acc[CONFIG_T::n_out];
-    #pragma HLS ARRAY_PARTITION variable=acc complete
+#pragma HLS ARRAY_PARTITION variable=acc complete
 
-    InitAccum:
+InitAccum:
     for (int iacc = 0; iacc < nout; iacc++) {
         #pragma HLS UNROLL
-        acc[iacc] = (typename CONFIG_T::accum_t) biases[iacc];
+        acc[iacc] = (typename CONFIG_T::accum_t)biases[iacc];
     }
 
-    ReuseLoop:
+ReuseLoop:
     for (int ir = 0; ir < rufactor; ir++) {
         #pragma HLS PIPELINE II=1 rewind
         typename CONFIG_T::accum_t tmpmult[block_factor];
-        #pragma HLS ARRAY_PARTITION variable=tmpmult complete
+    #pragma HLS ARRAY_PARTITION variable=tmpmult complete
 
-        MultLoop:
+    MultLoop:
         for (int im = 0; im < block_factor; im++) {
             #pragma HLS UNROLL
             int w_index = ir + rufactor * im;
             int in_index = w_index % nin;
-            if (w_index >= CONFIG_T::n_in*CONFIG_T::n_out) continue; // check out of bounds
-            tmpmult[im] = CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(data[in_index], weights[w_index]);
+            if (w_index >= CONFIG_T::n_in * CONFIG_T::n_out)
+                continue; // check out of bounds
+            tmpmult[im] =
+                CONFIG_T::template product<data_T, typename CONFIG_T::weight_t, typename CONFIG_T::accum_t>::product(
+                    data[in_index], weights[w_index]);
         }
 
         typename CONFIG_T::accum_t mult[multiplier_limit];
-        #pragma HLS ARRAY_PARTITION variable=mult complete
+    #pragma HLS ARRAY_PARTITION variable=mult complete
 
-        ResetMult:
+    ResetMult:
         for (int imult = 0; imult < multiplier_limit; imult++) {
             #pragma HLS UNROLL
             mult[imult] = 0;
         }
 
-        AccumLoop1:
+    AccumLoop1:
         for (int im = 0; im < block_factor; im++) {
             #pragma HLS UNROLL
             int w_index = ir + rufactor * im;
             int out_index = w_index / multfactor;
-            if (out_index >= multiplier_limit) continue; // check out of bounds
+            if (out_index >= multiplier_limit)
+                continue; // check out of bounds
             mult[out_index] += tmpmult[im];
         }
 
-        AccumLoop2:
+    AccumLoop2:
         for (int im = 0; im < multiplier_limit; im++) {
             #pragma HLS UNROLL
-            //int out_index = im/multscale; // This is the general case
-            //acc[out_index] += mult[im];
+            // int out_index = im/multscale; // This is the general case
+            // acc[out_index] += mult[im];
             acc[im] += mult[im]; // If RF > N_IN then multiplier_limit == n_out
         }
     }
 
-    // Cast to "res_t" type
-    Result:
+// Cast to "res_t" type
+Result:
     for (int ires = 0; ires < CONFIG_T::n_out; ires++) {
         #pragma HLS UNROLL
         res[ires] = cast<data_T, res_T, CONFIG_T>(acc[ires]);
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void dense_resource(
-    data_T data[CONFIG_T::n_in],
-    res_T  res[CONFIG_T::n_out],
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_in*CONFIG_T::n_out],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_out]) {
+template <class data_T, class res_T, typename CONFIG_T>
+void dense_resource(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
+                    typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                    typename CONFIG_T::bias_t biases[CONFIG_T::n_out])
+{
 
     #pragma HLS INLINE region
 
@@ -278,7 +287,6 @@ void dense_resource(
         dense_resource_rf_gt_nin<data_T, res_T, CONFIG_T>(data, res, weights, biases);
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense_stream.h
@@ -9,13 +9,11 @@
 
 namespace nnet {
 
-template<class data_T, class res_T, typename CONFIG_T>
-void dense_wrapper(
-    data_T data[CONFIG_T::n_in],
-    res_T  res[CONFIG_T::n_out],
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_in*CONFIG_T::n_out],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_out]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void dense_wrapper(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_out],
+                   typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+                   typename CONFIG_T::bias_t biases[CONFIG_T::n_out])
+{
     #pragma HLS INLINE region
     if (CONFIG_T::strategy == nnet::latency) {
         #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
@@ -25,25 +23,25 @@ void dense_wrapper(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void dense(
-    hls::stream<data_T> &data_stream,
-    hls::stream<res_T>  &res_stream,
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_in*CONFIG_T::n_out],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_out])
+template <class data_T, class res_T, typename CONFIG_T>
+void dense(hls::stream<data_T> &data_stream, hls::stream<res_T> &res_stream,
+           typename CONFIG_T::weight_t weights[CONFIG_T::n_in * CONFIG_T::n_out],
+           typename CONFIG_T::bias_t biases[CONFIG_T::n_out])
 {
     typename data_T::value_type data[CONFIG_T::n_in];
     #pragma HLS ARRAY_PARTITION variable=data complete
 
     typename res_T::value_type res[CONFIG_T::n_out];
-    #pragma HLS ARRAY_PARTITION variable=res complete
+#pragma HLS ARRAY_PARTITION variable=res complete
 
-    DataPrepare: for(int i_in = 0; i_in < CONFIG_T::n_in / data_T::size; i_in++) {
+DataPrepare:
+    for (int i_in = 0; i_in < CONFIG_T::n_in / data_T::size; i_in++) {
         if (CONFIG_T::n_in / data_T::size > 1) {
             #pragma HLS PIPELINE
         }
         data_T data_pack = data_stream.read();
-        DataPack: for (int i_pack = 0; i_pack < data_T::size; i_pack++) {
+    DataPack:
+        for (int i_pack = 0; i_pack < data_T::size; i_pack++) {
             #pragma HLS UNROLL
             data[i_in * data_T::size + i_pack] = data_pack[i_pack];
         }
@@ -51,20 +49,21 @@ void dense(
 
     dense_wrapper<typename data_T::value_type, typename res_T::value_type, CONFIG_T>(data, res, weights, biases);
 
-    ResWrite: for(unsigned i_out = 0; i_out < CONFIG_T::n_out / res_T::size; i_out++) {
+ResWrite:
+    for (unsigned i_out = 0; i_out < CONFIG_T::n_out / res_T::size; i_out++) {
         if (CONFIG_T::n_out / res_T::size > 1) {
             #pragma HLS PIPELINE
         }
         res_T res_pack;
-        #pragma HLS DATA_PACK variable=res_pack
-        ResPack: for (int i_pack = 0; i_pack < res_T::size; i_pack++) {
+    #pragma HLS DATA_PACK variable=res_pack
+    ResPack:
+        for (int i_pack = 0; i_pack < res_T::size; i_pack++) {
             #pragma HLS UNROLL
             res_pack[i_pack] = res[i_out * res_T::size + i_pack];
         }
         res_stream.write(res_pack);
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_garnet.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_garnet.h
@@ -25,635 +25,594 @@
 #include "hls_math.h"
 
 namespace nnet {
-  namespace garnet_utils {
+namespace garnet_utils {
 
-    template<class CONFIG_T>
-    inline
-    typename std::enable_if<std::is_class<typename CONFIG_T::distance_t>::value>::type
-    initialize_edge_weights_table(typename CONFIG_T::edge_weight_t edge_weights_table[])
-    {
-      typedef ap_uint<CONFIG_T::distance_width> index_t;
+template <class CONFIG_T>
+inline typename std::enable_if<std::is_class<typename CONFIG_T::distance_t>::value>::type
+initialize_edge_weights_table(typename CONFIG_T::edge_weight_t edge_weights_table[])
+{
+    typedef ap_uint<CONFIG_T::distance_width> index_t;
 
-      unsigned const table_size = (1 << CONFIG_T::distance_width);
+    unsigned const table_size = (1 << CONFIG_T::distance_width);
 
-      index_t index;
-      typename CONFIG_T::distance_t distance;
+    index_t index;
+    typename CONFIG_T::distance_t distance;
 
-      // edge_weight_t is ap_ufixed with 0 iwidth -> let index 0 be a saturated version of 1
-      edge_weights_table[0] = ap_ufixed<CONFIG_T::edge_weight_t::width, 0, AP_TRN, AP_SAT>(1.);
+    // edge_weight_t is ap_ufixed with 0 iwidth -> let index 0 be a saturated version of 1
+    edge_weights_table[0] = ap_ufixed<CONFIG_T::edge_weight_t::width, 0, AP_TRN, AP_SAT>(1.);
 
-      for (unsigned iw = 1; iw < table_size; ++iw) {
+    for (unsigned iw = 1; iw < table_size; ++iw) {
         index = iw;
         distance.range(CONFIG_T::distance_width - 1, 0) = index.range(CONFIG_T::distance_width - 1, 0);
         edge_weights_table[iw] = hls::exp(-distance * distance);
-      }
     }
+}
 
-    template<class CONFIG_T>
-    inline
-    typename std::enable_if<not std::is_class<typename CONFIG_T::distance_t>::value>::type
-    initialize_edge_weights_table(typename CONFIG_T::edge_weight_t edge_weights_table[])
-    {
-      unsigned const table_size = (1 << CONFIG_T::distance_width);
-      double const step = 64. / table_size;
+template <class CONFIG_T>
+inline typename std::enable_if<not std::is_class<typename CONFIG_T::distance_t>::value>::type
+initialize_edge_weights_table(typename CONFIG_T::edge_weight_t edge_weights_table[])
+{
+    unsigned const table_size = (1 << CONFIG_T::distance_width);
+    double const step = 64. / table_size;
 
-      typename CONFIG_T::distance_t v = -32.;
-      for (unsigned iw = 0; iw < table_size; ++iw) {
+    typename CONFIG_T::distance_t v = -32.;
+    for (unsigned iw = 0; iw < table_size; ++iw) {
         edge_weights_table[iw] = std::exp(-v * v);
         v += step;
-      }
     }
+}
 
-    template<class CONFIG_T>
-    inline
-    typename std::enable_if<std::is_class<typename CONFIG_T::distance_t>::value, typename CONFIG_T::edge_weight_t>::type
-    get_edge_weight(typename CONFIG_T::distance_t distance, typename CONFIG_T::edge_weight_t edge_weights_table[])
-    {
-      typedef ap_uint<CONFIG_T::distance_width> index_t;
+template <class CONFIG_T>
+inline typename std::enable_if<std::is_class<typename CONFIG_T::distance_t>::value,
+                               typename CONFIG_T::edge_weight_t>::type
+get_edge_weight(typename CONFIG_T::distance_t distance, typename CONFIG_T::edge_weight_t edge_weights_table[])
+{
+    typedef ap_uint<CONFIG_T::distance_width> index_t;
 
-      index_t index(distance.range(CONFIG_T::distance_width - 1, 0));
+    index_t index(distance.range(CONFIG_T::distance_width - 1, 0));
 
-      return edge_weights_table[index];
-    }
+    return edge_weights_table[index];
+}
 
-    template<class CONFIG_T>
-    inline
-    typename std::enable_if<not std::is_class<typename CONFIG_T::distance_t>::value, typename CONFIG_T::edge_weight_t>::type
-    get_edge_weight(typename CONFIG_T::distance_t distance, typename CONFIG_T::edge_weight_t edge_weights_table[])
-    {
-      unsigned const table_size = (1 << CONFIG_T::distance_width);
-      double const step = 64. / table_size;
+template <class CONFIG_T>
+inline typename std::enable_if<not std::is_class<typename CONFIG_T::distance_t>::value,
+                               typename CONFIG_T::edge_weight_t>::type
+get_edge_weight(typename CONFIG_T::distance_t distance, typename CONFIG_T::edge_weight_t edge_weights_table[])
+{
+    unsigned const table_size = (1 << CONFIG_T::distance_width);
+    double const step = 64. / table_size;
 
-      int index = (distance + 32.) / step;
-      if (index < 0)
+    int index = (distance + 32.) / step;
+    if (index < 0)
         index = 0;
-      else if (index >= table_size)
+    else if (index >= table_size)
         index = table_size - 1;
 
-      return edge_weights_table[index];
-    }
+    return edge_weights_table[index];
+}
 
-    template<class CONFIG_T>
-    typename CONFIG_T::edge_weight_t
-    compute_edge_weight(typename CONFIG_T::distance_t distance)
-    {
-      if (CONFIG_T::is_stack) {
+template <class CONFIG_T> typename CONFIG_T::edge_weight_t compute_edge_weight(typename CONFIG_T::distance_t distance)
+{
+    if (CONFIG_T::is_stack) {
         #pragma HLS INLINE OFF
-      }
+    }
 #ifdef __SYNTHESIS__
-      typename CONFIG_T::edge_weight_t edge_weights_table[1 << CONFIG_T::distance_width];
-      // unsigned const reshape_factor = CONFIG_T::n_aggregators * CONFIG_T::n_in_features * (CONFIG_T::n_vertices / CONFIG_T::reuse_factor);
-      // #pragma HLS ARRAY_RESHAPE variable=edge_weights_table cyclic factor=reshape_factor dim=1
-      bool initialized = false;
+    typename CONFIG_T::edge_weight_t edge_weights_table[1 << CONFIG_T::distance_width];
+    // unsigned const reshape_factor = CONFIG_T::n_aggregators * CONFIG_T::n_in_features * (CONFIG_T::n_vertices /
+    // CONFIG_T::reuse_factor);
+    // #pragma HLS ARRAY_RESHAPE variable=edge_weights_table cyclic factor=reshape_factor dim=1
+    bool initialized = false;
 #else
-      static typename CONFIG_T::edge_weight_t edge_weights_table[1 << CONFIG_T::distance_width];
-      static bool initialized = false;
+    static typename CONFIG_T::edge_weight_t edge_weights_table[1 << CONFIG_T::distance_width];
+    static bool initialized = false;
 #endif
-      if (not initialized) {
+    if (not initialized) {
         initialize_edge_weights_table<CONFIG_T>(edge_weights_table);
         initialized = true;
-      }
-
-      return get_edge_weight<CONFIG_T>(distance, edge_weights_table);
     }
 
-    template<class dividend_T, class exponent_T>
-    inline
-    typename std::enable_if<std::is_class<dividend_T>::value, dividend_T>::type
-    normalize_log2(dividend_T dividend, exponent_T exponent)
+    return get_edge_weight<CONFIG_T>(distance, edge_weights_table);
+}
+
+template <class dividend_T, class exponent_T>
+inline typename std::enable_if<std::is_class<dividend_T>::value, dividend_T>::type normalize_log2(dividend_T dividend,
+                                                                                                  exponent_T exponent)
+{
+    #pragma HLS INLINE
+    return dividend >> exponent;
+}
+
+template <class dividend_T, class exponent_T>
+inline typename std::enable_if<not std::is_class<dividend_T>::value, dividend_T>::type
+normalize_log2(dividend_T dividend, exponent_T exponent)
+{
+    #pragma HLS INLINE
+    return dividend / std::pow(2., exponent);
+}
+
+template <class CONFIG_T, class E = typename CONFIG_T::edge_weight_t> struct Means {
+    typedef E edge_weight_t;
+
+    edge_weight_t edge_weight_mean[CONFIG_T::n_aggregators];
+    typename CONFIG_T::aggr_t weighted_feature_mean[CONFIG_T::n_aggregators * CONFIG_T::n_in_features];
+
+    Means()
     {
-      #pragma HLS INLINE
-      return dividend >> exponent;
-    }
+    #pragma HLS INLINE
+    #pragma HLS ARRAY_PARTITION variable=edge_weight_mean complete
+    #pragma HLS ARRAY_PARTITION variable=weighted_feature_mean complete
+    #pragma HLS UNROLL region
 
-    template<class dividend_T, class exponent_T>
-    inline
-    typename std::enable_if<not std::is_class<dividend_T>::value, dividend_T>::type
-    normalize_log2(dividend_T dividend, exponent_T exponent)
-    {
-      #pragma HLS INLINE
-      return dividend / std::pow(2., exponent);
-    }
-
-    template<class CONFIG_T, class E = typename CONFIG_T::edge_weight_t>
-    struct Means {
-      typedef E edge_weight_t;
-      
-      edge_weight_t edge_weight_mean[CONFIG_T::n_aggregators];
-      typename CONFIG_T::aggr_t weighted_feature_mean[CONFIG_T::n_aggregators * CONFIG_T::n_in_features];
-
-      Means() {
-        #pragma HLS INLINE
-        #pragma HLS ARRAY_PARTITION variable=edge_weight_mean complete
-        #pragma HLS ARRAY_PARTITION variable=weighted_feature_mean complete
-        #pragma HLS UNROLL region
-
-       Aggregators:
+    Aggregators:
         for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
-          edge_weight_mean[ia] = 0.;
+            edge_weight_mean[ia] = 0.;
 
-         InFeatures:
-          for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
-            unsigned const iax = ia * CONFIG_T::n_in_features + ix;
-            weighted_feature_mean[iax] = 0.;
-          }
+        InFeatures:
+            for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
+                unsigned const iax = ia * CONFIG_T::n_in_features + ix;
+                weighted_feature_mean[iax] = 0.;
+            }
         }
-      }
+    }
 
-      void set_weight(unsigned, edge_weight_t const&) {
+    void set_weight(unsigned, edge_weight_t const &)
+    {
         #pragma HLS INLINE
-      }
+    }
 
-      void add_means_normalized(Means<CONFIG_T, edge_weight_t> const& local) {
+    void add_means_normalized(Means<CONFIG_T, edge_weight_t> const &local)
+    {
         #pragma HLS INLINE
         // Always called within a pipelined region - no UNROLL needed
 
         unsigned const log2_unroll_factor = CONFIG_T::n_vertices_width - CONFIG_T::log2_reuse_factor;
-        
-       Aggregators:
+
+    Aggregators:
         for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
-          edge_weight_mean[ia] += normalize_log2(local.edge_weight_mean[ia], log2_unroll_factor);
+            edge_weight_mean[ia] += normalize_log2(local.edge_weight_mean[ia], log2_unroll_factor);
 
-         InFeatures:
-          for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
-            unsigned const iax = ia * CONFIG_T::n_in_features + ix;
-            weighted_feature_mean[iax] += normalize_log2(local.weighted_feature_mean[iax], log2_unroll_factor);
-          }
+        InFeatures:
+            for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
+                unsigned const iax = ia * CONFIG_T::n_in_features + ix;
+                weighted_feature_mean[iax] += normalize_log2(local.weighted_feature_mean[iax], log2_unroll_factor);
+            }
         }
-      }
+    }
 
-      template<class nvtx_T, class arrays_T, class T = CONFIG_T>
-      typename std::enable_if<T::mean_by_nvert>::type set_means_normalized(nvtx_T const nvtx, arrays_T const& accum) {
+    template <class nvtx_T, class arrays_T, class T = CONFIG_T>
+    typename std::enable_if<T::mean_by_nvert>::type set_means_normalized(nvtx_T const nvtx, arrays_T const &accum)
+    {
         #pragma HLS INLINE
         #pragma HLS UNROLL region
 
         // accum comes divided by unroll factor
         typename T::norm_t nvtx_norm = (T::n_vertices / T::reuse_factor) / nvtx;
 
-       Aggregators:
+    Aggregators:
         for (unsigned ia = 0; ia < T::n_aggregators; ++ia) {
-          edge_weight_mean[ia] = accum.edge_weight_mean[ia] * nvtx_norm;
+            edge_weight_mean[ia] = accum.edge_weight_mean[ia] * nvtx_norm;
 
-         InFeatures:
-          for (unsigned ix = 0; ix < T::n_in_features; ++ix) {
-            unsigned const iax = ia * T::n_in_features + ix;
+        InFeatures:
+            for (unsigned ix = 0; ix < T::n_in_features; ++ix) {
+                unsigned const iax = ia * T::n_in_features + ix;
 
-            weighted_feature_mean[iax] = accum.weighted_feature_mean[iax] * nvtx_norm;
-          }
+                weighted_feature_mean[iax] = accum.weighted_feature_mean[iax] * nvtx_norm;
+            }
         }
-      }
+    }
 
-      template<class nvtx_T, class arrays_T, class T = CONFIG_T>
-      typename std::enable_if<not T::mean_by_nvert>::type set_means_normalized(nvtx_T const nvtx, arrays_T const& accum) {
-        #pragma HLS INLINE
-        #pragma HLS UNROLL region
+    template <class nvtx_T, class arrays_T, class T = CONFIG_T>
+    typename std::enable_if<not T::mean_by_nvert>::type set_means_normalized(nvtx_T const nvtx, arrays_T const &accum)
+    {
+    #pragma HLS INLINE
+    #pragma HLS UNROLL region
 
-       Aggregators:
+    Aggregators:
         for (unsigned ia = 0; ia < T::n_aggregators; ++ia) {
-  
-          edge_weight_mean[ia] = normalize_log2(accum.edge_weight_mean[ia], T::log2_reuse_factor);
-  
-         InFeatures:
-          for (unsigned ix = 0; ix < T::n_in_features; ++ix) {
-            unsigned const iax = ia * T::n_in_features + ix;
-  
-            weighted_feature_mean[iax] = normalize_log2(accum.weighted_feature_mean[iax], T::log2_reuse_factor);
-          }
+
+            edge_weight_mean[ia] = normalize_log2(accum.edge_weight_mean[ia], T::log2_reuse_factor);
+
+        InFeatures:
+            for (unsigned ix = 0; ix < T::n_in_features; ++ix) {
+                unsigned const iax = ia * T::n_in_features + ix;
+
+                weighted_feature_mean[iax] = normalize_log2(accum.weighted_feature_mean[iax], T::log2_reuse_factor);
+            }
         }
-      }
-    };
+    }
+};
 
-    template<class CONFIG_T, class E = typename CONFIG_T::edge_weight_t>
-    struct WeightsAndMeans : public Means<CONFIG_T, E> {
-      typedef E edge_weight_t;
+template <class CONFIG_T, class E = typename CONFIG_T::edge_weight_t>
+struct WeightsAndMeans : public Means<CONFIG_T, E> {
+    typedef E edge_weight_t;
 
-      edge_weight_t edge_weights[CONFIG_T::n_vertices * CONFIG_T::n_aggregators];
+    edge_weight_t edge_weights[CONFIG_T::n_vertices * CONFIG_T::n_aggregators];
 
-      WeightsAndMeans() : Means<CONFIG_T, E>() {
+    WeightsAndMeans() : Means<CONFIG_T, E>()
+    {
         #pragma HLS INLINE
         unsigned const reshape_factor = CONFIG_T::n_aggregators * (CONFIG_T::n_vertices / CONFIG_T::reuse_factor);
         #pragma HLS ARRAY_PARTITION variable=edge_weights cyclic factor=reshape_factor
-      }
+    }
 
-      void set_weight(unsigned iva, edge_weight_t const& weight) {
+    void set_weight(unsigned iva, edge_weight_t const &weight)
+    {
         #pragma HLS INLINE
         edge_weights[iva] = weight;
-      }
-    };
+    }
+};
 
+template <class CONFIG_T, class nvtx_T, class Enable = void> struct OutputBiasNormalizer;
 
-    template<class CONFIG_T, class nvtx_T, class Enable = void>
-    struct OutputBiasNormalizer;
+template <class CONFIG_T, class nvtx_T>
+struct OutputBiasNormalizer<CONFIG_T, nvtx_T, typename std::enable_if<CONFIG_T::mean_by_nvert>::type> {
+    typedef typename CONFIG_T::output_transform_biases_t biases_t;
 
-    template<class CONFIG_T, class nvtx_T>
-    struct OutputBiasNormalizer<CONFIG_T, nvtx_T, typename std::enable_if<CONFIG_T::mean_by_nvert>::type> {
-      typedef typename CONFIG_T::output_transform_biases_t biases_t;
+    biases_t const (&output_biases)[CONFIG_T::n_out_features];
 
-      biases_t const (&output_biases)[CONFIG_T::n_out_features];
-
-      OutputBiasNormalizer(nvtx_T const) : output_biases{CONFIG_T::output_transform_biases} {
+    OutputBiasNormalizer(nvtx_T const) : output_biases{ CONFIG_T::output_transform_biases }
+    {
         #pragma HLS INLINE
-      }
-    };
+    }
+};
 
-    template<class CONFIG_T, class nvtx_T>
-    struct OutputBiasNormalizer<CONFIG_T, nvtx_T, typename std::enable_if<not CONFIG_T::mean_by_nvert>::type> {
-      typedef typename CONFIG_T::output_transform_biases_t biases_t;
+template <class CONFIG_T, class nvtx_T>
+struct OutputBiasNormalizer<CONFIG_T, nvtx_T, typename std::enable_if<not CONFIG_T::mean_by_nvert>::type> {
+    typedef typename CONFIG_T::output_transform_biases_t biases_t;
 
-      biases_t output_biases[CONFIG_T::n_out_features];
-      
-      OutputBiasNormalizer(nvtx_T const nvtx) {
+    biases_t output_biases[CONFIG_T::n_out_features];
+
+    OutputBiasNormalizer(nvtx_T const nvtx)
+    {
         #pragma HLS ARRAY_PARTITION variable=output_biases complete
         #pragma HLS UNROLL region
-        
+
         // Cannot add a loop label here due to a Vivado HLS bug, apparently
         for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
-          typename CONFIG_T::aggr_t bias = CONFIG_T::output_transform_biases[io];
-          bias *= nvtx;
-          output_biases[io] = normalize_log2(bias, CONFIG_T::n_vertices_width);
+            typename CONFIG_T::aggr_t bias = CONFIG_T::output_transform_biases[io];
+            bias *= nvtx;
+            output_biases[io] = normalize_log2(bias, CONFIG_T::n_vertices_width);
         }
-      }
-    };
+    }
+};
 
-    template<class CONFIG_T, class data_T>
-    struct InputDataGetter {
-      typedef data_T data_t;
+template <class CONFIG_T, class data_T> struct InputDataGetter {
+    typedef data_T data_t;
 
-      data_T const* dataref;
+    data_T const *dataref;
 
-      InputDataGetter(data_T const* d) : dataref{d} {
+    InputDataGetter(data_T const *d) : dataref{ d }
+    {
         #pragma HLS INLINE
-      }
-      data_T const& get(unsigned iv, unsigned ix) const {
+    }
+    data_T const &get(unsigned iv, unsigned ix) const
+    {
         #pragma HLS INLINE
         unsigned const ivx = iv * CONFIG_T::n_in_features + ix;
         return dataref[ivx];
-      }
-    };
+    }
+};
 
-    template<class CONFIG_T, class data_T>
-    struct SingleVertexDataGetter {
-      typedef data_T data_t;
+template <class CONFIG_T, class data_T> struct SingleVertexDataGetter {
+    typedef data_T data_t;
 
-      data_T const (&dataref)[CONFIG_T::n_in_features];
+    data_T const (&dataref)[CONFIG_T::n_in_features];
 
-      SingleVertexDataGetter(data_T const (&d)[CONFIG_T::n_in_features]) : dataref{d} {
+    SingleVertexDataGetter(data_T const (&d)[CONFIG_T::n_in_features]) : dataref{ d }
+    {
         #pragma HLS INLINE
-      }
-      data_T const& get(unsigned, unsigned ix) const {
+    }
+    data_T const &get(unsigned, unsigned ix) const
+    {
         #pragma HLS INLINE
         return dataref[ix];
-      }
-    };
+    }
+};
 
-    template<class CONFIG_T, class res_T>
-    struct OutputResSetter {
-      typedef res_T res_t;
+template <class CONFIG_T, class res_T> struct OutputResSetter {
+    typedef res_T res_t;
 
-      res_T* resref;
+    res_T *resref;
 
-      OutputResSetter(res_T* r) : resref{r} {
+    OutputResSetter(res_T *r) : resref{ r }
+    {
         #pragma HLS INLINE
-      }
-      void set(unsigned iv, unsigned io, res_T const& acc) {
+    }
+    void set(unsigned iv, unsigned io, res_T const &acc)
+    {
         #pragma HLS INLINE
-        unsigned const ivo = iv * CONFIG_T::n_out_features + io;    
+        unsigned const ivo = iv * CONFIG_T::n_out_features + io;
         resref[ivo] = acc;
-      }
-    };
+    }
+};
 
-    template<class CONFIG_T, class res_T>
-    struct SingleVertexResSetter {
-      typedef res_T res_t;
+template <class CONFIG_T, class res_T> struct SingleVertexResSetter {
+    typedef res_T res_t;
 
-      res_T (&resref)[CONFIG_T::n_out_features];
+    res_T (&resref)[CONFIG_T::n_out_features];
 
-      SingleVertexResSetter(res_T (&r)[CONFIG_T::n_out_features]) : resref{r} {
+    SingleVertexResSetter(res_T (&r)[CONFIG_T::n_out_features]) : resref{ r }
+    {
         #pragma HLS INLINE
-      }
-      void set(unsigned, unsigned io, res_T const& acc) {
+    }
+    void set(unsigned, unsigned io, res_T const &acc)
+    {
         #pragma HLS INLINE
         resref[io] = acc;
-      }
-    };
+    }
+};
 
-    template<class CONFIG_T, class data_getter_T, class arrays_local_T, class arrays_T>
-    inline
-    void
-    compute_weights_aggregates(
-      data_getter_T const& data_getter,
-      unsigned iv,
-      arrays_local_T& arrays_local,
-      arrays_T& arrays
-    )
-    {
-      #pragma HLS INLINE
+template <class CONFIG_T, class data_getter_T, class arrays_local_T, class arrays_T>
+inline void compute_weights_aggregates(data_getter_T const &data_getter, unsigned iv, arrays_local_T &arrays_local,
+                                       arrays_T &arrays)
+{
+#pragma HLS INLINE
 
-     Aggregators:
-      for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+Aggregators:
+    for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
         typename CONFIG_T::distance_t distance = CONFIG_T::aggregator_distance_biases[ia];
 
-       InFeatures1:
+    InFeatures1:
         for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
-          unsigned const iax = ia * CONFIG_T::n_in_features + ix;
+            unsigned const iax = ia * CONFIG_T::n_in_features + ix;
 
-          typename CONFIG_T::distance_t incr = data_getter.get(iv, ix) * CONFIG_T::aggregator_distance_weights[iax];
+            typename CONFIG_T::distance_t incr = data_getter.get(iv, ix) * CONFIG_T::aggregator_distance_weights[iax];
 
-          distance += incr;
+            distance += incr;
         }
 
-        typename CONFIG_T::edge_weight_t edge_weight = garnet_utils::compute_edge_weight<typename CONFIG_T::base_t>(distance);
+        typename CONFIG_T::edge_weight_t edge_weight =
+            garnet_utils::compute_edge_weight<typename CONFIG_T::base_t>(distance);
 
         arrays_local.edge_weight_mean[ia] += edge_weight;
 
-       InFeatures2:
+    InFeatures2:
         for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
-          unsigned const iax = ia * CONFIG_T::n_in_features + ix;
+            unsigned const iax = ia * CONFIG_T::n_in_features + ix;
 
-          typename data_getter_T::data_t incr = data_getter.get(iv, ix) * edge_weight;
+            typename data_getter_T::data_t incr = data_getter.get(iv, ix) * edge_weight;
 
-          arrays_local.weighted_feature_mean[iax] += incr;
+            arrays_local.weighted_feature_mean[iax] += incr;
         }
 
         unsigned const iva = iv * CONFIG_T::n_aggregators + ia;
         arrays.set_weight(iva, edge_weight);
-      }
     }
+}
 
-    template<class CONFIG_T, class arrays_T>
-    inline
-    typename CONFIG_T::aggr_t
-    compute_output_base_core(
-      arrays_T const& arrays,
-      unsigned io,
-      unsigned ia
-    )
-    {
-      #pragma HLS INLINE
-      #pragma HLS UNROLL region
+template <class CONFIG_T, class arrays_T>
+inline typename CONFIG_T::aggr_t compute_output_base_core(arrays_T const &arrays, unsigned io, unsigned ia)
+{
+    #pragma HLS INLINE
+    #pragma HLS UNROLL region
 
-      unsigned const ioa = io * CONFIG_T::n_aggregators + ia;
-      typename CONFIG_T::aggr_t aggr = arrays.edge_weight_mean[ia] * CONFIG_T::input_transform_biases[ioa];
+    unsigned const ioa = io * CONFIG_T::n_aggregators + ia;
+    typename CONFIG_T::aggr_t aggr = arrays.edge_weight_mean[ia] * CONFIG_T::input_transform_biases[ioa];
 
-     InFeatures:
-      for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
+InFeatures:
+    for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
         unsigned const ioax = ioa * CONFIG_T::n_in_features + ix;
         unsigned const iax = ia * CONFIG_T::n_in_features + ix;
 
         aggr += arrays.weighted_feature_mean[iax] * CONFIG_T::input_transform_weights[ioax];
-      }
-
-      return aggr;
     }
 
-    template<class CONFIG_T, class arrays_T>
-    inline
-    void
-    compute_output_base(
-      arrays_T const& arrays,
-      typename CONFIG_T::aggr_t output_base[CONFIG_T::n_out_features * CONFIG_T::n_aggregators]
-    )
-    {
-      #pragma HLS INLINE
-      #pragma HLS UNROLL region
+    return aggr;
+}
 
-     OutFeatures:
-      for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
-       Aggregators:
+template <class CONFIG_T, class arrays_T>
+inline void
+compute_output_base(arrays_T const &arrays,
+                    typename CONFIG_T::aggr_t output_base[CONFIG_T::n_out_features * CONFIG_T::n_aggregators])
+{
+#pragma HLS INLINE
+#pragma HLS UNROLL region
+
+OutFeatures:
+    for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
+    Aggregators:
         for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
-          unsigned const ioa = io * CONFIG_T::n_aggregators + ia;
+            unsigned const ioa = io * CONFIG_T::n_aggregators + ia;
 
-          output_base[ioa] = compute_output_base_core<CONFIG_T>(arrays, io, ia);
+            output_base[ioa] = compute_output_base_core<CONFIG_T>(arrays, io, ia);
         }
-      }
     }
+}
 
-    template<class CONFIG_T, class arrays_T, class res_setter_T>
-    inline
-    void
-    compute_vertex_output(
-      arrays_T const& arrays,
-      unsigned iv,
-      typename CONFIG_T::aggr_t const output_base[CONFIG_T::n_out_features * CONFIG_T::n_aggregators],
-      res_setter_T& res_setter
-    )
-    {
-      #pragma HLS INLINE
+template <class CONFIG_T, class arrays_T, class res_setter_T>
+inline void
+compute_vertex_output(arrays_T const &arrays, unsigned iv,
+                      typename CONFIG_T::aggr_t const output_base[CONFIG_T::n_out_features * CONFIG_T::n_aggregators],
+                      res_setter_T &res_setter)
+{
+    #pragma HLS INLINE
 
-      typename arrays_T::edge_weight_t edge_weights[CONFIG_T::n_aggregators];
-      #pragma HLS ARRAY_PARTITION variable=edge_weights complete
+    typename arrays_T::edge_weight_t edge_weights[CONFIG_T::n_aggregators];
+#pragma HLS ARRAY_PARTITION variable=edge_weights complete
 
-     Aggregators1:
-      for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+Aggregators1:
+    for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
         unsigned const iva = iv * CONFIG_T::n_aggregators + ia;
 
         edge_weights[ia] = arrays.edge_weights[iva];
-      }
-      
-     OutFeatures:
-      for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
-        typename res_setter_T::res_t acc = CONFIG_T::output_transform_biases[io];
-    
-       Aggregators2:
-        for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
-          unsigned const ioa = io * CONFIG_T::n_aggregators + ia;
+    }
 
-          typename res_setter_T::res_t incr = edge_weights[ia] * output_base[ioa];
-          acc += incr;
+OutFeatures:
+    for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
+        typename res_setter_T::res_t acc = CONFIG_T::output_transform_biases[io];
+
+    Aggregators2:
+        for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+            unsigned const ioa = io * CONFIG_T::n_aggregators + ia;
+
+            typename res_setter_T::res_t incr = edge_weights[ia] * output_base[ioa];
+            acc += incr;
         }
 
         res_setter.set(iv, io, acc);
-      }
     }
+}
 
-    template<class CONFIG_T, class data_T, class nvtx_T, class arrays_T>
-    void
-    aggregate(
-      data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features],
-      nvtx_T const nvtx,
-      arrays_T& arrays
-    )
-    {
-      InputDataGetter<CONFIG_T, data_T> data_getter(data);
+template <class CONFIG_T, class data_T, class nvtx_T, class arrays_T>
+void aggregate(data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features], nvtx_T const nvtx, arrays_T &arrays)
+{
+    InputDataGetter<CONFIG_T, data_T> data_getter(data);
 
-      unsigned const unroll_factor = CONFIG_T::n_vertices >> CONFIG_T::log2_reuse_factor;
+    unsigned const unroll_factor = CONFIG_T::n_vertices >> CONFIG_T::log2_reuse_factor;
 
-      Means<CONFIG_T, typename CONFIG_T::edge_weight_aggr_t> means_accum;
-      
-     VerticesOuter:
-      for (unsigned ivv = 0; ivv < CONFIG_T::reuse_factor; ++ivv) {
+    Means<CONFIG_T, typename CONFIG_T::edge_weight_aggr_t> means_accum;
+
+VerticesOuter:
+    for (unsigned ivv = 0; ivv < CONFIG_T::reuse_factor; ++ivv) {
         #pragma HLS PIPELINE
 
         if (ivv * unroll_factor >= nvtx)
-          break;
+            break;
 
         Means<CONFIG_T, typename CONFIG_T::edge_weight_aggr_t> means_local;
 
-       VerticesInner:
+    VerticesInner:
         for (unsigned ir = 0; ir < unroll_factor; ++ir) {
-          unsigned iv = ivv * unroll_factor + ir;
+            unsigned iv = ivv * unroll_factor + ir;
 
-          if (iv == nvtx)
-            break;
-    
-          compute_weights_aggregates<CONFIG_T>(data_getter, iv, means_local, arrays);
+            if (iv == nvtx)
+                break;
+
+            compute_weights_aggregates<CONFIG_T>(data_getter, iv, means_local, arrays);
         }
 
         means_accum.add_means_normalized(means_local);
-      }
-
-      arrays.set_means_normalized(nvtx, means_accum);
     }
 
-    template<class CONFIG_T, class nvtx_T, class arrays_T, class res_T>
-    void
-    distribute(
-      nvtx_T const nvtx,
-      arrays_T const& arrays,
-      res_T res[CONFIG_T::n_vertices * CONFIG_T::n_out_features]
-    )
-    {
-      OutputResSetter<CONFIG_T, res_T> res_setter(res);
+    arrays.set_means_normalized(nvtx, means_accum);
+}
 
-      typename CONFIG_T::aggr_t output_base[CONFIG_T::n_out_features * CONFIG_T::n_aggregators];
-      #pragma HLS ARRAY_PARTITION variable=output_base complete      
+template <class CONFIG_T, class nvtx_T, class arrays_T, class res_T>
+void distribute(nvtx_T const nvtx, arrays_T const &arrays, res_T res[CONFIG_T::n_vertices * CONFIG_T::n_out_features])
+{
+    OutputResSetter<CONFIG_T, res_T> res_setter(res);
 
-      compute_output_base<CONFIG_T>(arrays, output_base);
+    typename CONFIG_T::aggr_t output_base[CONFIG_T::n_out_features * CONFIG_T::n_aggregators];
+    #pragma HLS ARRAY_PARTITION variable=output_base complete
 
-      unsigned const unroll_factor = CONFIG_T::n_vertices >> CONFIG_T::log2_reuse_factor;
+    compute_output_base<CONFIG_T>(arrays, output_base);
 
-     VerticesOuter:
-      for (unsigned ivv = 0; ivv < CONFIG_T::reuse_factor; ++ivv) {
+    unsigned const unroll_factor = CONFIG_T::n_vertices >> CONFIG_T::log2_reuse_factor;
+
+VerticesOuter:
+    for (unsigned ivv = 0; ivv < CONFIG_T::reuse_factor; ++ivv) {
         #pragma HLS PIPELINE
 
         if (ivv * unroll_factor >= nvtx)
-          break;
-
-       VerticesInner:
-        for (unsigned ir = 0; ir < unroll_factor; ++ir) {
-          unsigned iv = ivv * unroll_factor + ir;
-
-          if (iv == nvtx)
             break;
-    
-          compute_vertex_output<CONFIG_T>(arrays, iv, output_base, res_setter);
+
+    VerticesInner:
+        for (unsigned ir = 0; ir < unroll_factor; ++ir) {
+            unsigned iv = ivv * unroll_factor + ir;
+
+            if (iv == nvtx)
+                break;
+
+            compute_vertex_output<CONFIG_T>(arrays, iv, output_base, res_setter);
         }
-      }
     }
-    
-    template<class CONFIG_T, class output_biases_T, class arrays_T, class res_T>
-    void
-    set_output(
-      output_biases_T const& output_transform_biases,
-      arrays_T const& arrays,
-      res_T res[CONFIG_T::n_out_features]
-    )
-    {
-      #pragma HLS PIPELINE
-    
-     OutFeatures:
-      for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
+}
+
+template <class CONFIG_T, class output_biases_T, class arrays_T, class res_T>
+void set_output(output_biases_T const &output_transform_biases, arrays_T const &arrays,
+                res_T res[CONFIG_T::n_out_features])
+{
+#pragma HLS PIPELINE
+
+OutFeatures:
+    for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
         res_T acc = output_transform_biases.output_biases[io];
 
-       Aggregators:
+    Aggregators:
         for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
-          typename CONFIG_T::aggr_t aggr = compute_output_base_core<CONFIG_T>(arrays, io, ia);
+            typename CONFIG_T::aggr_t aggr = compute_output_base_core<CONFIG_T>(arrays, io, ia);
 
-          acc += arrays.edge_weight_mean[ia] * aggr;
+            acc += arrays.edge_weight_mean[ia] * aggr;
         }
-    
+
         res[io] = acc;
-      }
     }
+}
 
-    template<class prev_layer_t, class current_layer_t, class nvtx_T, class prev_arrays_T, class current_arrays_T>
-    void
-    distribute_aggregate(
-      nvtx_T const nvtx,
-      prev_arrays_T const& prev_arrays,
-      current_arrays_T& current_arrays
-    )
-    {
-      typedef typename prev_layer_t::output_t data_T;
+template <class prev_layer_t, class current_layer_t, class nvtx_T, class prev_arrays_T, class current_arrays_T>
+void distribute_aggregate(nvtx_T const nvtx, prev_arrays_T const &prev_arrays, current_arrays_T &current_arrays)
+{
+    typedef typename prev_layer_t::output_t data_T;
 
-      typename prev_layer_t::aggr_t prev_output_base[prev_layer_t::n_out_features * prev_layer_t::n_aggregators];
-      #pragma HLS ARRAY_PARTITION variable=prev_output_base complete
+    typename prev_layer_t::aggr_t prev_output_base[prev_layer_t::n_out_features * prev_layer_t::n_aggregators];
+    #pragma HLS ARRAY_PARTITION variable=prev_output_base complete
 
-      compute_output_base<prev_layer_t>(prev_arrays, prev_output_base);
+    compute_output_base<prev_layer_t>(prev_arrays, prev_output_base);
 
-      unsigned const unroll_factor = current_layer_t::n_vertices >> current_layer_t::log2_reuse_factor;
+    unsigned const unroll_factor = current_layer_t::n_vertices >> current_layer_t::log2_reuse_factor;
 
-      Means<current_layer_t, typename current_layer_t::edge_weight_aggr_t> means_accum;
-      
-     VerticesOuter:
-      for (unsigned ivv = 0; ivv < current_layer_t::reuse_factor; ++ivv) {
+    Means<current_layer_t, typename current_layer_t::edge_weight_aggr_t> means_accum;
+
+VerticesOuter:
+    for (unsigned ivv = 0; ivv < current_layer_t::reuse_factor; ++ivv) {
         #pragma HLS PIPELINE
 
         if (ivv * unroll_factor >= nvtx)
-          break;
+            break;
 
         Means<current_layer_t, typename current_layer_t::edge_weight_aggr_t> means_local;
 
-       VerticesInner:
+    VerticesInner:
         for (unsigned ir = 0; ir < unroll_factor; ++ir) {
-          unsigned iv = ivv * unroll_factor + ir;
+            unsigned iv = ivv * unroll_factor + ir;
 
-          if (iv == nvtx)
-            break;
-    
-          data_T data[prev_layer_t::n_out_features];
-          #pragma HLS ARRAY_PARTITION variable=data complete
+            if (iv == nvtx)
+                break;
 
-          SingleVertexResSetter<prev_layer_t, data_T> res_setter(data);
+            data_T data[prev_layer_t::n_out_features];
+            #pragma HLS ARRAY_PARTITION variable=data complete
 
-          compute_vertex_output<prev_layer_t>(prev_arrays, iv, prev_output_base, res_setter);
+            SingleVertexResSetter<prev_layer_t, data_T> res_setter(data);
 
-          SingleVertexDataGetter<current_layer_t, data_T> data_getter(data);
-          
-          compute_weights_aggregates<current_layer_t>(data_getter, iv, means_local, current_arrays);
+            compute_vertex_output<prev_layer_t>(prev_arrays, iv, prev_output_base, res_setter);
+
+            SingleVertexDataGetter<current_layer_t, data_T> data_getter(data);
+
+            compute_weights_aggregates<current_layer_t>(data_getter, iv, means_local, current_arrays);
         }
 
         means_accum.add_means_normalized(means_local);
-      }
-
-      current_arrays.set_means_normalized(nvtx, means_accum);
     }
 
-    template<class prev_layer_t, class current_layer_t, class last_layer_t, class nvtx_T, class prev_arrays_T, class last_arrays_T>
-    inline
-    typename std::enable_if<std::is_same<current_layer_t, last_layer_t>::value>::type
-    sublayer(
-      nvtx_T const nvtx,
-      prev_arrays_T const& prev_arrays,
-      last_arrays_T& last_arrays
-    )
-    {
-      #pragma HLS INLINE
+    current_arrays.set_means_normalized(nvtx, means_accum);
+}
 
-      distribute_aggregate<prev_layer_t, current_layer_t>(nvtx, prev_arrays, last_arrays);
-    }
-      
-    template<class prev_layer_t, class current_layer_t, class last_layer_t, class nvtx_T, class prev_arrays_T, class last_arrays_T>
-    inline
-    typename std::enable_if<not std::is_same<current_layer_t, last_layer_t>::value>::type
-    sublayer(
-      nvtx_T const nvtx,
-      prev_arrays_T const& prev_arrays,
-      last_arrays_T& last_arrays
-    )
-    {
-      #pragma HLS INLINE
+template <class prev_layer_t, class current_layer_t, class last_layer_t, class nvtx_T, class prev_arrays_T,
+          class last_arrays_T>
+inline typename std::enable_if<std::is_same<current_layer_t, last_layer_t>::value>::type
+sublayer(nvtx_T const nvtx, prev_arrays_T const &prev_arrays, last_arrays_T &last_arrays)
+{
+    #pragma HLS INLINE
 
-      WeightsAndMeans<current_layer_t> current_arrays;
+    distribute_aggregate<prev_layer_t, current_layer_t>(nvtx, prev_arrays, last_arrays);
+}
 
-      distribute_aggregate<prev_layer_t, current_layer_t>(nvtx, prev_arrays, current_arrays);
+template <class prev_layer_t, class current_layer_t, class last_layer_t, class nvtx_T, class prev_arrays_T,
+          class last_arrays_T>
+inline typename std::enable_if<not std::is_same<current_layer_t, last_layer_t>::value>::type
+sublayer(nvtx_T const nvtx, prev_arrays_T const &prev_arrays, last_arrays_T &last_arrays)
+{
+    #pragma HLS INLINE
 
-      sublayer<current_layer_t, typename current_layer_t::next_layer_t, last_layer_t>(nvtx, current_arrays, last_arrays);
-    }
-  }
- 
-  struct garnet_config
-  {
+    WeightsAndMeans<current_layer_t> current_arrays;
+
+    distribute_aggregate<prev_layer_t, current_layer_t>(nvtx, prev_arrays, current_arrays);
+
+    sublayer<current_layer_t, typename current_layer_t::next_layer_t, last_layer_t>(nvtx, current_arrays, last_arrays);
+}
+}
+
+struct garnet_config {
     // Layer specs
     static const unsigned n_vertices_width = 8;
     static const unsigned n_vertices = (1 << n_vertices_width);
@@ -670,7 +629,7 @@ namespace nnet {
     typedef float output_transform_biases_t;
     typedef float aggregator_distance_weights_t;
     typedef float aggregator_distance_biases_t;
-  
+
     typedef float norm_t;
     typedef float distance_t;
     typedef float edge_weight_t;
@@ -678,91 +637,67 @@ namespace nnet {
     typedef float aggr_t;
     typedef float output_t;
 
-    /* static const input_transform_weights_t (&input_transform_weights)[n_out_features * n_aggregators * n_in_features]; */
+    /* static const input_transform_weights_t (&input_transform_weights)[n_out_features * n_aggregators *
+     * n_in_features]; */
     /* static const input_transform_biases_t (&input_transform_biases)[n_out_features * n_aggregators]; */
     /* static const aggregator_distance_weights_t (&aggregator_distance_weights)[n_aggregators * n_in_features]; */
     /* static const aggregator_distance_biases_t (&aggregator_distance_biases)[n_aggregators]; */
     /* static const output_transform_biases_t (&output_transform_biases)[n_out_features]; */
 
     enum OutputCollapse {
-      no_collapse,
-      collapse_mean,
-      collapse_max
+        no_collapse,
+        collapse_mean,
+        collapse_max
     };
-  
+
     static const unsigned output_collapse = no_collapse;
 
     static const bool mean_by_nvert = false;
     static const bool is_stack = false;
- 
+
     // Optimization specs
     static const unsigned reuse_factor = 64;
     static const unsigned log2_reuse_factor = 6;
-  };
+};
 
-  // vertices -> vertices
-  template<class data_T, class nvtx_T, class res_T, typename CONFIG_T>
-  typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::no_collapse>::type
-  garnet(
-    data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features],
-    nvtx_T const nvtx[1],
-    res_T res[CONFIG_T::n_vertices * CONFIG_T::n_out_features]
-  )
-  {
+// vertices -> vertices
+template <class data_T, class nvtx_T, class res_T, typename CONFIG_T>
+typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::no_collapse>::type
+garnet(data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features], nvtx_T const nvtx[1],
+       res_T res[CONFIG_T::n_vertices * CONFIG_T::n_out_features])
+{
     #pragma HLS DATAFLOW
 
     garnet_utils::WeightsAndMeans<CONFIG_T> arrays;
 
-    garnet_utils::aggregate<CONFIG_T>(
-      data,
-      nvtx[0],
-      arrays
-    );
-  
-    garnet_utils::distribute<CONFIG_T>(
-      nvtx[0],
-      arrays,
-      res
-    );
-  }
+    garnet_utils::aggregate<CONFIG_T>(data, nvtx[0], arrays);
 
-  // vertices -> out features
-  template<class data_T, class nvtx_T, class res_T, class CONFIG_T>
-  typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::collapse_mean>::type
-  garnet(
-    data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features],
-    nvtx_T const nvtx[1],
-    res_T res[CONFIG_T::n_out_features]
-  )
-  {
+    garnet_utils::distribute<CONFIG_T>(nvtx[0], arrays, res);
+}
+
+// vertices -> out features
+template <class data_T, class nvtx_T, class res_T, class CONFIG_T>
+typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::collapse_mean>::type
+garnet(data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features], nvtx_T const nvtx[1],
+       res_T res[CONFIG_T::n_out_features])
+{
     #pragma HLS DATAFLOW
 
     garnet_utils::Means<CONFIG_T> arrays;
-  
-    garnet_utils::aggregate<CONFIG_T>(
-      data,
-      nvtx[0],
-      arrays
-    );
+
+    garnet_utils::aggregate<CONFIG_T>(data, nvtx[0], arrays);
 
     garnet_utils::OutputBiasNormalizer<CONFIG_T, nvtx_T> normalize_bias(nvtx[0]);
 
-    garnet_utils::set_output<CONFIG_T>(
-      normalize_bias,
-      arrays,
-      res
-    );
-  }
+    garnet_utils::set_output<CONFIG_T>(normalize_bias, arrays, res);
+}
 
-  // vertices -> vertices
-  template<class data_T, class nvtx_T, class res_T, class CONFIG_T>
-  typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::no_collapse>::type
-  garnet_stack(
-    data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features],
-    nvtx_T const nvtx[1],
-    res_T res[CONFIG_T::n_vertices * CONFIG_T::n_out_features]
-  )
-  {
+// vertices -> vertices
+template <class data_T, class nvtx_T, class res_T, class CONFIG_T>
+typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::no_collapse>::type
+garnet_stack(data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features], nvtx_T const nvtx[1],
+             res_T res[CONFIG_T::n_vertices * CONFIG_T::n_out_features])
+{
     #pragma HLS DATAFLOW
 
     typedef typename CONFIG_T::template sublayer_t<0> first_layer_t;
@@ -772,34 +707,20 @@ namespace nnet {
     garnet_utils::WeightsAndMeans<first_layer_t> arrays_first;
     garnet_utils::Means<last_layer_t> arrays_last;
 
-    garnet_utils::aggregate<first_layer_t>(
-      data,
-      nvtx[0],
-      arrays_first
-    );
+    garnet_utils::aggregate<first_layer_t>(data, nvtx[0], arrays_first);
 
-    garnet_utils::sublayer<first_layer_t, typename first_layer_t::next_layer_t, last_layer_t>(
-      nvtx[0],
-      arrays_first,
-      arrays_last
-    );
+    garnet_utils::sublayer<first_layer_t, typename first_layer_t::next_layer_t, last_layer_t>(nvtx[0], arrays_first,
+                                                                                              arrays_last);
 
-    garnet_utils::distribute<last_layer_t>(
-      nvtx[0],
-      arrays_last,
-      res
-    );
-  }
+    garnet_utils::distribute<last_layer_t>(nvtx[0], arrays_last, res);
+}
 
-  // vertices -> out features
-  template<class data_T, class nvtx_T, class res_T, class CONFIG_T>
-  typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::collapse_mean>::type
-  garnet_stack(
-    data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features],
-    nvtx_T const nvtx[1],
-    res_T res[CONFIG_T::n_out_features]
-  )
-  {
+// vertices -> out features
+template <class data_T, class nvtx_T, class res_T, class CONFIG_T>
+typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::collapse_mean>::type
+garnet_stack(data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features], nvtx_T const nvtx[1],
+             res_T res[CONFIG_T::n_out_features])
+{
     #pragma HLS DATAFLOW
 
     typedef typename CONFIG_T::template sublayer_t<0> first_layer_t;
@@ -809,175 +730,153 @@ namespace nnet {
     garnet_utils::WeightsAndMeans<first_layer_t> arrays_first;
     garnet_utils::Means<last_layer_t> arrays_last;
 
-    garnet_utils::aggregate<first_layer_t>(
-      data,
-      nvtx[0],
-      arrays_first
-    );
+    garnet_utils::aggregate<first_layer_t>(data, nvtx[0], arrays_first);
 
-    garnet_utils::sublayer<first_layer_t, typename first_layer_t::next_layer_t, last_layer_t>(
-      nvtx[0],
-      arrays_first,
-      arrays_last
-    );
+    garnet_utils::sublayer<first_layer_t, typename first_layer_t::next_layer_t, last_layer_t>(nvtx[0], arrays_first,
+                                                                                              arrays_last);
 
     garnet_utils::OutputBiasNormalizer<last_layer_t, nvtx_T> normalize_bias(nvtx[0]);
 
-    garnet_utils::set_output<last_layer_t>(
-      normalize_bias,
-      arrays_last,
-      res
-    );
-  }
+    garnet_utils::set_output<last_layer_t>(normalize_bias, arrays_last, res);
+}
 
-  /* Reference (dumb) implementation returning (Vertices, Features) */
-  template<class data_T, class nvtx_T, class res_T, typename CONFIG_T>
-  typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::no_collapse>::type
-  garnet_ref(
-    data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features],
-    nvtx_T const nvtx[1],
-    res_T res[CONFIG_T::n_vertices * CONFIG_T::n_out_features]
-  )
-  {
+/* Reference (dumb) implementation returning (Vertices, Features) */
+template <class data_T, class nvtx_T, class res_T, typename CONFIG_T>
+typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::no_collapse>::type
+garnet_ref(data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features], nvtx_T const nvtx[1],
+           res_T res[CONFIG_T::n_vertices * CONFIG_T::n_out_features])
+{
     typename CONFIG_T::edge_weight_t edge_weights[CONFIG_T::n_vertices * CONFIG_T::n_aggregators];
     typename CONFIG_T::aggr_t propagated_features[CONFIG_T::n_vertices * CONFIG_T::n_propagate];
-  
-    for (unsigned iv = 0; iv < CONFIG_T::n_vertices; ++iv) {
-      if (iv == nvtx[0])
-        break;
-  
-      for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
-        unsigned const ivp = iv * CONFIG_T::n_propagate + ip;
-  
-        propagated_features[ivp] = CONFIG_T::input_transform_biases[ip];
-  
-        for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
-          unsigned const ivx = iv * CONFIG_T::n_in_features + ix;
-          unsigned const ipx = ip * CONFIG_T::n_in_features + ix;
-  
-          propagated_features[ivp] += data[ivx] * CONFIG_T::input_transform_weights[ipx];
-        }
-      }
-  
-      for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
-        unsigned const iva = iv * CONFIG_T::n_aggregators + ia;
-  
-        typename CONFIG_T::aggr_t distance = CONFIG_T::aggregator_distance_biases[ia];
-  
-        for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
-          unsigned const ivx = iv * CONFIG_T::n_in_features + ix;
-          unsigned const iax = ia * CONFIG_T::n_in_features + ix;
-  
-          distance += data[ivx] * CONFIG_T::aggregator_distance_weights[iax];
-        }
-  
-        edge_weights[iva] = garnet_utils::compute_edge_weight<CONFIG_T>(distance);
-      }
-    }
-  
-    typename CONFIG_T::aggr_t aggregated_features[CONFIG_T::n_aggregators * CONFIG_T::n_propagate];
-  
-    for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
-      for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
-        unsigned const iap = ia * CONFIG_T::n_propagate + ip;
-  
-        aggregated_features[iap] = 0.;
-  
-        for (unsigned iv = 0; iv < CONFIG_T::n_vertices; ++iv) {
-          if (iv == nvtx[0])
-            break;
-  
-          unsigned const iva = iv * CONFIG_T::n_aggregators + ia;
-          unsigned const ivp = iv * CONFIG_T::n_propagate + ip;
-  
-          aggregated_features[iap] += edge_weights[iva] * propagated_features[ivp];
-        }
-      }
-    }
-  
-    for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
-      for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
-        unsigned const iap = ia * CONFIG_T::n_propagate + ip;
-  
-        if (CONFIG_T::mean_by_nvert)
-          aggregated_features[iap] /= nvtx[0];
-        else {
-          // Not using right shift in case aggr_t is float or double
-          aggregated_features[iap] /= CONFIG_T::n_vertices;
-        }
-      }
-    }
-  
-    for (unsigned iv = 0; iv < CONFIG_T::n_vertices; ++iv) {
-      if (iv == nvtx[0])
-        break;
-  
-      for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
-        unsigned const ivo = iv * CONFIG_T::n_out_features + io;
-  
-        typename CONFIG_T::aggr_t acc = CONFIG_T::output_transform_biases[io];
-  
-        for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
-          unsigned const iva = iv * CONFIG_T::n_aggregators + ia;
-          unsigned const ioa = io * CONFIG_T::n_aggregators + ia;
-  
-          typename CONFIG_T::aggr_t aggr = 0.;
-  
-          for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
-            unsigned const iap = ia * CONFIG_T::n_propagate + ip;
-            unsigned const ioap = ioa * CONFIG_T::n_propagate + ip;
-  
-            aggr += CONFIG_T::output_transform_weights[ioap] * aggregated_features[iap];
-          }
-  
-          acc += edge_weights[iva] * aggr;
-        }
-  
-        res[ivo] = acc;
-      }
-    }
-  }
 
-  /* Reference (dumb) implementation returning (Features) - output averaged over vertices already */
-  template<class data_T, class nvtx_T, class res_T, typename CONFIG_T>
-  typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::collapse_mean>::type
-  garnet_ref(
-    data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features],
-    nvtx_T const nvtx[1],
-    res_T res[CONFIG_T::n_out_features]
-  )
-  {
+    for (unsigned iv = 0; iv < CONFIG_T::n_vertices; ++iv) {
+        if (iv == nvtx[0])
+            break;
+
+        for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
+            unsigned const ivp = iv * CONFIG_T::n_propagate + ip;
+
+            propagated_features[ivp] = CONFIG_T::input_transform_biases[ip];
+
+            for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
+                unsigned const ivx = iv * CONFIG_T::n_in_features + ix;
+                unsigned const ipx = ip * CONFIG_T::n_in_features + ix;
+
+                propagated_features[ivp] += data[ivx] * CONFIG_T::input_transform_weights[ipx];
+            }
+        }
+
+        for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+            unsigned const iva = iv * CONFIG_T::n_aggregators + ia;
+
+            typename CONFIG_T::aggr_t distance = CONFIG_T::aggregator_distance_biases[ia];
+
+            for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
+                unsigned const ivx = iv * CONFIG_T::n_in_features + ix;
+                unsigned const iax = ia * CONFIG_T::n_in_features + ix;
+
+                distance += data[ivx] * CONFIG_T::aggregator_distance_weights[iax];
+            }
+
+            edge_weights[iva] = garnet_utils::compute_edge_weight<CONFIG_T>(distance);
+        }
+    }
+
+    typename CONFIG_T::aggr_t aggregated_features[CONFIG_T::n_aggregators * CONFIG_T::n_propagate];
+
+    for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+        for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
+            unsigned const iap = ia * CONFIG_T::n_propagate + ip;
+
+            aggregated_features[iap] = 0.;
+
+            for (unsigned iv = 0; iv < CONFIG_T::n_vertices; ++iv) {
+                if (iv == nvtx[0])
+                    break;
+
+                unsigned const iva = iv * CONFIG_T::n_aggregators + ia;
+                unsigned const ivp = iv * CONFIG_T::n_propagate + ip;
+
+                aggregated_features[iap] += edge_weights[iva] * propagated_features[ivp];
+            }
+        }
+    }
+
+    for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+        for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
+            unsigned const iap = ia * CONFIG_T::n_propagate + ip;
+
+            if (CONFIG_T::mean_by_nvert)
+                aggregated_features[iap] /= nvtx[0];
+            else {
+                // Not using right shift in case aggr_t is float or double
+                aggregated_features[iap] /= CONFIG_T::n_vertices;
+            }
+        }
+    }
+
+    for (unsigned iv = 0; iv < CONFIG_T::n_vertices; ++iv) {
+        if (iv == nvtx[0])
+            break;
+
+        for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
+            unsigned const ivo = iv * CONFIG_T::n_out_features + io;
+
+            typename CONFIG_T::aggr_t acc = CONFIG_T::output_transform_biases[io];
+
+            for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+                unsigned const iva = iv * CONFIG_T::n_aggregators + ia;
+                unsigned const ioa = io * CONFIG_T::n_aggregators + ia;
+
+                typename CONFIG_T::aggr_t aggr = 0.;
+
+                for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
+                    unsigned const iap = ia * CONFIG_T::n_propagate + ip;
+                    unsigned const ioap = ioa * CONFIG_T::n_propagate + ip;
+
+                    aggr += CONFIG_T::output_transform_weights[ioap] * aggregated_features[iap];
+                }
+
+                acc += edge_weights[iva] * aggr;
+            }
+
+            res[ivo] = acc;
+        }
+    }
+}
+
+/* Reference (dumb) implementation returning (Features) - output averaged over vertices already */
+template <class data_T, class nvtx_T, class res_T, typename CONFIG_T>
+typename std::enable_if<CONFIG_T::output_collapse == CONFIG_T::collapse_mean>::type
+garnet_ref(data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features], nvtx_T const nvtx[1],
+           res_T res[CONFIG_T::n_out_features])
+{
     typename CONFIG_T::aggr_t vertex_res[CONFIG_T::n_vertices * CONFIG_T::n_out_features];
 
-    garnet_ref<CONFIG_T>(
-      data,
-      nvtx,
-      vertex_res
-    );
-  
-    for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
-      typename CONFIG_T::aggr_t acc = 0.;
-  
-      for (unsigned iv = 0; iv < CONFIG_T::n_vertices; ++iv) {
-        if (iv == nvtx[0])
-          break;
-  
-        unsigned const ivo = iv * CONFIG_T::n_out_features + io;
-  
-        acc += vertex_res[ivo];
-      }
-  
-      if (CONFIG_T::mean_by_nvert)
-        acc /= nvtx[0];
-      else {
-        // Not using right shift in case aggr_t is float or double
-        acc /= CONFIG_T::n_vertices;
-      }
-  
-      res[io] = acc;
-    }
-  }
+    garnet_ref<CONFIG_T>(data, nvtx, vertex_res);
 
+    for (unsigned io = 0; io < CONFIG_T::n_out_features; ++io) {
+        typename CONFIG_T::aggr_t acc = 0.;
+
+        for (unsigned iv = 0; iv < CONFIG_T::n_vertices; ++iv) {
+            if (iv == nvtx[0])
+                break;
+
+            unsigned const ivo = iv * CONFIG_T::n_out_features + io;
+
+            acc += vertex_res[ivo];
+        }
+
+        if (CONFIG_T::mean_by_nvert)
+            acc /= nvtx[0];
+        else {
+            // Not using right shift in case aggr_t is float or double
+            acc /= CONFIG_T::n_vertices;
+        }
+
+        res[io] = acc;
+    }
+}
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_helpers.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_helpers.h
@@ -36,8 +36,8 @@ namespace nnet {
 #define WEIGHTS_DIR "weights"
 #endif
 
-template<class T, size_t SIZE>
-void load_weights_from_txt(T *w, const char* fname) {
+template <class T, size_t SIZE> void load_weights_from_txt(T *w, const char *fname)
+{
 
     std::string full_path = std::string(WEIGHTS_DIR) + "/" + std::string(fname);
     std::ifstream infile(full_path.c_str(), std::ios::binary);
@@ -53,7 +53,7 @@ void load_weights_from_txt(T *w, const char* fname) {
         std::string token;
 
         size_t i = 0;
-        while(std::getline(iss, token, ',')) {
+        while (std::getline(iss, token, ',')) {
             std::istringstream(token) >> w[i];
             i++;
         }
@@ -65,8 +65,8 @@ void load_weights_from_txt(T *w, const char* fname) {
     }
 }
 
-template<class T, size_t SIZE>
-void load_compressed_weights_from_txt(T *w, const char* fname) {
+template <class T, size_t SIZE> void load_compressed_weights_from_txt(T *w, const char *fname)
+{
 
     std::string full_path = std::string(WEIGHTS_DIR) + "/" + std::string(fname);
     std::ifstream infile(full_path.c_str(), std::ios::binary);
@@ -83,11 +83,11 @@ void load_compressed_weights_from_txt(T *w, const char* fname) {
         std::string extra_chars = "} ";
 
         size_t i = 0;
-        while(std::getline(iss, token, '{')) {
+        while (std::getline(iss, token, '{')) {
             if (token.length() == 0) {
                 continue;
             }
-            for (char c: extra_chars) {
+            for (char c : extra_chars) {
                 token.erase(std::remove(token.begin(), token.end(), c), token.end());
             }
             if (token.back() == ',') {
@@ -97,7 +97,7 @@ void load_compressed_weights_from_txt(T *w, const char* fname) {
             std::replace(token.begin(), token.end(), ',', ' ');
             std::istringstream structss(token);
 
-            if(!(structss >> w[i].row_index >> w[i].col_index >> w[i].weight)) {
+            if (!(structss >> w[i].row_index >> w[i].col_index >> w[i].weight)) {
                 std::cerr << "ERROR: Unable to parse file " << std::string(fname);
                 exit(1);
             }
@@ -111,8 +111,8 @@ void load_compressed_weights_from_txt(T *w, const char* fname) {
     }
 }
 
-template<class T, size_t SIZE>
-void load_exponent_weights_from_txt(T *w, const char* fname) {
+template <class T, size_t SIZE> void load_exponent_weights_from_txt(T *w, const char *fname)
+{
 
     std::string full_path = std::string(WEIGHTS_DIR) + "/" + std::string(fname);
     std::ifstream infile(full_path.c_str(), std::ios::binary);
@@ -129,11 +129,11 @@ void load_exponent_weights_from_txt(T *w, const char* fname) {
         std::string extra_chars = "} ";
 
         size_t i = 0;
-        while(std::getline(iss, token, '{')) {
+        while (std::getline(iss, token, '{')) {
             if (token.length() == 0) {
                 continue;
             }
-            for (char c: extra_chars) {
+            for (char c : extra_chars) {
                 token.erase(std::remove(token.begin(), token.end(), c), token.end());
             }
             if (token.back() == ',') {
@@ -143,7 +143,7 @@ void load_exponent_weights_from_txt(T *w, const char* fname) {
             std::replace(token.begin(), token.end(), ',', ' ');
             std::istringstream structss(token);
 
-            if(!(structss >> w[i].sign >> w[i].weight)) {
+            if (!(structss >> w[i].sign >> w[i].weight)) {
                 std::cerr << "ERROR: Unable to parse file " << std::string(fname);
                 exit(1);
             }
@@ -156,15 +156,15 @@ void load_exponent_weights_from_txt(T *w, const char* fname) {
         }
     }
 }
-template<class srcType, class dstType, size_t SIZE>
-void convert_data(srcType *src, dstType *dst) {
+template <class srcType, class dstType, size_t SIZE> void convert_data(srcType *src, dstType *dst)
+{
     for (size_t i = 0; i < SIZE; i++) {
         dst[i] = dstType(src[i]);
     }
 }
 
-template<class srcType, class dstType, size_t SIZE>
-void convert_data(srcType *src, hls::stream<dstType> &dst) {
+template <class srcType, class dstType, size_t SIZE> void convert_data(srcType *src, hls::stream<dstType> &dst)
+{
     for (size_t i = 0; i < SIZE / dstType::size; i++) {
         dstType ctype;
         for (size_t j = 0; j < dstType::size; j++) {
@@ -174,8 +174,8 @@ void convert_data(srcType *src, hls::stream<dstType> &dst) {
     }
 }
 
-template<class srcType, class dstType, size_t SIZE>
-void convert_data(hls::stream<srcType> &src, dstType *dst) {
+template <class srcType, class dstType, size_t SIZE> void convert_data(hls::stream<srcType> &src, dstType *dst)
+{
     for (size_t i = 0; i < SIZE / srcType::size; i++) {
         srcType ctype = src.read();
         for (size_t j = 0; j < srcType::size; j++) {
@@ -188,15 +188,15 @@ extern bool trace_enabled;
 extern std::map<std::string, void *> *trace_outputs;
 extern size_t trace_type_size;
 
-template<class data_T, class save_T>
-void save_output_array(data_T *data, save_T *ptr, size_t layer_size) {
-    for(int i = 0; i < layer_size; i++) {
+template <class data_T, class save_T> void save_output_array(data_T *data, save_T *ptr, size_t layer_size)
+{
+    for (int i = 0; i < layer_size; i++) {
         ptr[i] = save_T(data[i]);
     }
 }
 
-template<class data_T, class save_T>
-void save_output_array(hls::stream<data_T> &data, save_T *ptr, size_t layer_size) {
+template <class data_T, class save_T> void save_output_array(hls::stream<data_T> &data, save_T *ptr, size_t layer_size)
+{
     for (size_t i = 0; i < layer_size / data_T::size; i++) {
         data_T ctype = data.read();
         for (size_t j = 0; j < data_T::size; j++) {
@@ -208,16 +208,17 @@ void save_output_array(hls::stream<data_T> &data, save_T *ptr, size_t layer_size
 
 // We don't want to include save_T in this function because it will be inserted into myproject.cpp
 // so a workaround with element size is used
-template<class data_T>
-void save_layer_output(data_T *data, const char *layer_name, size_t layer_size) {
-    if (!trace_enabled) return;
-    
+template <class data_T> void save_layer_output(data_T *data, const char *layer_name, size_t layer_size)
+{
+    if (!trace_enabled)
+        return;
+
     if (trace_outputs) {
         if (trace_outputs->count(layer_name) > 0) {
             if (trace_type_size == 4) {
-                save_output_array<data_T, float>(data, (float *) (*trace_outputs)[layer_name], layer_size);
+                save_output_array<data_T, float>(data, (float *)(*trace_outputs)[layer_name], layer_size);
             } else if (trace_type_size == 8) {
-                save_output_array<data_T, double>(data, (double *) (*trace_outputs)[layer_name], layer_size);
+                save_output_array<data_T, double>(data, (double *)(*trace_outputs)[layer_name], layer_size);
             } else {
                 std::cout << "Unknown trace type!" << std::endl;
             }
@@ -226,11 +227,12 @@ void save_layer_output(data_T *data, const char *layer_name, size_t layer_size) 
         }
     } else {
         std::ostringstream filename;
-        filename << "./tb_data/" << layer_name << "_output.log"; //TODO if run as a shared lib, path should be ../tb_data
+        filename << "./tb_data/" << layer_name
+                 << "_output.log"; // TODO if run as a shared lib, path should be ../tb_data
         std::fstream out;
         out.open(filename.str(), std::ios::app);
         assert(out.is_open());
-        for(int i = 0; i < layer_size; i++) {
+        for (int i = 0; i < layer_size; i++) {
             out << float(data[i]) << " "; // We don't care about precision in text files
         }
         out << std::endl;
@@ -238,16 +240,17 @@ void save_layer_output(data_T *data, const char *layer_name, size_t layer_size) 
     }
 }
 
-template<class data_T>
-void save_layer_output(hls::stream<data_T> &data, const char *layer_name, size_t layer_size) {
-    if (!trace_enabled) return;
-    
+template <class data_T> void save_layer_output(hls::stream<data_T> &data, const char *layer_name, size_t layer_size)
+{
+    if (!trace_enabled)
+        return;
+
     if (trace_outputs) {
         if (trace_outputs->count(layer_name) > 0) {
             if (trace_type_size == 4) {
-                save_output_array<data_T, float>(data, (float *) (*trace_outputs)[layer_name], layer_size);
+                save_output_array<data_T, float>(data, (float *)(*trace_outputs)[layer_name], layer_size);
             } else if (trace_type_size == 8) {
-                save_output_array<data_T, double>(data, (double *) (*trace_outputs)[layer_name], layer_size);
+                save_output_array<data_T, double>(data, (double *)(*trace_outputs)[layer_name], layer_size);
             } else {
                 std::cout << "Unknown trace type!" << std::endl;
             }
@@ -256,7 +259,8 @@ void save_layer_output(hls::stream<data_T> &data, const char *layer_name, size_t
         }
     } else {
         std::ostringstream filename;
-        filename << "./tb_data/" << layer_name << "_output.log"; //TODO if run as a shared lib, path should be ../tb_data
+        filename << "./tb_data/" << layer_name
+                 << "_output.log"; // TODO if run as a shared lib, path should be ../tb_data
         std::fstream out;
         out.open(filename.str(), std::ios::app);
         assert(out.is_open());
@@ -272,18 +276,18 @@ void save_layer_output(hls::stream<data_T> &data, const char *layer_name, size_t
     }
 }
 
-
 #endif
 
-template<class src_T, class dst_T, size_t OFFSET, size_t SIZE>
-void copy_data(std::vector<src_T> src, dst_T dst[SIZE]) {
+template <class src_T, class dst_T, size_t OFFSET, size_t SIZE> void copy_data(std::vector<src_T> src, dst_T dst[SIZE])
+{
     typename std::vector<src_T>::const_iterator in_begin = src.cbegin() + OFFSET;
     typename std::vector<src_T>::const_iterator in_end = in_begin + SIZE;
     std::copy(in_begin, in_end, dst);
 }
 
-template<class src_T, class dst_T, size_t OFFSET, size_t SIZE>
-void copy_data(std::vector<src_T> src, hls::stream<dst_T> &dst) {
+template <class src_T, class dst_T, size_t OFFSET, size_t SIZE>
+void copy_data(std::vector<src_T> src, hls::stream<dst_T> &dst)
+{
     typename std::vector<src_T>::const_iterator in_begin = src.cbegin() + OFFSET;
     typename std::vector<src_T>::const_iterator in_end = in_begin + SIZE;
 
@@ -298,119 +302,119 @@ void copy_data(std::vector<src_T> src, hls::stream<dst_T> &dst) {
     }
 }
 
-template<class res_T, size_t SIZE>
-void print_result(res_T result[SIZE], std::ostream &out, bool keep = false) {
-    for(int i = 0; i < SIZE; i++) {
+template <class res_T, size_t SIZE> void print_result(res_T result[SIZE], std::ostream &out, bool keep = false)
+{
+    for (int i = 0; i < SIZE; i++) {
         out << result[i] << " ";
     }
     out << std::endl;
 }
 
-template<class res_T, size_t SIZE>
-void print_result(hls::stream<res_T> &result, std::ostream &out, bool keep = false) {
-    for(int i = 0; i < SIZE / res_T::size; i++) {
+template <class res_T, size_t SIZE> void print_result(hls::stream<res_T> &result, std::ostream &out, bool keep = false)
+{
+    for (int i = 0; i < SIZE / res_T::size; i++) {
         res_T res_pack = result.read();
-        for(int j = 0; j < res_T::size; j++) {
+        for (int j = 0; j < res_T::size; j++) {
             out << res_pack[j] << " ";
         }
-        if (keep) result.write(res_pack);
+        if (keep)
+            result.write(res_pack);
     }
     out << std::endl;
 }
 
-template<class data_T, size_t SIZE>
-void fill_zero(data_T data[SIZE]) {
+template <class data_T, size_t SIZE> void fill_zero(data_T data[SIZE])
+{
     std::fill_n(data, SIZE, 0.);
 }
 
-template<class data_T, size_t SIZE>
-void fill_zero(hls::stream<data_T> &data) {
-    for(int i = 0; i < SIZE / data_T::size; i++) {
+template <class data_T, size_t SIZE> void fill_zero(hls::stream<data_T> &data)
+{
+    for (int i = 0; i < SIZE / data_T::size; i++) {
         data_T data_pack;
-        for(int j = 0; j < data_T::size; j++) {
+        for (int j = 0; j < data_T::size; j++) {
             data_pack[j] = 0.;
         }
         data.write(data_pack);
     }
 }
 
-template <class dataType, unsigned int nrows>
-int read_file_1D(const char * filename, dataType data[nrows])
+template <class dataType, unsigned int nrows> int read_file_1D(const char *filename, dataType data[nrows])
 {
-  FILE *fp;
-  fp = fopen(filename, "r");
-  if (fp == 0) {
-    return -1;
-  }
-  // Read data from file
-  float newval;
-  for (int ii = 0; ii < nrows; ii++){
-    if (fscanf(fp, "%f\n", &newval) != 0){
-      data[ii] = newval;
-    } else {
-      return -2;
+    FILE *fp;
+    fp = fopen(filename, "r");
+    if (fp == 0) {
+        return -1;
     }
-  }
-  fclose(fp);
-  return 0;
+    // Read data from file
+    float newval;
+    for (int ii = 0; ii < nrows; ii++) {
+        if (fscanf(fp, "%f\n", &newval) != 0) {
+            data[ii] = newval;
+        } else {
+            return -2;
+        }
+    }
+    fclose(fp);
+    return 0;
 }
 
 template <class dataType, unsigned int nrows, unsigned int ncols>
-int read_file_2D(const char * filename, dataType data[nrows][ncols])
+int read_file_2D(const char *filename, dataType data[nrows][ncols])
 {
-  FILE *fp;
-  fp = fopen(filename, "r");
-  if (fp == 0) {
-    return -1;
-  }
-  // Read data from file
-  float newval;
-  for (int ii = 0; ii < nrows; ii++) {
-    for (int jj = 0; jj < ncols; jj++){
-      if (fscanf(fp, "%f\n", &newval) != 0){
-        data[ii][jj] = newval;
-      } else {
-        return -2;
-      }
+    FILE *fp;
+    fp = fopen(filename, "r");
+    if (fp == 0) {
+        return -1;
     }
-  }
-  fclose(fp);
-  return 0;
+    // Read data from file
+    float newval;
+    for (int ii = 0; ii < nrows; ii++) {
+        for (int jj = 0; jj < ncols; jj++) {
+            if (fscanf(fp, "%f\n", &newval) != 0) {
+                data[ii][jj] = newval;
+            } else {
+                return -2;
+            }
+        }
+    }
+    fclose(fp);
+    return 0;
 }
 
-template<class in_T, class out_T, int N_IN>
-void change_type(hls::stream<in_T> &in, hls::stream<out_T> &out)
+template <class in_T, class out_T, int N_IN> void change_type(hls::stream<in_T> &in, hls::stream<out_T> &out)
 {
     in_T datareg;
     hls::stream<out_T> input_trunc;
-    for (int ii=0; ii<N_IN; ii++) {
-        out << (out_T) in.read();
+    for (int ii = 0; ii < N_IN; ii++) {
+        out << (out_T)in.read();
     }
 }
 
-template<class data_T, int N_IN>
-void  hls_stream_debug(hls::stream<data_T> &data, hls::stream<data_T> &res)
+template <class data_T, int N_IN> void hls_stream_debug(hls::stream<data_T> &data, hls::stream<data_T> &res)
 {
     data_T datareg;
-    for (int ii=0; ii<N_IN; ii++) {
+    for (int ii = 0; ii < N_IN; ii++) {
         datareg = data.read();
         std::cout << "[" << ii << "]: " << datareg << std::endl;
         res << datareg;
     }
 }
 
-constexpr int ceillog2(int x){
-  return (x <= 2) ? 1 : 1 + ceillog2((x+1) / 2);
+constexpr int ceillog2(int x)
+{
+    return (x <= 2) ? 1 : 1 + ceillog2((x + 1) / 2);
 }
 
-constexpr int floorlog2(int x){
-  return (x < 2) ? 0 : 1 + floorlog2(x / 2);
+constexpr int floorlog2(int x)
+{
+    return (x < 2) ? 0 : 1 + floorlog2(x / 2);
 }
 
-constexpr int pow2(int x){
-  return x == 0 ? 1 : 2 * pow2(x - 1);
+constexpr int pow2(int x)
+{
+    return x == 0 ? 1 : 2 * pow2(x - 1);
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_image.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_image.h
@@ -15,11 +15,10 @@ struct resize_config {
     static const unsigned new_width = 10;
 };
 
-template<class data_T, typename CONFIG_T>
-void resize_nearest(
-    data_T image[CONFIG_T::height * CONFIG_T::width * CONFIG_T::n_chan],
-    data_T resized[CONFIG_T::new_height * CONFIG_T::new_width * CONFIG_T::n_chan]
-) {
+template <class data_T, typename CONFIG_T>
+void resize_nearest(data_T image[CONFIG_T::height * CONFIG_T::width * CONFIG_T::n_chan],
+                    data_T resized[CONFIG_T::new_height * CONFIG_T::new_width * CONFIG_T::n_chan])
+{
     int y_ratio = (int)((CONFIG_T::height << 16) / CONFIG_T::new_height) + 1;
     int x_ratio = (int)((CONFIG_T::width << 16) / CONFIG_T::new_width) + 1;
     int x2, y2;
@@ -31,12 +30,12 @@ void resize_nearest(
             x2 = ((j * x_ratio) >> 16);
             y2 = ((i * y_ratio) >> 16);
             for (int k = 0; k < CONFIG_T::n_chan; k++) {
-                resized[(i * CONFIG_T::new_width * CONFIG_T::n_chan) + j * CONFIG_T::n_chan + k] = image[(y2 * CONFIG_T::width * CONFIG_T::n_chan) + x2 * CONFIG_T::n_chan + k];
+                resized[(i * CONFIG_T::new_width * CONFIG_T::n_chan) + j * CONFIG_T::n_chan + k] =
+                    image[(y2 * CONFIG_T::width * CONFIG_T::n_chan) + x2 * CONFIG_T::n_chan + k];
             }
         }
-    }  
+    }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_image_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_image_stream.h
@@ -6,29 +6,29 @@
 
 namespace nnet {
 
-template<class data_T, typename CONFIG_T>
-void resize_nearest(
-    hls::stream<data_T> &image,
-    hls::stream<data_T> &resized
-) {
+template <class data_T, typename CONFIG_T> void resize_nearest(hls::stream<data_T> &image, hls::stream<data_T> &resized)
+{
     assert(CONFIG_T::new_height % CONFIG_T::height == 0);
     assert(CONFIG_T::new_width % CONFIG_T::width == 0);
     constexpr unsigned ratio_height = CONFIG_T::new_height / CONFIG_T::height;
     constexpr unsigned ratio_width = CONFIG_T::new_width / CONFIG_T::width;
     constexpr unsigned ii = ratio_height * ratio_width;
 
-    ResizeImage: for (unsigned i = 0; i < CONFIG_T::height * CONFIG_T::width; i++) {
+ResizeImage:
+    for (unsigned i = 0; i < CONFIG_T::height * CONFIG_T::width; i++) {
         #pragma HLS PIPELINE II=ii
-        
-        data_T  in_data = image.read();
 
-        ResizeNew: for (unsigned j = 0; j < ratio_height * ratio_width; j++) {
+        data_T in_data = image.read();
+
+    ResizeNew:
+        for (unsigned j = 0; j < ratio_height * ratio_width; j++) {
             #pragma HLS UNROLL
 
             data_T out_data;
-            #pragma HLS DATA_PACK variable=out_data
-            
-            ResizeChan: for (unsigned k = 0; k < CONFIG_T::n_chan; k++) {
+        #pragma HLS DATA_PACK variable=out_data
+
+        ResizeChan:
+            for (unsigned k = 0; k < CONFIG_T::n_chan; k++) {
                 #pragma HLS UNROLL
                 out_data[k] = in_data[k];
             }
@@ -37,7 +37,6 @@ void resize_nearest(
         }
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
@@ -27,8 +27,7 @@
 
 namespace nnet {
 
-struct merge_config
-{
+struct merge_config {
     static const unsigned n_elem = 10;
 };
 
@@ -38,8 +37,7 @@ struct dot_config {
     static const unsigned reuse_factor = 1;
     typedef float accum_t;
     // Product function to use
-    template<class x_T, class y_T, class res_T>
-    using product = nnet::product::mult<x_T, y_T, res_T>;
+    template <class x_T, class y_T, class res_T> using product = nnet::product::mult<x_T, y_T, res_T>;
 };
 
 struct concat_config {
@@ -53,78 +51,56 @@ struct concat_config {
     static const unsigned axis = -1;
 };
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void add(
-    input1_T data1[CONFIG_T::n_elem],
-	input2_T data2[CONFIG_T::n_elem],
-    res_T res[CONFIG_T::n_elem])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void add(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
         res[ii] = data1[ii] + data2[ii];
     }
 }
 
-
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void subtract(
-    input1_T data1[CONFIG_T::n_elem],
-	input2_T data2[CONFIG_T::n_elem],
-    res_T res[CONFIG_T::n_elem])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void subtract(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
         res[ii] = data1[ii] - data2[ii];
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void multiply(
-    input1_T data1[CONFIG_T::n_elem],
-	input2_T data2[CONFIG_T::n_elem],
-    res_T res[CONFIG_T::n_elem])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void multiply(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
         res[ii] = data1[ii] * data2[ii];
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void average(
-    input1_T data1[CONFIG_T::n_elem],
-	input2_T data2[CONFIG_T::n_elem],
-    res_T res[CONFIG_T::n_elem])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void average(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
-        res[ii] = (data1[ii] + data2[ii]) / (res_T) 2;
+    for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
+        res[ii] = (data1[ii] + data2[ii]) / (res_T)2;
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void maximum(
-    input1_T data1[CONFIG_T::n_elem],
-	input2_T data2[CONFIG_T::n_elem],
-    res_T res[CONFIG_T::n_elem])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void maximum(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
         res[ii] = (data1[ii] > data2[ii]) ? data1[ii] : data2[ii];
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void minimum(
-    input1_T data1[CONFIG_T::n_elem],
-	input2_T data2[CONFIG_T::n_elem],
-    res_T res[CONFIG_T::n_elem])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void minimum(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
         res[ii] = (data1[ii] < data2[ii]) ? data1[ii] : data2[ii];
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void dot1d(
-    input1_T data1[CONFIG_T::n_in],
-	input2_T data2[CONFIG_T::n_in],
-    res_T res[CONFIG_T::n_out])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void dot1d(input1_T data1[CONFIG_T::n_in], input2_T data2[CONFIG_T::n_in], res_T res[CONFIG_T::n_out])
 {
     #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
@@ -135,12 +111,15 @@ void dot1d(
     #pragma HLS ARRAY_PARTITION variable=mult complete
     typename CONFIG_T::accum_t acc = 0;
 
-    Product: for(int i_mult=0; i_mult < CONFIG_T::n_in; i_mult++) {
+Product:
+    for (int i_mult = 0; i_mult < CONFIG_T::n_in; i_mult++) {
         #pragma HLS UNROLL
-        mult[i_mult] = CONFIG_T::template product<input1_T, input2_T, typename CONFIG_T::accum_t>::product(data1[i_mult], data2[i_mult]);
+        mult[i_mult] = CONFIG_T::template product<input1_T, input2_T, typename CONFIG_T::accum_t>::product(
+            data1[i_mult], data2[i_mult]);
     }
 
-    Accum: for(int i_acc = 0; i_acc < CONFIG_T::n_in; i_acc++) {
+Accum:
+    for (int i_acc = 0; i_acc < CONFIG_T::n_in; i_acc++) {
         #pragma HLS UNROLL
         acc += mult[i_acc];
     }
@@ -148,56 +127,51 @@ void dot1d(
     res[0] = cast<input1_T, res_T, CONFIG_T>(acc);
 }
 
-
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void concatenate1d(
-    input1_T data1[CONFIG_T::n_elem1_0],
-	input2_T data2[CONFIG_T::n_elem2_0],
-    res_T res[CONFIG_T::n_elem1_0 + CONFIG_T::n_elem2_0])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate1d(input1_T data1[CONFIG_T::n_elem1_0], input2_T data2[CONFIG_T::n_elem2_0],
+                   res_T res[CONFIG_T::n_elem1_0 + CONFIG_T::n_elem2_0])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem1_0; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem1_0; ii++) {
         res[ii] = data1[ii];
     }
-    for (int ii=0; ii<CONFIG_T::n_elem2_0; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem2_0; ii++) {
         res[CONFIG_T::n_elem1_0 + ii] = data2[ii];
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void concatenate2d_0(
-    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1],
-	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
-    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d_0(input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1],
+                     input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
+                     res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1; ii++) {
         res[ii] = data1[ii];
     }
-    for (int ii=0; ii<CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1; ii++) {
         res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + ii] = data2[ii];
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void concatenate2d_1(
-    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1],
-	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
-    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d_1(input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1],
+                     input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
+                     res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem1_0; ii++) {
-        for (int jj=0; jj<CONFIG_T::n_elem1_1; jj++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem1_0; ii++) {
+        for (int jj = 0; jj < CONFIG_T::n_elem1_1; jj++) {
             res[ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) + jj] = data1[ii * CONFIG_T::n_elem1_1 + jj];
         }
-        for (int jj=0; jj<CONFIG_T::n_elem2_1; jj++) {
-            res[ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) + CONFIG_T::n_elem1_1 + jj] = data2[ii * CONFIG_T::n_elem2_1 + jj];
+        for (int jj = 0; jj < CONFIG_T::n_elem2_1; jj++) {
+            res[ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) + CONFIG_T::n_elem1_1 + jj] =
+                data2[ii * CONFIG_T::n_elem2_1 + jj];
         }
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void concatenate2d(
-    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1],
-	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
-    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d(input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1],
+                   input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
+                   res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1])
 {
     if (CONFIG_T::axis == 2 || CONFIG_T::axis == -1) {
         concatenate2d_1<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
@@ -206,88 +180,77 @@ void concatenate2d(
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void concatenate3d_0(
-input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
-	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
-    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_0(input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
+                     input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+                     res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 +
+                               CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2; ii++) {
         res[ii] = data1[ii];
     }
-    for (int ii=0; ii<CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2; ii++) {
         res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + ii] = data2[ii];
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void concatenate3d_1(
-input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
-	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
-    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_1(input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
+                     input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+                     res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 +
+                               CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem1_0; ii++) {
-        for (int jj=0; jj<CONFIG_T::n_elem1_1; jj++) {
-            for (int kk=0; kk<CONFIG_T::n_elem1_2; kk++) {
-                int res_idx = ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) * CONFIG_T::n_elem1_2
-                            + jj * CONFIG_T::n_elem1_2
-                            + kk;
-                int data_idx = ii * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2
-                             + jj * CONFIG_T::n_elem1_2
-                             + kk;
+    for (int ii = 0; ii < CONFIG_T::n_elem1_0; ii++) {
+        for (int jj = 0; jj < CONFIG_T::n_elem1_1; jj++) {
+            for (int kk = 0; kk < CONFIG_T::n_elem1_2; kk++) {
+                int res_idx = ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) * CONFIG_T::n_elem1_2 +
+                              jj * CONFIG_T::n_elem1_2 + kk;
+                int data_idx = ii * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + jj * CONFIG_T::n_elem1_2 + kk;
                 res[res_idx] = data1[data_idx];
             }
         }
-        for (int jj=0; jj<CONFIG_T::n_elem2_1; jj++) {
-            for (int kk=0; kk<CONFIG_T::n_elem2_2; kk++) {
-                int res_idx = ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) * CONFIG_T::n_elem1_2
-                            + (jj + CONFIG_T::n_elem1_1) * CONFIG_T::n_elem1_2
-                            + kk;
-                int data_idx = ii * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2
-                             + jj * CONFIG_T::n_elem2_2
-                             + kk;
+        for (int jj = 0; jj < CONFIG_T::n_elem2_1; jj++) {
+            for (int kk = 0; kk < CONFIG_T::n_elem2_2; kk++) {
+                int res_idx = ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) * CONFIG_T::n_elem1_2 +
+                              (jj + CONFIG_T::n_elem1_1) * CONFIG_T::n_elem1_2 + kk;
+                int data_idx = ii * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2 + jj * CONFIG_T::n_elem2_2 + kk;
                 res[res_idx] = data2[data_idx];
             }
         }
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void concatenate3d_2(
-input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
-	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
-    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_2(input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
+                     input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+                     res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 +
+                               CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
 {
-    for (int ii=0; ii<CONFIG_T::n_elem1_0; ii++) {
-        for (int jj=0; jj<CONFIG_T::n_elem1_1; jj++) {
-            for (int kk=0; kk<CONFIG_T::n_elem1_2; kk++) {
-                int res_idx = ii * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2)
-                            + jj * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2)
-                            + kk;
-                int data_idx = ii * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2
-                             + jj * CONFIG_T::n_elem1_2
-                             + kk;
+    for (int ii = 0; ii < CONFIG_T::n_elem1_0; ii++) {
+        for (int jj = 0; jj < CONFIG_T::n_elem1_1; jj++) {
+            for (int kk = 0; kk < CONFIG_T::n_elem1_2; kk++) {
+                int res_idx = ii * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) +
+                              jj * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) + kk;
+                int data_idx = ii * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + jj * CONFIG_T::n_elem1_2 + kk;
                 res[res_idx] = data1[data_idx];
             }
-            for (int kk=0; kk<CONFIG_T::n_elem1_2; kk++) {
-                res[ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) + CONFIG_T::n_elem1_1 + jj] = data1[ii * CONFIG_T::n_elem2_1 + jj];
-                int res_idx = ii * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2)
-                            + jj * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2)
-                            + kk + CONFIG_T::n_elem1_2;
-                int data_idx = ii * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2
-                             + jj * CONFIG_T::n_elem2_2
-                             + kk;
+            for (int kk = 0; kk < CONFIG_T::n_elem1_2; kk++) {
+                res[ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) + CONFIG_T::n_elem1_1 + jj] =
+                    data1[ii * CONFIG_T::n_elem2_1 + jj];
+                int res_idx = ii * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) +
+                              jj * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) + kk + CONFIG_T::n_elem1_2;
+                int data_idx = ii * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2 + jj * CONFIG_T::n_elem2_2 + kk;
                 res[res_idx] = data2[data_idx];
             }
         }
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void concatenate3d(
-    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
-	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
-    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d(input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
+                   input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+                   res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 +
+                             CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
 {
     if (CONFIG_T::axis == 3 || CONFIG_T::axis == -1) {
         concatenate3d_2<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
@@ -297,7 +260,6 @@ void concatenate3d(
         concatenate3d_0<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_merge_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_merge_stream.h
@@ -26,23 +26,22 @@
 
 namespace nnet {
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void add(
-    hls::stream<input1_T> &data1,
-    hls::stream<input2_T> &data2,
-    hls::stream<res_T> &res)
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void add(hls::stream<input1_T> &data1, hls::stream<input2_T> &data2, hls::stream<res_T> &res)
 {
     assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
 
-    AddLoop: for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+AddLoop:
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
         #pragma HLS PIPELINE
 
         input1_T in_data1 = data1.read();
         input2_T in_data2 = data2.read();
         res_T out_data;
-        #pragma HLS DATA_PACK variable=out_data
+    #pragma HLS DATA_PACK variable=out_data
 
-        AddPack: for (int j = 0; j < res_T::size; j++) {
+    AddPack:
+        for (int j = 0; j < res_T::size; j++) {
             #pragma HLS UNROLL
             out_data[j] = in_data1[j] + in_data2[j];
         }
@@ -51,23 +50,22 @@ void add(
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void subtract(
-    hls::stream<input1_T> &data1,
-    hls::stream<input2_T> &data2,
-    hls::stream<res_T> &res)
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void subtract(hls::stream<input1_T> &data1, hls::stream<input2_T> &data2, hls::stream<res_T> &res)
 {
     assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
 
-    SubtractLoop: for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+SubtractLoop:
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
         #pragma HLS PIPELINE
 
         input1_T in_data1 = data1.read();
         input2_T in_data2 = data2.read();
         res_T out_data;
-        #pragma HLS DATA_PACK variable=out_data
+    #pragma HLS DATA_PACK variable=out_data
 
-        SubtractPack: for (int j = 0; j < res_T::size; j++) {
+    SubtractPack:
+        for (int j = 0; j < res_T::size; j++) {
             #pragma HLS UNROLL
             out_data[j] = in_data1[j] - in_data2[j];
         }
@@ -76,23 +74,22 @@ void subtract(
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void multiply(
-    hls::stream<input1_T> &data1,
-    hls::stream<input2_T> &data2,
-    hls::stream<res_T> &res)
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void multiply(hls::stream<input1_T> &data1, hls::stream<input2_T> &data2, hls::stream<res_T> &res)
 {
     assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
 
-    MultiplyLoop: for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+MultiplyLoop:
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
         #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
         input1_T in_data1 = data1.read();
         input2_T in_data2 = data2.read();
         res_T out_data;
-        #pragma HLS DATA_PACK variable=out_data
+    #pragma HLS DATA_PACK variable=out_data
 
-        MultiplyPack: for (int j = 0; j < res_T::size; j++) {
+    MultiplyPack:
+        for (int j = 0; j < res_T::size; j++) {
             #pragma HLS UNROLL
             out_data[j] = in_data1[j] * in_data2[j];
         }
@@ -101,48 +98,46 @@ void multiply(
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void average(
-    hls::stream<input1_T> &data1,
-    hls::stream<input2_T> &data2,
-    hls::stream<res_T> &res)
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void average(hls::stream<input1_T> &data1, hls::stream<input2_T> &data2, hls::stream<res_T> &res)
 {
     assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
 
-    AverageLoop: for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+AverageLoop:
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
         #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
         input1_T in_data1 = data1.read();
         input2_T in_data2 = data2.read();
         res_T out_data;
-        #pragma HLS DATA_PACK variable=out_data
+    #pragma HLS DATA_PACK variable=out_data
 
-        AveragePack: for (int j = 0; j < res_T::size; j++) {
+    AveragePack:
+        for (int j = 0; j < res_T::size; j++) {
             #pragma HLS UNROLL
-            out_data[j] = (in_data1[j] + in_data2[j]) / (typename res_T::value_type) 2;
+            out_data[j] = (in_data1[j] + in_data2[j]) / (typename res_T::value_type)2;
         }
 
         res.write(out_data);
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void maximum(
-    hls::stream<input1_T> &data1,
-    hls::stream<input2_T> &data2,
-    hls::stream<res_T> &res)
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void maximum(hls::stream<input1_T> &data1, hls::stream<input2_T> &data2, hls::stream<res_T> &res)
 {
     assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
 
-    MaximumLoop: for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+MaximumLoop:
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
         #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
         input1_T in_data1 = data1.read();
         input2_T in_data2 = data2.read();
         res_T out_data;
-        #pragma HLS DATA_PACK variable=out_data
+    #pragma HLS DATA_PACK variable=out_data
 
-        MaximumPack: for (int j = 0; j < res_T::size; j++) {
+    MaximumPack:
+        for (int j = 0; j < res_T::size; j++) {
             #pragma HLS UNROLL
             out_data[j] = (in_data1[j] > in_data2[j]) ? in_data1[j] : in_data2[j];
         }
@@ -151,23 +146,22 @@ void maximum(
     }
 }
 
-template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void minimum(
-    hls::stream<input1_T> &data1,
-    hls::stream<input2_T> &data2,
-    hls::stream<res_T> &res)
+template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void minimum(hls::stream<input1_T> &data1, hls::stream<input2_T> &data2, hls::stream<res_T> &res)
 {
     assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
 
-    MinimumLoop: for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+MinimumLoop:
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
         #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
         input1_T in_data1 = data1.read();
         input2_T in_data2 = data2.read();
         res_T out_data;
-        #pragma HLS DATA_PACK variable=out_data
+    #pragma HLS DATA_PACK variable=out_data
 
-        MinimumPack: for (int j = 0; j < res_T::size; j++) {
+    MinimumPack:
+        for (int j = 0; j < res_T::size; j++) {
             #pragma HLS UNROLL
             out_data[j] = (in_data1[j] < in_data2[j]) ? in_data1[j] : in_data2[j];
         }
@@ -175,7 +169,6 @@ void minimum(
         res.write(out_data);
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_mult.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_mult.h
@@ -8,99 +8,107 @@
 
 namespace nnet {
 
-namespace product{
+namespace product {
 
 /* ---
  * 5 different methods to perform the product of input and weight, depending on the
- * types of each. 
+ * types of each.
  * --- */
 
-template<class x_T, class w_T, class y_T>
-class Product{
-    public:
-    static y_T product(x_T a, w_T w){
+template <class x_T, class w_T, class y_T> class Product {
+  public:
+    static y_T product(x_T a, w_T w)
+    {
         // 'Normal' product
         #pragma HLS INLINE
         return a * w;
     }
-    static void limit(unsigned multiplier_limit) {} // Nothing to do here
+    static void limit(unsigned multiplier_limit)
+    {
+    } // Nothing to do here
 };
 
-template<class x_T, class w_T, class y_T>
-class both_binary : public Product<x_T, w_T, y_T>{
-    public:
-    static y_T product(x_T a, w_T w){
+template <class x_T, class w_T, class y_T> class both_binary : public Product<x_T, w_T, y_T> {
+  public:
+    static y_T product(x_T a, w_T w)
+    {
         // specialisation for 1-bit weights and incoming data
         #pragma HLS INLINE
         return a == w;
     }
 };
 
-template<class x_T, class w_T, class y_T>
-class weight_binary : public Product<x_T, w_T, y_T>{
-    public:
-    static y_T product(x_T a, w_T w){
+template <class x_T, class w_T, class y_T> class weight_binary : public Product<x_T, w_T, y_T> {
+  public:
+    static y_T product(x_T a, w_T w)
+    {
         // Specialisation for 1-bit weights, arbitrary data
         #pragma HLS INLINE
-        return w == 0 ? (x_T) -a : a;
+        return w == 0 ? (x_T) - a : a;
     }
 };
 
-template<class x_T, class w_T, class y_T>
-class weight_ternary : public Product<x_T, w_T, y_T>{
-    public:
-    static y_T product(x_T a, w_T w){
+template <class x_T, class w_T, class y_T> class weight_ternary : public Product<x_T, w_T, y_T> {
+  public:
+    static y_T product(x_T a, w_T w)
+    {
         // Specialisation for 2-bit weights, arbitrary data
         #pragma HLS INLINE
-        if (w == 0) return (x_T) 0;
-        else if(w == -1) return (x_T) -a;
-        else return (x_T) a; // if(w == 1)
+        if (w == 0)
+            return (x_T)0;
+        else if (w == -1)
+            return (x_T) - a;
+        else
+            return (x_T)a; // if(w == 1)
     }
 };
 
-template<class x_T, class w_T, class y_T>
-class mult : public Product<x_T, w_T, y_T>{
-    public:
-    static y_T product(x_T a, w_T w){
+template <class x_T, class w_T, class y_T> class mult : public Product<x_T, w_T, y_T> {
+  public:
+    static y_T product(x_T a, w_T w)
+    {
         // 'Normal' product
         #pragma HLS INLINE
         return a * w;
     }
-    static void limit(unsigned multiplier_limit){
+    static void limit(unsigned multiplier_limit)
+    {
         #pragma HLS INLINE
         #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
     }
 };
 
-template<class x_T, class w_T, class y_T>
-class weight_exponential : public Product<x_T, w_T, y_T>{
-    public:
-    static y_T product(x_T a, w_T w){
+template <class x_T, class w_T, class y_T> class weight_exponential : public Product<x_T, w_T, y_T> {
+  public:
+    static y_T product(x_T a, w_T w)
+    {
         // Shift product for exponential weights
         #pragma HLS INLINE
         // shift by the exponent. Negative weights shift right
         y_T ay = a;
         y_T y = ay << w.weight;
         // negate or not depending on weight sign
-        return w.sign == 1 ? (y_T) y : (y_T) -y;
+        return w.sign == 1 ? (y_T)y : (y_T) - y;
     }
 };
 
 } // namespace product_type
 
-template<class data_T, class res_T, typename CONFIG_T>
-inline typename std::enable_if<std::is_same<data_T, ap_uint<1>>::value
-        && std::is_same<typename CONFIG_T::weight_t, ap_uint<1>>::value, ap_int<nnet::ceillog2(CONFIG_T::n_in) + 2>>::type
-cast(typename CONFIG_T::accum_t x){
-  return (ap_int<nnet::ceillog2(CONFIG_T::n_in) + 2>) (x - CONFIG_T::n_in / 2) * 2;
+template <class data_T, class res_T, typename CONFIG_T>
+inline typename std::enable_if<
+    std::is_same<data_T, ap_uint<1> >::value &&std::is_same<typename CONFIG_T::weight_t, ap_uint<1> >::value,
+    ap_int<nnet::ceillog2(CONFIG_T::n_in) + 2> >::type
+cast(typename CONFIG_T::accum_t x)
+{
+    return (ap_int<nnet::ceillog2(CONFIG_T::n_in) + 2>)(x - CONFIG_T::n_in / 2) * 2;
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-inline typename std::enable_if<(! std::is_same<data_T, ap_uint<1>>::value), res_T>::type
-cast(typename CONFIG_T::accum_t x){
-  return (res_T) x;
+template <class data_T, class res_T, typename CONFIG_T>
+inline typename std::enable_if<(!std::is_same<data_T, ap_uint<1> >::value), res_T>::type
+cast(typename CONFIG_T::accum_t x)
+{
+    return (res_T)x;
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_padding.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_padding.h
@@ -13,18 +13,17 @@ struct padding1d_config {
     static const unsigned pad_right = 0;
 };
 
-template<class data_T, class res_T, typename CONFIG_T>
-void zeropad1d_cf(
-    data_T data[CONFIG_T::n_chan * CONFIG_T::in_width],
-    data_T res[CONFIG_T::n_chan * CONFIG_T::out_width]
-) {
-    for(int j = 0; j < CONFIG_T::n_chan; j++) {
+template <class data_T, class res_T, typename CONFIG_T>
+void zeropad1d_cf(data_T data[CONFIG_T::n_chan * CONFIG_T::in_width],
+                  data_T res[CONFIG_T::n_chan * CONFIG_T::out_width])
+{
+    for (int j = 0; j < CONFIG_T::n_chan; j++) {
         for (int i = 0; i < CONFIG_T::pad_left; i++) {
             *(res++) = 0;
         }
 
         for (int i = 0; i < CONFIG_T::in_width; i++) {
-            *(res++) = (res_T) *(data++);
+            *(res++) = (res_T) * (data++);
         }
 
         for (int i = 0; i < CONFIG_T::pad_right; i++) {
@@ -33,30 +32,27 @@ void zeropad1d_cf(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void zeropad1d_cl(
-    data_T data[CONFIG_T::n_chan * CONFIG_T::in_width],
-    res_T res[CONFIG_T::n_chan * CONFIG_T::out_width]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void zeropad1d_cl(data_T data[CONFIG_T::n_chan * CONFIG_T::in_width], res_T res[CONFIG_T::n_chan * CONFIG_T::out_width])
+{
     for (int i = 0; i < CONFIG_T::pad_left; i++) {
-        for(int j = 0; j < CONFIG_T::n_chan; j++) {
+        for (int j = 0; j < CONFIG_T::n_chan; j++) {
             *(res++) = 0;
         }
     }
 
     for (int i = 0; i < CONFIG_T::in_width; i++) {
-        for(int j = 0; j < CONFIG_T::n_chan; j++) {
-            *(res++) = (res_T) *(data++);
+        for (int j = 0; j < CONFIG_T::n_chan; j++) {
+            *(res++) = (res_T) * (data++);
         }
     }
 
     for (int i = 0; i < CONFIG_T::pad_right; i++) {
-        for(int j = 0; j < CONFIG_T::n_chan; j++) {
+        for (int j = 0; j < CONFIG_T::n_chan; j++) {
             *(res++) = 0;
         }
     }
 }
-
 
 struct padding2d_config {
     static const unsigned n_chan = 10;
@@ -70,12 +66,11 @@ struct padding2d_config {
     static const unsigned pad_right = 0;
 };
 
-template<class data_T, class res_T, typename CONFIG_T>
-void zeropad2d_cf(
-    data_T data[CONFIG_T::n_chan * CONFIG_T::in_height * CONFIG_T::in_width],
-    data_T res[CONFIG_T::n_chan * CONFIG_T::out_height * CONFIG_T::out_width]
-) {
-    for(int k = 0; k < CONFIG_T::n_chan; k++) {
+template <class data_T, class res_T, typename CONFIG_T>
+void zeropad2d_cf(data_T data[CONFIG_T::n_chan * CONFIG_T::in_height * CONFIG_T::in_width],
+                  data_T res[CONFIG_T::n_chan * CONFIG_T::out_height * CONFIG_T::out_width])
+{
+    for (int k = 0; k < CONFIG_T::n_chan; k++) {
 
         for (int i = 0; i < CONFIG_T::pad_top; i++) {
             for (int j = 0; j < CONFIG_T::out_width; j++) {
@@ -88,7 +83,7 @@ void zeropad2d_cf(
                 *(res++) = 0;
             }
             for (int j = 0; j < CONFIG_T::in_width; j++) {
-                *(res++) = (res_T) *(data++);
+                *(res++) = (res_T) * (data++);
             }
             for (int j = 0; j < CONFIG_T::pad_right; j++) {
                 *(res++) = 0;
@@ -103,14 +98,13 @@ void zeropad2d_cf(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void zeropad2d_cl(
-    data_T data[CONFIG_T::n_chan * CONFIG_T::in_height * CONFIG_T::in_width],
-    res_T res[CONFIG_T::n_chan * CONFIG_T::out_height * CONFIG_T::out_width]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void zeropad2d_cl(data_T data[CONFIG_T::n_chan * CONFIG_T::in_height * CONFIG_T::in_width],
+                  res_T res[CONFIG_T::n_chan * CONFIG_T::out_height * CONFIG_T::out_width])
+{
     for (int i = 0; i < CONFIG_T::pad_top; i++) {
         for (int j = 0; j < CONFIG_T::out_width; j++) {
-            for(int k = 0; k < CONFIG_T::n_chan; k++) {
+            for (int k = 0; k < CONFIG_T::n_chan; k++) {
                 *(res++) = 0;
             }
         }
@@ -118,17 +112,17 @@ void zeropad2d_cl(
 
     for (int i = 0; i < CONFIG_T::in_height; i++) {
         for (int j = 0; j < CONFIG_T::pad_left; j++) {
-            for(int k = 0; k < CONFIG_T::n_chan; k++) {
+            for (int k = 0; k < CONFIG_T::n_chan; k++) {
                 *(res++) = 0;
             }
         }
         for (int j = 0; j < CONFIG_T::in_width; j++) {
-            for(int k = 0; k < CONFIG_T::n_chan; k++) {
-                *(res++) = (res_T) *(data++);
+            for (int k = 0; k < CONFIG_T::n_chan; k++) {
+                *(res++) = (res_T) * (data++);
             }
         }
         for (int j = 0; j < CONFIG_T::pad_right; j++) {
-            for(int k = 0; k < CONFIG_T::n_chan; k++) {
+            for (int k = 0; k < CONFIG_T::n_chan; k++) {
                 *(res++) = 0;
             }
         }
@@ -136,13 +130,12 @@ void zeropad2d_cl(
 
     for (int i = 0; i < CONFIG_T::pad_bottom; i++) {
         for (int j = 0; j < CONFIG_T::out_width; j++) {
-            for(int k = 0; k < CONFIG_T::n_chan; k++) {
+            for (int k = 0; k < CONFIG_T::n_chan; k++) {
                 *(res++) = 0;
             }
         }
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_padding_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_padding_stream.h
@@ -5,19 +5,20 @@
 
 namespace nnet {
 
-template<class res_T, typename CONFIG_T>
-void fill_zero(hls::stream<res_T> &res) {
+template <class res_T, typename CONFIG_T> void fill_zero(hls::stream<res_T> &res)
+{
     #pragma HLS INLINE
     res_T res_part;
-	for (int c = 0; c < CONFIG_T::n_chan; c++) {
+    for (int c = 0; c < CONFIG_T::n_chan; c++) {
         #pragma HLS UNROLL
-	    res_part[c] = 0;
+        res_part[c] = 0;
     }
     res.write(res_part);
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void fill_data(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+template <class data_T, class res_T, typename CONFIG_T>
+void fill_data(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
     #pragma HLS INLINE
     data_T data_part = data.read();
     res_T res_part;
@@ -28,55 +29,61 @@ void fill_data(hls::stream<data_T> &data, hls::stream<res_T> &res) {
     res.write(res_part);
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void zeropad1d_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res
-) {
-    PadLeft: for (int i = 0; i < CONFIG_T::pad_left; i++) {
+template <class data_T, class res_T, typename CONFIG_T>
+void zeropad1d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
+PadLeft:
+    for (int i = 0; i < CONFIG_T::pad_left; i++) {
         fill_zero<res_T, CONFIG_T>(res);
     }
 
-    CopyMain: for (int i = 0; i < CONFIG_T::in_width; i++) {
+CopyMain:
+    for (int i = 0; i < CONFIG_T::in_width; i++) {
         fill_data<data_T, res_T, CONFIG_T>(data, res);
     }
 
-    PadRight: for (int i = 0; i < CONFIG_T::pad_right; i++) {
+PadRight:
+    for (int i = 0; i < CONFIG_T::pad_right; i++) {
         fill_zero<res_T, CONFIG_T>(res);
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void zeropad2d_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void zeropad2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
 
-    PadTop: for (int i = 0; i < CONFIG_T::pad_top; i++) {
-        PadTopWidth: for (int j = 0; j < CONFIG_T::out_width; j++) {
+PadTop:
+    for (int i = 0; i < CONFIG_T::pad_top; i++) {
+    PadTopWidth:
+        for (int j = 0; j < CONFIG_T::out_width; j++) {
             fill_zero<res_T, CONFIG_T>(res);
         }
     }
 
-    PadMain: for (int i = 0; i < CONFIG_T::in_height; i++) {
-        PadLeft: for (int j = 0; j < CONFIG_T::pad_left; j++) {
+PadMain:
+    for (int i = 0; i < CONFIG_T::in_height; i++) {
+    PadLeft:
+        for (int j = 0; j < CONFIG_T::pad_left; j++) {
             fill_zero<res_T, CONFIG_T>(res);
         }
-        CopyMain: for (int j = 0; j < CONFIG_T::in_width; j++) {
+    CopyMain:
+        for (int j = 0; j < CONFIG_T::in_width; j++) {
             fill_data<data_T, res_T, CONFIG_T>(data, res);
         }
-        PadRight: for (int j = 0; j < CONFIG_T::pad_right; j++) {
+    PadRight:
+        for (int j = 0; j < CONFIG_T::pad_right; j++) {
             fill_zero<res_T, CONFIG_T>(res);
         }
     }
 
-    PadBottom: for (int i = 0; i < CONFIG_T::pad_bottom; i++) {
-        PadBottomWidth: for (int j = 0; j < CONFIG_T::out_width; j++) {
+PadBottom:
+    for (int i = 0; i < CONFIG_T::pad_bottom; i++) {
+    PadBottomWidth:
+        for (int j = 0; j < CONFIG_T::out_width; j++) {
             fill_zero<res_T, CONFIG_T>(res);
         }
     }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_pooling.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_pooling.h
@@ -4,275 +4,293 @@
 #include <iostream>
 #include "nnet_helpers.h"
 
-namespace nnet{
+namespace nnet {
 
 // Return the maximum value from an array
-template<typename T, int N>
-T max(T x[N]){
-  T y = x[0];
-  for(int i = 1; i < N; i++){
-    y = x[i] > y ? x[i] : y;
-  }
-  return y;
+template <typename T, int N> T max(T x[N])
+{
+    T y = x[0];
+    for (int i = 1; i < N; i++) {
+        y = x[i] > y ? x[i] : y;
+    }
+    return y;
 }
 
-template<int W, int N>
-ap_int<W> avg(ap_int<W> (&x)[N]){
-  // Use a wider accumulator than the input to avoid overflow
-  ap_int<W + ceillog2(N)> tmp = 0;
-  for(int i = 0; i < N; i++){
-    tmp += x[i];
-  }
-  tmp /= N;
-  // Now cast back to original type
-  ap_int<W> y = tmp;
-  return tmp;
+template <int W, int N> ap_int<W> avg(ap_int<W>(&x)[N])
+{
+    // Use a wider accumulator than the input to avoid overflow
+    ap_int<W + ceillog2(N)> tmp = 0;
+    for (int i = 0; i < N; i++) {
+        tmp += x[i];
+    }
+    tmp /= N;
+    // Now cast back to original type
+    ap_int<W> y = tmp;
+    return tmp;
 }
 
-template<int W, int I, int N>
-ap_fixed<W, I> avg(ap_fixed<W, I> (&x)[N]){
-  // Use a wider accumulator than the input to avoid overflow
-  ap_fixed<W + ceillog2(N), I + ceillog2(N)> tmp = 0;
-  for(int i = 0; i < N; i++){
-    tmp += x[i];
-  }
-  tmp /= N;
-  // Now cast back to original type
-  ap_fixed<W, I> y = tmp;
-  return y;
+template <int W, int I, int N> ap_fixed<W, I> avg(ap_fixed<W, I>(&x)[N])
+{
+    // Use a wider accumulator than the input to avoid overflow
+    ap_fixed<W + ceillog2(N), I + ceillog2(N)> tmp = 0;
+    for (int i = 0; i < N; i++) {
+        tmp += x[i];
+    }
+    tmp /= N;
+    // Now cast back to original type
+    ap_fixed<W, I> y = tmp;
+    return y;
 }
 
 // Return the mean value of an array
-template<typename T, int N>
-T avg(T (&x)[N]){
-  T y = 0;
-  for(int i = 0; i < N; i++){
-    y += x[i];
-  }
-  y /= N;
-  return y;
+template <typename T, int N> T avg(T (&x)[N])
+{
+    T y = 0;
+    for (int i = 0; i < N; i++) {
+        y += x[i];
+    }
+    y /= N;
+    return y;
 }
 
 // Enumeration for pooling operation (max, avg, l2norm pooling)
-enum Pool_Op { Max, Average }; // L2Norm };
-template<typename T, int N, Pool_Op op>
-T pool_op(T (&x)[N]){
-	switch(op){
-	case Max: return max<T, N>(x);
-	case Average: return avg(x);
-	// case L2Norm: return l2norm<T, N>(x);
-	}
+enum Pool_Op {
+    Max,
+    Average
+}; // L2Norm };
+template <typename T, int N, Pool_Op op> T pool_op(T (&x)[N])
+{
+    switch (op) {
+    case Max:
+        return max<T, N>(x);
+    case Average:
+        return avg(x);
+        // case L2Norm: return l2norm<T, N>(x);
+    }
 }
 
-template<typename T, Pool_Op op>
-T pad_val(){
-  /*---
-  *- In Tensorflow, pooling ignores the value in the padded cells
-  *- For Avg pooling, return 0 (the divisior is modified to the
-  *- area overlapping the unpadded image.
-  *- For max pooling, return the most negative value for the type.
-  *- TODO this is not really generic, it assumes fixed point or integer T
-  ---*/
-  switch(op){
-    case Max:{ 
-      T x = 0;
-      x[x.width - 1] = 1;
-      return x;
-      break;}
-    case Average: return 0;
-  }
+template <typename T, Pool_Op op> T pad_val()
+{
+    /*---
+    *- In Tensorflow, pooling ignores the value in the padded cells
+    *- For Avg pooling, return 0 (the divisior is modified to the
+    *- area overlapping the unpadded image.
+    *- For max pooling, return the most negative value for the type.
+    *- TODO this is not really generic, it assumes fixed point or integer T
+    ---*/
+    switch (op) {
+    case Max: {
+        T x = 0;
+        x[x.width - 1] = 1;
+        return x;
+        break;
+    }
+    case Average:
+        return 0;
+    }
 }
 
-struct pooling1d_config{
-  // IO size
-  static const unsigned n_in = 10;
-  static const unsigned pool_width = 2;
-  static const unsigned n_out = n_in / pool_width;
-  static const unsigned pad_left = 0;
-  static const unsigned pad_right = 0;
-  // Pooling function
-  static const Pool_Op pool_op = Max;
+struct pooling1d_config {
+    // IO size
+    static const unsigned n_in = 10;
+    static const unsigned pool_width = 2;
+    static const unsigned n_out = n_in / pool_width;
+    static const unsigned pad_left = 0;
+    static const unsigned pad_right = 0;
+    // Pooling function
+    static const Pool_Op pool_op = Max;
 };
 
-template<typename CONFIG_T>
-constexpr int pool_op_limit_1d() {
-  return CONFIG_T::n_in * CONFIG_T::n_filt / CONFIG_T::reuse;
+template <typename CONFIG_T> constexpr int pool_op_limit_1d()
+{
+    return CONFIG_T::n_in * CONFIG_T::n_filt / CONFIG_T::reuse;
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void pooling1d_cl(data_T data[CONFIG_T::n_in * CONFIG_T::n_filt], res_T res[CONFIG_T::n_out * CONFIG_T::n_filt]) {
+template <class data_T, class res_T, typename CONFIG_T>
+void pooling1d_cl(data_T data[CONFIG_T::n_in * CONFIG_T::n_filt], res_T res[CONFIG_T::n_out * CONFIG_T::n_filt])
+{
 
-  // TODO partition the arrays according to the reuse factor
-  const int limit = pool_op_limit_1d<CONFIG_T>();
-  #pragma HLS ALLOCATION instances=pool_op limit=limit function
-  // Add any necessary padding
-  unsigned padded_width = CONFIG_T::n_in + CONFIG_T::pad_left + CONFIG_T::pad_right;
-  if (CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
-    padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
-  }
+    // TODO partition the arrays according to the reuse factor
+    const int limit = pool_op_limit_1d<CONFIG_T>();
+    #pragma HLS ALLOCATION instances=pool_op limit=limit function
+    // Add any necessary padding
+    unsigned padded_width = CONFIG_T::n_in + CONFIG_T::pad_left + CONFIG_T::pad_right;
+    if (CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
+        padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
+    }
 
-  for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-    // Loop over input image x in steps of stride
-    for(int ii = 0; ii < padded_width; ii += CONFIG_T::stride_width) {
-      data_T pool[CONFIG_T::pool_width];
-      // Keep track of number of pixels in image vs padding region
-      unsigned img_overlap = 0;
-      // Loop over pool window x
-      for(int jj = 0; jj < CONFIG_T::stride_width; jj++) {
-        if(ii+jj < CONFIG_T::pad_left || ii+jj >= (padded_width - CONFIG_T::pad_right)) {
-          // Add padding
-          pool[jj] = pad_val<data_T, CONFIG_T::pool_op>();
-        }else{
-          pool[jj] = data[(ii + jj) * CONFIG_T::n_filt + ff];
-          img_overlap++;
+    for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+        // Loop over input image x in steps of stride
+        for (int ii = 0; ii < padded_width; ii += CONFIG_T::stride_width) {
+            data_T pool[CONFIG_T::pool_width];
+            // Keep track of number of pixels in image vs padding region
+            unsigned img_overlap = 0;
+            // Loop over pool window x
+            for (int jj = 0; jj < CONFIG_T::stride_width; jj++) {
+                if (ii + jj < CONFIG_T::pad_left || ii + jj >= (padded_width - CONFIG_T::pad_right)) {
+                    // Add padding
+                    pool[jj] = pad_val<data_T, CONFIG_T::pool_op>();
+                } else {
+                    pool[jj] = data[(ii + jj) * CONFIG_T::n_filt + ff];
+                    img_overlap++;
+                }
+            }
+            // do the pooling
+            // TODO in the case of average pooling, need to reduce width to area of pool window
+            // not overlapping padding region
+            res[(ii / CONFIG_T::stride_width) * CONFIG_T::n_filt + ff] =
+                pool_op<data_T, CONFIG_T::pool_width, CONFIG_T::pool_op>(pool);
+            // If the pool op is Average, the zero-padding needs to be removed from the results
+            if (CONFIG_T::pool_op == Average) {
+                data_T rescale = CONFIG_T::pool_width / img_overlap;
+                res[(ii / CONFIG_T::stride_width) * CONFIG_T::n_filt + ff] *= rescale;
+            }
         }
-      }
-      // do the pooling
-      // TODO in the case of average pooling, need to reduce width to area of pool window
-      // not overlapping padding region
-      res[(ii/CONFIG_T::stride_width)* CONFIG_T::n_filt + ff] =
-          pool_op<data_T, CONFIG_T::pool_width, CONFIG_T::pool_op>(pool);
-      // If the pool op is Average, the zero-padding needs to be removed from the results
-      if(CONFIG_T::pool_op == Average) {
-        data_T rescale = CONFIG_T::pool_width / img_overlap;
-        res[(ii/CONFIG_T::stride_width)* CONFIG_T::n_filt + ff] *= rescale;
-      }
-	  }
-  }
+    }
 }
 
-struct pooling2d_config{
-  // IO size
-  static const unsigned in_height = 10;
-  static const unsigned in_width = 10;
-  static const unsigned n_filt = 4;
-  static const unsigned stride_height = 2;
-  static const unsigned stride_width = 2;
-  static const unsigned pool_height = 2;
-  static const unsigned pool_width = 2;
-  static const unsigned out_height = (in_height - pool_height) / stride_height + 1;
-  static const unsigned out_width = (in_width - pool_width) / stride_width + 1;
-  // Padding
-  static const unsigned pad_top = 0;
-  static const unsigned pad_bottom = 0;
-  static const unsigned pad_left = 0;
-  static const unsigned pad_right = 0;
-  // Pooling function
-  static const Pool_Op pool_op = Max;
-  // Reuse
-  static const unsigned reuse = 1;
-  
-  // Internal data type definitions
-  typedef float accum_t;
+struct pooling2d_config {
+    // IO size
+    static const unsigned in_height = 10;
+    static const unsigned in_width = 10;
+    static const unsigned n_filt = 4;
+    static const unsigned stride_height = 2;
+    static const unsigned stride_width = 2;
+    static const unsigned pool_height = 2;
+    static const unsigned pool_width = 2;
+    static const unsigned out_height = (in_height - pool_height) / stride_height + 1;
+    static const unsigned out_width = (in_width - pool_width) / stride_width + 1;
+    // Padding
+    static const unsigned pad_top = 0;
+    static const unsigned pad_bottom = 0;
+    static const unsigned pad_left = 0;
+    static const unsigned pad_right = 0;
+    // Pooling function
+    static const Pool_Op pool_op = Max;
+    // Reuse
+    static const unsigned reuse = 1;
+
+    // Internal data type definitions
+    typedef float accum_t;
 };
 
-template<typename CONFIG_T>
-constexpr int pool_op_limit(){
-  return (CONFIG_T::out_height * CONFIG_T::out_width) * CONFIG_T::n_filt / CONFIG_T::reuse;
+template <typename CONFIG_T> constexpr int pool_op_limit()
+{
+    return (CONFIG_T::out_height * CONFIG_T::out_width) * CONFIG_T::n_filt / CONFIG_T::reuse;
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class res_T, typename CONFIG_T>
 void pooling2d_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_filt],
-               res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt]){
+                  res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt])
+{
 
-  // TODO partition the arrays according to the reuse factor
-  const int limit = pool_op_limit<CONFIG_T>();
-  #pragma HLS ALLOCATION instances=pool_op limit=limit function
-  // Add any necessary padding
-  unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
-  unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
-  if (CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
-    padded_height -= padded_height - (padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height);
-    padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
-  }
+    // TODO partition the arrays according to the reuse factor
+    const int limit = pool_op_limit<CONFIG_T>();
+    #pragma HLS ALLOCATION instances=pool_op limit=limit function
+    // Add any necessary padding
+    unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
+    unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
+    if (CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
+        padded_height -= padded_height - (padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height);
+        padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
+    }
 
-  for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
-	  // Loop over input image y in steps of stride
-	  for(int ii = 0; ii < padded_height; ii += CONFIG_T::stride_height){
-		  // Loop over input image x in steps of stride
-		  for(int jj = 0; jj < padded_width; jj += CONFIG_T::stride_width){
-			  data_T pool[CONFIG_T::pool_height * CONFIG_T::pool_width];
-        // Keep track of number of pixels in image vs padding region
-        unsigned img_overlap = 0;
-			  // Loop over pool window y
-			  for(int kk = 0; kk < CONFIG_T::stride_height; kk++){
-				  // Loop over pool window x
-				  for(int ll = 0; ll < CONFIG_T::stride_width; ll++){
-            if(ii+kk < CONFIG_T::pad_top || ii+kk >= (padded_height - CONFIG_T::pad_bottom) || jj+ll < CONFIG_T::pad_left || jj+ll >= (padded_width - CONFIG_T::pad_right)){
-              // Add padding
-              pool[kk * CONFIG_T::stride_width + ll] = pad_val<data_T, CONFIG_T::pool_op>();
-            }else{
-  					  pool[kk * CONFIG_T::stride_width + ll] = data[(ii + kk) * CONFIG_T::in_width * CONFIG_T::n_filt + (jj + ll) * CONFIG_T::n_filt + ff];
-              img_overlap++;
+    for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+        // Loop over input image y in steps of stride
+        for (int ii = 0; ii < padded_height; ii += CONFIG_T::stride_height) {
+            // Loop over input image x in steps of stride
+            for (int jj = 0; jj < padded_width; jj += CONFIG_T::stride_width) {
+                data_T pool[CONFIG_T::pool_height * CONFIG_T::pool_width];
+                // Keep track of number of pixels in image vs padding region
+                unsigned img_overlap = 0;
+                // Loop over pool window y
+                for (int kk = 0; kk < CONFIG_T::stride_height; kk++) {
+                    // Loop over pool window x
+                    for (int ll = 0; ll < CONFIG_T::stride_width; ll++) {
+                        if (ii + kk < CONFIG_T::pad_top || ii + kk >= (padded_height - CONFIG_T::pad_bottom) ||
+                            jj + ll < CONFIG_T::pad_left || jj + ll >= (padded_width - CONFIG_T::pad_right)) {
+                            // Add padding
+                            pool[kk * CONFIG_T::stride_width + ll] = pad_val<data_T, CONFIG_T::pool_op>();
+                        } else {
+                            pool[kk * CONFIG_T::stride_width + ll] = data
+                                [(ii + kk) * CONFIG_T::in_width * CONFIG_T::n_filt + (jj + ll) * CONFIG_T::n_filt + ff];
+                            img_overlap++;
+                        }
+                    }
+                }
+                // do the pooling
+                // TODO in the case of average pooling, need to reduce height * width to area of pool window
+                // not overlapping padding region
+                res[(ii / CONFIG_T::stride_height) * CONFIG_T::out_width * CONFIG_T::n_filt +
+                    (jj / CONFIG_T::stride_width) * CONFIG_T::n_filt + ff] =
+                    pool_op<data_T, CONFIG_T::pool_height *CONFIG_T::pool_width, CONFIG_T::pool_op>(pool);
+                // If the pool op is Average, the zero-padding needs to be removed from the results
+                if (CONFIG_T::pool_op == Average) {
+                    data_T rescale = CONFIG_T::pool_height * CONFIG_T::pool_width / img_overlap;
+                    res[(ii / CONFIG_T::stride_height) * CONFIG_T::out_width * CONFIG_T::n_filt +
+                        (jj / CONFIG_T::stride_width) * CONFIG_T::n_filt + ff] *= rescale;
+                }
             }
-				  }
-			  }
-			  // do the pooling
-        // TODO in the case of average pooling, need to reduce height * width to area of pool window
-        // not overlapping padding region
-			  res[(ii/CONFIG_T::stride_height) * CONFIG_T::out_width * CONFIG_T::n_filt + (jj/CONFIG_T::stride_width)* CONFIG_T::n_filt + ff] =
-					  pool_op<data_T, CONFIG_T::pool_height*CONFIG_T::pool_width, CONFIG_T::pool_op>(pool);
-        // If the pool op is Average, the zero-padding needs to be removed from the results
-        if(CONFIG_T::pool_op == Average){
-          data_T rescale = CONFIG_T::pool_height * CONFIG_T::pool_width / img_overlap;
-          res[(ii/CONFIG_T::stride_height) * CONFIG_T::out_width * CONFIG_T::n_filt + (jj/CONFIG_T::stride_width)* CONFIG_T::n_filt + ff] *= rescale;
         }
-		  }
-	  }
-  }
+    }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class res_T, typename CONFIG_T>
 void pooling2d_cf(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_filt],
-               res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt]){
+                  res_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt])
+{
 
-  // TODO partition the arrays according to the reuse factor
-  const int limit = pool_op_limit<CONFIG_T>();
-  #pragma HLS ALLOCATION instances=pool_op limit=limit function
-  // Add any necessary padding
-  unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
-  unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
-  if (CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
-    padded_height -= padded_height - (padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height);
-    padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
-  }
+    // TODO partition the arrays according to the reuse factor
+    const int limit = pool_op_limit<CONFIG_T>();
+    #pragma HLS ALLOCATION instances=pool_op limit=limit function
+    // Add any necessary padding
+    unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
+    unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
+    if (CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
+        padded_height -= padded_height - (padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height);
+        padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
+    }
 
-  for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
-	  // Loop over input image y in steps of stride
-	  for(int ii = 0; ii < padded_height; ii += CONFIG_T::stride_height){
-		  // Loop over input image x in steps of stride
-		  for(int jj = 0; jj < padded_width; jj += CONFIG_T::stride_width){
-			  data_T pool[CONFIG_T::pool_height * CONFIG_T::pool_width];
-        // Keep track of number of pixels in image vs padding region
-        unsigned img_overlap = 0;
-			  // Loop over pool window y
-			  for(int kk = 0; kk < CONFIG_T::stride_height; kk++){
-				  // Loop over pool window x
-				  for(int ll = 0; ll < CONFIG_T::stride_width; ll++){
-            if(ii+kk < CONFIG_T::pad_top || ii+kk >= (padded_height - CONFIG_T::pad_bottom) || jj+ll < CONFIG_T::pad_left || jj+ll >= (padded_width - CONFIG_T::pad_right)){
-              // Add padding
-              pool[kk * CONFIG_T::stride_width + ll] = pad_val<data_T, CONFIG_T::pool_op>();
-            }else{
-  					  pool[kk * CONFIG_T::stride_width + ll] = data[(ii + kk) * CONFIG_T::in_width + ff * CONFIG_T::in_width*CONFIG_T::in_height + ll + jj];
-              img_overlap++;
+    for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+        // Loop over input image y in steps of stride
+        for (int ii = 0; ii < padded_height; ii += CONFIG_T::stride_height) {
+            // Loop over input image x in steps of stride
+            for (int jj = 0; jj < padded_width; jj += CONFIG_T::stride_width) {
+                data_T pool[CONFIG_T::pool_height * CONFIG_T::pool_width];
+                // Keep track of number of pixels in image vs padding region
+                unsigned img_overlap = 0;
+                // Loop over pool window y
+                for (int kk = 0; kk < CONFIG_T::stride_height; kk++) {
+                    // Loop over pool window x
+                    for (int ll = 0; ll < CONFIG_T::stride_width; ll++) {
+                        if (ii + kk < CONFIG_T::pad_top || ii + kk >= (padded_height - CONFIG_T::pad_bottom) ||
+                            jj + ll < CONFIG_T::pad_left || jj + ll >= (padded_width - CONFIG_T::pad_right)) {
+                            // Add padding
+                            pool[kk * CONFIG_T::stride_width + ll] = pad_val<data_T, CONFIG_T::pool_op>();
+                        } else {
+                            pool[kk * CONFIG_T::stride_width + ll] =
+                                data[(ii + kk) * CONFIG_T::in_width + ff * CONFIG_T::in_width * CONFIG_T::in_height +
+                                     ll + jj];
+                            img_overlap++;
+                        }
+                    }
+                }
+                // do the pooling
+                // TODO in the case of average pooling, need to reduce height * width to area of pool window
+                // not overlapping padding region
+                res[(ii / CONFIG_T::stride_height) * CONFIG_T::out_width + (jj / CONFIG_T::stride_width) +
+                    ff * CONFIG_T::out_height * CONFIG_T::out_width] =
+                    pool_op<data_T, CONFIG_T::pool_height *CONFIG_T::pool_width, CONFIG_T::pool_op>(pool);
+                // If the pool op is Average, the zero-padding needs to be removed from the results
+                if (CONFIG_T::pool_op == Average) {
+                    data_T rescale = CONFIG_T::pool_height * CONFIG_T::pool_width / img_overlap;
+                    res[(ii / CONFIG_T::stride_height) * CONFIG_T::out_width + (jj / CONFIG_T::stride_width) +
+                        ff * CONFIG_T::out_height * CONFIG_T::out_width] *= rescale;
+                }
             }
-				  }
-			  }
-			  // do the pooling
-        // TODO in the case of average pooling, need to reduce height * width to area of pool window
-        // not overlapping padding region
-			  res[(ii/CONFIG_T::stride_height) * CONFIG_T::out_width + (jj/CONFIG_T::stride_width) + ff* CONFIG_T::out_height* CONFIG_T::out_width] =
-					  pool_op<data_T, CONFIG_T::pool_height*CONFIG_T::pool_width, CONFIG_T::pool_op>(pool);
-        // If the pool op is Average, the zero-padding needs to be removed from the results
-        if(CONFIG_T::pool_op == Average){
-          data_T rescale = CONFIG_T::pool_height * CONFIG_T::pool_width / img_overlap;
-          res[(ii/CONFIG_T::stride_height) * CONFIG_T::out_width + (jj/CONFIG_T::stride_width) + ff* CONFIG_T::out_height* CONFIG_T::out_width] *= rescale;
         }
-		  }
-	  }
-  }
+    }
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_pooling_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_pooling_stream.h
@@ -14,46 +14,47 @@ namespace nnet {
 //       Max/average pooling
 // *************************************************
 
-template <class T, int N, class CONFIG_T>
-T reduce_pool(T x[N]) {
+template <class T, int N, class CONFIG_T> T reduce_pool(T x[N])
+{
     #pragma HLS INLINE
     if (CONFIG_T::pool_op == Max) {
         Op_max<T> op_max;
-        return reduce<T, N, Op_max<T>>(x, op_max);
+        return reduce<T, N, Op_max<T> >(x, op_max);
     } else {
         Op_add<T> op_add;
-        T sum = reduce<T, N, Op_add<T>>(x, op_add);
+        T sum = reduce<T, N, Op_add<T> >(x, op_add);
         return sum / N;
     }
 }
 
-template<unsigned TABLE_SIZE, unsigned POOL_SIZE>
-void init_pool_table(
-    unsigned table[TABLE_SIZE]
-) {
+template <unsigned TABLE_SIZE, unsigned POOL_SIZE> void init_pool_table(unsigned table[TABLE_SIZE])
+{
     for (unsigned ii = 0; ii < TABLE_SIZE; ii++) {
         table[ii] = ii % POOL_SIZE;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void compute_pool_encoded_2d(
-    const unsigned h_idx,
-    const unsigned w_idx,
-    const data_T& in_elem,
-    hls::stream<typename data_T::value_type> data_window[CONFIG_T::pool_height * CONFIG_T::pool_width * CONFIG_T::n_filt],
-    hls::stream<res_T> &res,
-    res_T &res_pack,
-    unsigned &outputs_ready
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void compute_pool_encoded_2d(const unsigned h_idx, const unsigned w_idx, const data_T &in_elem,
+                             hls::stream<typename data_T::value_type> data_window
+                                 [CONFIG_T::pool_height * CONFIG_T::pool_width * CONFIG_T::n_filt],
+                             hls::stream<res_T> &res, res_T &res_pack, unsigned &outputs_ready)
+{
     // Nearest H without unused pixels on the right
-    constexpr unsigned nH = ((CONFIG_T::in_height - CONFIG_T::pool_height) / CONFIG_T::stride_height) * CONFIG_T::stride_height + CONFIG_T::pool_height;
+    constexpr unsigned nH =
+        ((CONFIG_T::in_height - CONFIG_T::pool_height) / CONFIG_T::stride_height) * CONFIG_T::stride_height +
+        CONFIG_T::pool_height;
     // Scaled H that behaves like original H
-    constexpr unsigned sH = (DIV_ROUNDUP(CONFIG_T::pool_height, CONFIG_T::stride_height) - 1) * CONFIG_T::stride_height + CONFIG_T::pool_height;
+    constexpr unsigned sH =
+        (DIV_ROUNDUP(CONFIG_T::pool_height, CONFIG_T::stride_height) - 1) * CONFIG_T::stride_height +
+        CONFIG_T::pool_height;
     // Nearest W without unused pixels on the right
-    constexpr unsigned nW = ((CONFIG_T::in_width - CONFIG_T::pool_width) / CONFIG_T::stride_width) * CONFIG_T::stride_width + CONFIG_T::pool_width;
+    constexpr unsigned nW =
+        ((CONFIG_T::in_width - CONFIG_T::pool_width) / CONFIG_T::stride_width) * CONFIG_T::stride_width +
+        CONFIG_T::pool_width;
     // Scaled W that behaves like original W
-    constexpr unsigned sW = (DIV_ROUNDUP(CONFIG_T::pool_width, CONFIG_T::stride_width) - 1) * CONFIG_T::stride_width + CONFIG_T::pool_width;
+    constexpr unsigned sW =
+        (DIV_ROUNDUP(CONFIG_T::pool_width, CONFIG_T::stride_width) - 1) * CONFIG_T::stride_width + CONFIG_T::pool_width;
 
 #ifdef __SYNTHESIS__
     bool initialized = false;
@@ -83,31 +84,42 @@ void compute_pool_encoded_2d(
     const unsigned sh_idx = pool_table_height[h_idx] * CONFIG_T::pool_width;
     const unsigned wp_idx = w_idx * (data_T::size / CONFIG_T::n_filt);
 
-    PixelLoop: for (unsigned p = 0; p < data_T::size / CONFIG_T::n_filt; p++) {
+PixelLoop:
+    for (unsigned p = 0; p < data_T::size / CONFIG_T::n_filt; p++) {
         #pragma HLS PIPELINE
 
-        ap_uint<CONFIG_T::pool_height * CONFIG_T::pool_width> filt_mask = 0;
+        ap_uint<CONFIG_T::pool_height *CONFIG_T::pool_width> filt_mask = 0;
         if ((h_idx < nH) && (wp_idx + p < nW)) {
             filt_mask = sh_idx + pool_table_width[wp_idx + p] + 1;
         }
 
-        CopyDataFilt: for (unsigned c = 0; c < CONFIG_T::n_filt; c++) {
-            if (filt_mask > 0) data_window[c * CONFIG_T::pool_height * CONFIG_T::pool_width + filt_mask.to_uint() - 1].write(in_elem[p * CONFIG_T::n_filt + c]);
+    CopyDataFilt:
+        for (unsigned c = 0; c < CONFIG_T::n_filt; c++) {
+            if (filt_mask > 0)
+                data_window[c * CONFIG_T::pool_height * CONFIG_T::pool_width + filt_mask.to_uint() - 1]
+                    .write(in_elem[p * CONFIG_T::n_filt + c]);
         }
 
         if (filt_mask == CONFIG_T::pool_height * CONFIG_T::pool_width) {
-            FiltLoop: for(unsigned c = 0; c < CONFIG_T::n_filt; c++) {
-                PoolLoop: for(unsigned f = 0; f < CONFIG_T::pool_height * CONFIG_T::pool_width; f++) {
+        FiltLoop:
+            for (unsigned c = 0; c < CONFIG_T::n_filt; c++) {
+            PoolLoop:
+                for (unsigned f = 0; f < CONFIG_T::pool_height * CONFIG_T::pool_width; f++) {
                     pool_window[f] = data_window[c * CONFIG_T::pool_height * CONFIG_T::pool_width + f].read();
                 }
-                if (res_T::size / CONFIG_T::n_filt == 1) { // Saves resources if we don't pack output, compiler will remove the else branch
-                    res_pack[c] = reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_height * CONFIG_T::pool_width, CONFIG_T>(pool_window);
+                if (res_T::size / CONFIG_T::n_filt ==
+                    1) { // Saves resources if we don't pack output, compiler will remove the else branch
+                    res_pack[c] =
+                        reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_height *CONFIG_T::pool_width, CONFIG_T>(
+                            pool_window);
                 } else {
-                    res_pack[outputs_ready * CONFIG_T::n_filt + c] = reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_height * CONFIG_T::pool_width, CONFIG_T>(pool_window);
+                    res_pack[outputs_ready * CONFIG_T::n_filt + c] =
+                        reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_height *CONFIG_T::pool_width, CONFIG_T>(
+                            pool_window);
                 }
-
             }
-            if (res_T::size / CONFIG_T::n_filt == 1) { // Saves resources if we don't pack output, compiler will remove the else branch
+            if (res_T::size / CONFIG_T::n_filt ==
+                1) { // Saves resources if we don't pack output, compiler will remove the else branch
                 res.write(res_pack);
             } else {
                 if (outputs_ready == (res_T::size / CONFIG_T::n_filt) - 1) {
@@ -121,11 +133,9 @@ void compute_pool_encoded_2d(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void pooling2d_encoded_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T> &res
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void pooling2d_encoded_cl(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
     assert(CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
     assert(CONFIG_T::pool_height == CONFIG_T::stride_height && CONFIG_T::pool_width == CONFIG_T::stride_width);
 
@@ -133,7 +143,8 @@ void pooling2d_encoded_cl(
     #pragma HLS DATA_PACK variable=res_pack
     unsigned outputs_ready = 0;
 
-    hls::stream<typename data_T::value_type> data_window[CONFIG_T::pool_height * CONFIG_T::pool_width * CONFIG_T::n_filt];
+    hls::stream<typename data_T::value_type> data_window
+        [CONFIG_T::pool_height * CONFIG_T::pool_width * CONFIG_T::n_filt];
     constexpr int win_depth = CONFIG_T::pool_height * CONFIG_T::out_width;
     for (unsigned i_out = 0; i_out < CONFIG_T::pool_height * CONFIG_T::pool_width * CONFIG_T::n_filt; i_out++) {
         #pragma HLS STREAM variable=data_window[i_out] depth=win_depth
@@ -141,13 +152,16 @@ void pooling2d_encoded_cl(
 
     constexpr int pack_factor = data_T::size / CONFIG_T::n_filt;
 
-    ReadInputHeight: for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
-        ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (pack_factor); i_iw++) {
+ReadInputHeight:
+    for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
+    ReadInputWidth:
+        for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (pack_factor); i_iw++) {
             #pragma HLS LOOP_FLATTEN
             if (res_T::size / CONFIG_T::n_filt == 1) {
                 #pragma HLS PIPELINE II=pack_factor
             }
-            compute_pool_encoded_2d<data_T, res_T, CONFIG_T>(i_ih, i_iw, data.read(), data_window, res, res_pack, outputs_ready);
+            compute_pool_encoded_2d<data_T, res_T, CONFIG_T>(i_ih, i_iw, data.read(), data_window, res, res_pack,
+                                                             outputs_ready);
         }
     }
 }
@@ -155,16 +169,16 @@ void pooling2d_encoded_cl(
 // *************************************************
 //       Line Buffer Implementation (Phil's)
 // *************************************************
-template<class data_T, class res_T, typename CONFIG_T>
-void compute_pool_buffer_2d(
-    const data_T& in_elem,
-    ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[MAX(CONFIG_T::pool_height - 1,1)][CONFIG_T::n_filt],
-    hls::stream<res_T> &res
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void compute_pool_buffer_2d(const data_T &in_elem,
+                            ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer
+                                [MAX(CONFIG_T::pool_height - 1, 1)][CONFIG_T::n_filt],
+                            hls::stream<res_T> &res)
+{
     #pragma HLS INLINE
     const static int lShiftX = CONFIG_T::pool_width - 1;
     const static int lShiftY = CONFIG_T::pool_height - 1;
-    static int pX = 0; // pixel X 
+    static int pX = 0; // pixel X
     static int pY = 0; // pixel Y
     static int sX = 0; // stride X
     static int sY = 0; // stride Y
@@ -183,16 +197,20 @@ void compute_pool_buffer_2d(
 
     // Can compute pooling output
     if ((sX - lShiftX) == 0 && (sY - lShiftY) == 0 && pY > lShiftY - 1 && pX > lShiftX - 1) {
-        FiltLoop: for(unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
-            #pragma HLS PIPELINE
+    FiltLoop:
+        for (unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
+        #pragma HLS PIPELINE
 
-            // Retrieve data for current channel
-            PoolLoop: for(unsigned i_ihw = 0; i_ihw < CONFIG_T::pool_height * CONFIG_T::pool_width; i_ihw++) {
-                pool_window[i_ihw] = kernel_data[i_ihw * CONFIG_T::n_filt + i_ic]; 
+        // Retrieve data for current channel
+        PoolLoop:
+            for (unsigned i_ihw = 0; i_ihw < CONFIG_T::pool_height * CONFIG_T::pool_width; i_ihw++) {
+                pool_window[i_ihw] = kernel_data[i_ihw * CONFIG_T::n_filt + i_ic];
             }
 
             // Compute Pooling
-            res_pack[i_ic] = reduce_pool<typename data_T::value_type, CONFIG_T::pool_height * CONFIG_T::pool_width, CONFIG_T>(pool_window);
+            res_pack[i_ic] =
+                reduce_pool<typename data_T::value_type, CONFIG_T::pool_height *CONFIG_T::pool_width, CONFIG_T>(
+                    pool_window);
         }
 
         // Write to output
@@ -200,38 +218,39 @@ void compute_pool_buffer_2d(
     }
 
     // Counter Housekeeping
-    if (pX + 1 == CONFIG_T::in_width)  // Includes padding, end of line (padded)
+    if (pX + 1 == CONFIG_T::in_width) // Includes padding, end of line (padded)
     {
         pX = 0;
         sX = 0;
-        if (pY + 1 == CONFIG_T::in_height) {  // Reached bottom of image
+        if (pY + 1 == CONFIG_T::in_height) { // Reached bottom of image
             pY = 0;
             sY = 0;
         } else { // Next line
             pY = pY + 1;
             // Update stride (threshold) ? subtract stride : increment stride
-            sY = ((sY - lShiftY) == 0) ? sY - CONFIG_T::stride_height + 1 : sY + 1; 
+            sY = ((sY - lShiftY) == 0) ? sY - CONFIG_T::stride_height + 1 : sY + 1;
         }
     } else {
         pX = pX + 1;
         // Update stride (threshold) ? subtract stride : increment stride
-        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1; 
+        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void pooling2d_buffer_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T> &res
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void pooling2d_buffer_cl(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
     assert(CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
     assert(CONFIG_T::pool_height == CONFIG_T::stride_height && CONFIG_T::pool_width == CONFIG_T::stride_width);
 
-    static ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[MAX(CONFIG_T::pool_height - 1,1)][CONFIG_T::n_filt];
-    #pragma HLS ARRAY_PARTITION variable = line_buffer complete dim = 2
+    static ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[MAX(CONFIG_T::pool_height - 1, 1)]
+                                                                                    [CONFIG_T::n_filt];
+#pragma HLS ARRAY_PARTITION variable = line_buffer complete dim = 2
 
-    ReadInputHeight: for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
-        ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width; i_iw++) {
+ReadInputHeight:
+    for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
+    ReadInputWidth:
+        for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width; i_iw++) {
             #pragma HLS LOOP_FLATTEN
             #pragma HLS PIPELINE
 
@@ -240,39 +259,37 @@ void pooling2d_buffer_cl(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void pooling2d_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T> &res
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void pooling2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
     #pragma HLS inline region
-    switch(CONFIG_T::implementation){
-        case conv_implementation::linebuffer:
-            pooling2d_buffer_cl<data_T, res_T, CONFIG_T>(data, res);
-            break;
-        case conv_implementation::encoded:
-            pooling2d_encoded_cl<data_T, res_T, CONFIG_T>(data, res);
-            break;
-        } 
+    switch (CONFIG_T::implementation) {
+    case conv_implementation::linebuffer:
+        pooling2d_buffer_cl<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    case conv_implementation::encoded:
+        pooling2d_encoded_cl<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    }
 }
 
 // *************************************************
 //                  Pooling 1D
 // *************************************************
 
-template<class data_T, class res_T, typename CONFIG_T>
-void compute_pool_encoded_1d(
-    const unsigned w_idx,
-    const data_T& in_elem,
-    hls::stream<typename data_T::value_type> data_window[CONFIG_T::pool_width * CONFIG_T::n_filt],
-    hls::stream<res_T> &res,
-    res_T &res_pack,
-    unsigned &outputs_ready
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void
+compute_pool_encoded_1d(const unsigned w_idx, const data_T &in_elem,
+                        hls::stream<typename data_T::value_type> data_window[CONFIG_T::pool_width * CONFIG_T::n_filt],
+                        hls::stream<res_T> &res, res_T &res_pack, unsigned &outputs_ready)
+{
     // Nearest W without unused pixels on the right
-    constexpr unsigned nW = ((CONFIG_T::n_in - CONFIG_T::pool_width) / CONFIG_T::stride_width) * CONFIG_T::stride_width + CONFIG_T::pool_width;
+    constexpr unsigned nW =
+        ((CONFIG_T::n_in - CONFIG_T::pool_width) / CONFIG_T::stride_width) * CONFIG_T::stride_width +
+        CONFIG_T::pool_width;
     // Scaled W that behaves like original W
-    constexpr unsigned sW = (DIV_ROUNDUP(CONFIG_T::pool_width, CONFIG_T::stride_width) - 1) * CONFIG_T::stride_width + CONFIG_T::pool_width;
+    constexpr unsigned sW =
+        (DIV_ROUNDUP(CONFIG_T::pool_width, CONFIG_T::stride_width) - 1) * CONFIG_T::stride_width + CONFIG_T::pool_width;
 
 #ifdef __SYNTHESIS__
     bool initialized = false;
@@ -297,7 +314,8 @@ void compute_pool_encoded_1d(
 
     const unsigned wp_idx = w_idx * (data_T::size / CONFIG_T::n_filt);
 
-    PixelLoop: for (unsigned p = 0; p < data_T::size / CONFIG_T::n_filt; p++) {
+PixelLoop:
+    for (unsigned p = 0; p < data_T::size / CONFIG_T::n_filt; p++) {
         #pragma HLS PIPELINE
 
         ap_uint<CONFIG_T::pool_width> filt_mask = 0;
@@ -305,23 +323,30 @@ void compute_pool_encoded_1d(
             filt_mask = pool_table_width[wp_idx + p] + 1;
         }
 
-        CopyDataFilt: for (unsigned c = 0; c < CONFIG_T::n_filt; c++) {
-            if (filt_mask > 0) data_window[c * CONFIG_T::pool_width + filt_mask.to_uint() - 1].write(in_elem[p * CONFIG_T::n_filt + c]);
+    CopyDataFilt:
+        for (unsigned c = 0; c < CONFIG_T::n_filt; c++) {
+            if (filt_mask > 0)
+                data_window[c * CONFIG_T::pool_width + filt_mask.to_uint() - 1]
+                    .write(in_elem[p * CONFIG_T::n_filt + c]);
         }
 
         if (filt_mask == CONFIG_T::pool_width) {
-            FiltLoop: for(unsigned c = 0; c < CONFIG_T::n_filt; c++) {
-                PoolLoop: for(unsigned f = 0; f < CONFIG_T::pool_width; f++) {
+        FiltLoop:
+            for (unsigned c = 0; c < CONFIG_T::n_filt; c++) {
+            PoolLoop:
+                for (unsigned f = 0; f < CONFIG_T::pool_width; f++) {
                     pool_window[f] = data_window[c * CONFIG_T::pool_width + f].read();
                 }
-                if (res_T::size / CONFIG_T::n_filt == 1) { // Saves resources if we don't pack output, compiler will remove the else branch
+                if (res_T::size / CONFIG_T::n_filt ==
+                    1) { // Saves resources if we don't pack output, compiler will remove the else branch
                     res_pack[c] = reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_width, CONFIG_T>(pool_window);
                 } else {
-                    res_pack[outputs_ready * CONFIG_T::n_filt + c] = reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_width, CONFIG_T>(pool_window);
+                    res_pack[outputs_ready * CONFIG_T::n_filt + c] =
+                        reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_width, CONFIG_T>(pool_window);
                 }
-
             }
-            if (res_T::size / CONFIG_T::n_filt == 1) { // Saves resources if we don't pack output, compiler will remove the else branch
+            if (res_T::size / CONFIG_T::n_filt ==
+                1) { // Saves resources if we don't pack output, compiler will remove the else branch
                 res.write(res_pack);
             } else {
                 if (outputs_ready == (res_T::size / CONFIG_T::n_filt) - 1) {
@@ -335,11 +360,9 @@ void compute_pool_encoded_1d(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void pooling1d_encoded_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T> &res
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void pooling1d_encoded_cl(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
     assert(CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
     assert(CONFIG_T::pool_width == CONFIG_T::stride_width);
 
@@ -355,7 +378,8 @@ void pooling1d_encoded_cl(
 
     constexpr int pack_factor = data_T::size / CONFIG_T::n_filt;
 
-    ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::n_in / (pack_factor); i_iw++) {
+ReadInputWidth:
+    for (unsigned i_iw = 0; i_iw < CONFIG_T::n_in / (pack_factor); i_iw++) {
         #pragma HLS LOOP_FLATTEN
         if (res_T::size / CONFIG_T::n_filt == 1) {
             #pragma HLS PIPELINE II=pack_factor
@@ -367,11 +391,9 @@ void pooling1d_encoded_cl(
 // *************************************************
 //       Line Buffer Implementation (Phil's) 1D
 // *************************************************
-template<class data_T, class res_T, typename CONFIG_T>
-void compute_pool_buffer_1d(
-    const data_T& in_elem,
-    hls::stream<res_T> &res
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void compute_pool_buffer_1d(const data_T &in_elem, hls::stream<res_T> &res)
+{
     #pragma HLS INLINE
     const static int lShiftX = CONFIG_T::pool_width - 1;
     // Counters
@@ -392,13 +414,15 @@ void compute_pool_buffer_1d(
     nnet::kernel_shift_1d<data_T, CONFIG_T>(in_elem, kernel_data);
 
     // Can compute pooling output
-    if ( (sX - lShiftX) == 0 && pX > lShiftX - 1) {
-        FiltLoop: for(unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
-            #pragma HLS PIPELINE
+    if ((sX - lShiftX) == 0 && pX > lShiftX - 1) {
+    FiltLoop:
+        for (unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
+        #pragma HLS PIPELINE
 
-            // Retrieve data for current channel
-            PoolLoop: for(unsigned i_iw = 0; i_iw < CONFIG_T::pool_width; i_iw++) {
-                pool_window[i_iw] = kernel_data[i_iw * CONFIG_T::n_filt + i_ic]; 
+        // Retrieve data for current channel
+        PoolLoop:
+            for (unsigned i_iw = 0; i_iw < CONFIG_T::pool_width; i_iw++) {
+                pool_window[i_iw] = kernel_data[i_iw * CONFIG_T::n_filt + i_ic];
             }
 
             // Compute Pooling
@@ -410,93 +434,86 @@ void compute_pool_buffer_1d(
     }
 
     // Counter Housekeeping
-    if (pX + 1 == CONFIG_T::n_in)  // Includes padding, end of line (padded)
+    if (pX + 1 == CONFIG_T::n_in) // Includes padding, end of line (padded)
     {
         pX = 0;
         sX = 0;
     } else {
         pX = pX + 1;
         // Update stride (threshold) ? subtract stride : increment stride
-        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1; 
+        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void pooling1d_buffer_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T> &res
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void pooling1d_buffer_cl(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
     assert(CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
-    
-    ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::n_in; i_iw++) {
+
+ReadInputWidth:
+    for (unsigned i_iw = 0; i_iw < CONFIG_T::n_in; i_iw++) {
         #pragma HLS LOOP_FLATTEN
         #pragma HLS PIPELINE
         compute_pool_buffer_1d<data_T, res_T, CONFIG_T>(data.read(), res);
     }
 }
 
-
-template<class data_T, class res_T, typename CONFIG_T>
-void pooling1d_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T> &res
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void pooling1d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
     #pragma HLS inline region
-    switch(CONFIG_T::implementation){
-        case conv_implementation::linebuffer:
-            pooling1d_buffer_cl<data_T, res_T, CONFIG_T>(data, res);
-            break;
-        case conv_implementation::encoded:
-            pooling1d_encoded_cl<data_T, res_T, CONFIG_T>(data, res);
-            break;
-    } 
+    switch (CONFIG_T::implementation) {
+    case conv_implementation::linebuffer:
+        pooling1d_buffer_cl<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    case conv_implementation::encoded:
+        pooling1d_encoded_cl<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    }
 }
-
 
 // *************************************************
 //       Global max/average pooling
 // *************************************************
 
-template <class T, int N, class CONFIG_T>
-T reduce_global_pool(T x, T y[N]) {
+template <class T, int N, class CONFIG_T> T reduce_global_pool(T x, T y[N])
+{
     #pragma HLS INLINE
     if (CONFIG_T::pool_op == Max) {
         Op_max<T> op_max;
-        T y_max = reduce<T, N, Op_max<T>>(y, op_max);
+        T y_max = reduce<T, N, Op_max<T> >(y, op_max);
         return (x > y_max) ? x : y_max;
     } else {
         Op_add<T> op_add;
-        T y_sum = reduce<T, N, Op_add<T>>(y, op_add);
+        T y_sum = reduce<T, N, Op_add<T> >(y, op_add);
         return x + y_sum;
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void compute_global_pool(
-    const unsigned h_idx,
-    const unsigned w_idx,
-    const data_T& in_elem,
-    typename CONFIG_T::accum_t data_window[CONFIG_T::n_filt]
-) {
-    PoolFilt: for (unsigned c = 0; c < CONFIG_T::n_filt; c++) {
+template <class data_T, class res_T, typename CONFIG_T>
+void compute_global_pool(const unsigned h_idx, const unsigned w_idx, const data_T &in_elem,
+                         typename CONFIG_T::accum_t data_window[CONFIG_T::n_filt])
+{
+PoolFilt:
+    for (unsigned c = 0; c < CONFIG_T::n_filt; c++) {
         #pragma HLS UNROLL
 
         typename CONFIG_T::accum_t data_pack[data_T::size / CONFIG_T::n_filt];
-        #pragma HLS ARRAY_PARTITION variable=data_pack complete dim=0
+    #pragma HLS ARRAY_PARTITION variable=data_pack complete dim=0
 
-        PixelLoop: for (unsigned p = 0; p < data_T::size / CONFIG_T::n_filt; p++) {
+    PixelLoop:
+        for (unsigned p = 0; p < data_T::size / CONFIG_T::n_filt; p++) {
             #pragma HLS UNROLL
             data_pack[p] = in_elem[p * CONFIG_T::n_filt + c];
         }
-        data_window[c] = reduce_global_pool<typename CONFIG_T::accum_t, data_T::size / CONFIG_T::n_filt, CONFIG_T>(data_window[c], data_pack);
+        data_window[c] = reduce_global_pool<typename CONFIG_T::accum_t, data_T::size / CONFIG_T::n_filt, CONFIG_T>(
+            data_window[c], data_pack);
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void global_pooling2d_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T> &res
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void global_pooling2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
     assert(CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
     assert(CONFIG_T::pool_height == CONFIG_T::stride_height && CONFIG_T::pool_width == CONFIG_T::stride_width);
 
@@ -508,46 +525,51 @@ void global_pooling2d_cl(
         init = hls::numeric_limits<typename CONFIG_T::accum_t>::min();
     }
 
-    PoolInitLoop: for (unsigned i_init = 0; i_init < CONFIG_T::n_filt; i_init++) {
+PoolInitLoop:
+    for (unsigned i_init = 0; i_init < CONFIG_T::n_filt; i_init++) {
         #pragma HLS UNROLL
         data_window[i_init] = init;
     }
 
-    ReadInputHeight: for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
-        ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_filt); i_iw++) {
+ReadInputHeight:
+    for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
+    ReadInputWidth:
+        for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_filt); i_iw++) {
             #pragma HLS LOOP_FLATTEN
             compute_global_pool<data_T, res_T, CONFIG_T>(i_ih, i_iw, data.read(), data_window);
         }
     }
 
     if (CONFIG_T::pool_op == Max) {
-        MaxPoolRes: for (unsigned i_res = 0; i_res < CONFIG_T::n_filt / res_T::size; i_res++) {
+    MaxPoolRes:
+        for (unsigned i_res = 0; i_res < CONFIG_T::n_filt / res_T::size; i_res++) {
             #pragma HLS PIPELINE
 
             res_T res_pack;
-            #pragma HLS DATA_PACK variable=res_pack
-            MaxPoolPack: for (unsigned i_pack = 0; i_pack < res_T::size; i_pack++) {
+        #pragma HLS DATA_PACK variable=res_pack
+        MaxPoolPack:
+            for (unsigned i_pack = 0; i_pack < res_T::size; i_pack++) {
                 #pragma HLS UNROLL
                 res_pack[i_pack] = data_window[i_pack];
             }
             res.write(res_pack);
         }
     } else {
-        AvgPoolRes: for (unsigned i_res = 0; i_res < CONFIG_T::n_filt / res_T::size; i_res++) {
+    AvgPoolRes:
+        for (unsigned i_res = 0; i_res < CONFIG_T::n_filt / res_T::size; i_res++) {
             #pragma HLS PIPELINE
 
             res_T res_pack;
-            #pragma HLS DATA_PACK variable=res_pack
-            AvgPoolPack: for (unsigned i_pack = 0; i_pack < res_T::size; i_pack++) {
+        #pragma HLS DATA_PACK variable=res_pack
+        AvgPoolPack:
+            for (unsigned i_pack = 0; i_pack < res_T::size; i_pack++) {
                 #pragma HLS UNROLL
                 res_pack[i_pack] = data_window[i_pack] / (CONFIG_T::in_height * CONFIG_T::in_width);
             }
             res.write(res_pack);
         }
     }
-
 }
-
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_sepconv1d_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_sepconv1d_stream.h
@@ -8,12 +8,10 @@
 
 namespace nnet {
 
-template<class data_T, class res_T, typename CONFIG_T>
-void depthwise_conv_1d_encoded_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_chan])
+template <class data_T, class res_T, typename CONFIG_T>
+void depthwise_conv_1d_encoded_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                                  typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan],
+                                  typename CONFIG_T::bias_t biases[CONFIG_T::n_chan])
 {
     assert(CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
 
@@ -30,28 +28,29 @@ void depthwise_conv_1d_encoded_cl(
     unsigned outputs_ready = 0;
 
     ap_uint<CONFIG_T::filt_width> pixel_idx[data_T::size / CONFIG_T::n_chan];
-    #pragma HLS ARRAY_PARTITION variable=pixel_idx complete
+#pragma HLS ARRAY_PARTITION variable=pixel_idx complete
 
-    ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_chan); i_iw++) {
+ReadInputWidth:
+    for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_chan); i_iw++) {
         #pragma HLS LOOP_FLATTEN
         if (CONFIG_T::strategy == nnet::latency && data_T::size / CONFIG_T::n_chan == 1) {
             #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
         }
         compute_scaled_indices_1d<data_T, CONFIG_T>(i_iw, pixel_idx);
-        compute_depthwise_output_encoded<data_T, res_T, CONFIG_T>(data.read(), data_window, res, res_pack, outputs_ready, weights, biases, pixel_idx);
+        compute_depthwise_output_encoded<data_T, res_T, CONFIG_T>(data.read(), data_window, res, res_pack,
+                                                                  outputs_ready, weights, biases, pixel_idx);
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void depthwise_conv_1d_buffer_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
-    typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_chan])
+template <class data_T, class res_T, typename CONFIG_T>
+void depthwise_conv_1d_buffer_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                                 typename CONFIG_T::weight_t weights[CONFIG_T::filt_width * CONFIG_T::n_chan],
+                                 typename CONFIG_T::bias_t biases[CONFIG_T::n_chan])
 {
     assert(CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
 
-    ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width; i_iw++) {
+ReadInputWidth:
+    for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width; i_iw++) {
         #pragma HLS LOOP_FLATTEN
         if (CONFIG_T::strategy == nnet::latency) {
             #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
@@ -60,20 +59,19 @@ void depthwise_conv_1d_buffer_cl(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void pointwise_conv_1d_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void pointwise_conv_1d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                          typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
+                          typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     assert(CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
     assert(CONFIG_T::filt_width == 1);
 
-    #pragma HLS ARRAY_PARTITION variable=weights complete
-    #pragma HLS ARRAY_PARTITION variable=biases complete
+#pragma HLS ARRAY_PARTITION variable=weights complete
+#pragma HLS ARRAY_PARTITION variable=biases complete
 
-    ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_chan); i_iw++) {
+ReadInputWidth:
+    for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_chan); i_iw++) {
         if (CONFIG_T::strategy == nnet::latency && data_T::size / CONFIG_T::n_chan == 1) {
             #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
         }
@@ -85,32 +83,34 @@ void pointwise_conv_1d_cl(
     }
 }
 
-
-template<class data_T, class res_T, typename CONFIG_T>
-void separable_conv_1d_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
-    typename CONFIG_T::depthwise_config::weight_t depthwise_weights[CONFIG_T::depthwise_config::filt_width * CONFIG_T::depthwise_config::n_chan],
-    typename CONFIG_T::pointwise_config::weight_t pointwise_weights[CONFIG_T::pointwise_config::n_chan * CONFIG_T::pointwise_config::n_filt],
-    typename CONFIG_T::depthwise_config::bias_t   depthwise_biases[CONFIG_T::depthwise_config::n_chan],
-    typename CONFIG_T::pointwise_config::bias_t   pointwise_biases[CONFIG_T::pointwise_config::n_filt]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void
+separable_conv_1d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                     typename CONFIG_T::depthwise_config::weight_t depthwise_weights
+                         [CONFIG_T::depthwise_config::filt_width * CONFIG_T::depthwise_config::n_chan],
+                     typename CONFIG_T::pointwise_config::weight_t pointwise_weights
+                         [CONFIG_T::pointwise_config::n_chan * CONFIG_T::pointwise_config::n_filt],
+                     typename CONFIG_T::depthwise_config::bias_t depthwise_biases[CONFIG_T::depthwise_config::n_chan],
+                     typename CONFIG_T::pointwise_config::bias_t pointwise_biases[CONFIG_T::pointwise_config::n_filt])
+{
     #pragma HLS DATAFLOW
 
     hls::stream<data_T> depthwise_res;
     unsigned res_depth = CONFIG_T::depthwise_config::out_width;
     #pragma HLS STREAM variable=depthwise_res depth=res_depth
 
-    switch(CONFIG_T::depthwise_config::implementation){
-        case conv_implementation::linebuffer:
-            depthwise_conv_1d_buffer_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(data, depthwise_res, depthwise_weights, depthwise_biases);
-            break;
-        case conv_implementation::encoded:
-            depthwise_conv_1d_encoded_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(data, depthwise_res, depthwise_weights, depthwise_biases);
-            break;
-    } 
-    pointwise_conv_1d_cl<data_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights, pointwise_biases);
+    switch (CONFIG_T::depthwise_config::implementation) {
+    case conv_implementation::linebuffer:
+        depthwise_conv_1d_buffer_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(
+            data, depthwise_res, depthwise_weights, depthwise_biases);
+        break;
+    case conv_implementation::encoded:
+        depthwise_conv_1d_encoded_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(
+            data, depthwise_res, depthwise_weights, depthwise_biases);
+        break;
+    }
+    pointwise_conv_1d_cl<data_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights,
+                                                                             pointwise_biases);
 }
-
 }
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_sepconv2d_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_sepconv2d_stream.h
@@ -8,17 +8,17 @@
 
 namespace nnet {
 
-template<class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class res_T, typename CONFIG_T>
 void depthwise_conv_2d_encoded_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
+    hls::stream<data_T> &data, hls::stream<res_T> &res,
     typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_chan])
+    typename CONFIG_T::bias_t biases[CONFIG_T::n_chan])
 {
     assert(CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
     assert(CONFIG_T::filt_height == CONFIG_T::filt_width);
 
-    hls::stream<typename data_T::value_type> data_window[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan];
+    hls::stream<typename data_T::value_type> data_window
+        [CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan];
     const int win_depth = CONFIG_T::filt_height * CONFIG_T::out_width;
     for (unsigned i_out = 0; i_out < CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan; i_out++) {
         #pragma HLS STREAM variable=data_window[i_out] depth=win_depth
@@ -30,42 +30,48 @@ void depthwise_conv_2d_encoded_cl(
     #pragma HLS DATA_PACK variable=res_pack
     unsigned outputs_ready = 0;
 
-    ap_uint<CONFIG_T::filt_height * CONFIG_T::filt_width> pixel_idx[data_T::size / CONFIG_T::n_chan];
-    #pragma HLS ARRAY_PARTITION variable=pixel_idx complete
+    ap_uint<CONFIG_T::filt_height *CONFIG_T::filt_width> pixel_idx[data_T::size / CONFIG_T::n_chan];
+#pragma HLS ARRAY_PARTITION variable=pixel_idx complete
 
-    ReadInputHeight: for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
-        ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_chan); i_iw++) {
+ReadInputHeight:
+    for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
+    ReadInputWidth:
+        for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_chan); i_iw++) {
             #pragma HLS LOOP_FLATTEN
             if (CONFIG_T::strategy == nnet::latency && data_T::size / CONFIG_T::n_chan == 1) {
                 #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
             }
             compute_scaled_indices_2d<data_T, CONFIG_T>(i_ih, i_iw, pixel_idx);
-            compute_depthwise_output_encoded<data_T, res_T, CONFIG_T>(data.read(), data_window, res, res_pack, outputs_ready, weights, biases, pixel_idx);
+            compute_depthwise_output_encoded<data_T, res_T, CONFIG_T>(data.read(), data_window, res, res_pack,
+                                                                      outputs_ready, weights, biases, pixel_idx);
         }
     }
 }
 
 // Line Buffer Implementation (Phil's)
-template<class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class res_T, typename CONFIG_T>
 void depthwise_conv_2d_buffer_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
+    hls::stream<data_T> &data, hls::stream<res_T> &res,
     typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_chan])
+    typename CONFIG_T::bias_t biases[CONFIG_T::n_chan])
 {
     assert(CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
 
-    static ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[CONFIG_T::filt_height - 1][CONFIG_T::n_chan];
-    #pragma HLS ARRAY_PARTITION variable = line_buffer complete dim = 2
+    static ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[CONFIG_T::filt_height - 1]
+                                                                                    [CONFIG_T::n_chan];
+#pragma HLS ARRAY_PARTITION variable = line_buffer complete dim = 2
 
-    ReadInputHeight: for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
-        ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width; i_iw++) {
+ReadInputHeight:
+    for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
+    ReadInputWidth:
+        for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width; i_iw++) {
             #pragma HLS LOOP_FLATTEN
             if (CONFIG_T::strategy == nnet::latency) {
                 #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
             }
             if (CONFIG_T::filt_height > 1) {
-                compute_depthwise_output_buffer_2d<data_T, res_T, CONFIG_T>(data.read(), line_buffer, res, weights, biases);
+                compute_depthwise_output_buffer_2d<data_T, res_T, CONFIG_T>(data.read(), line_buffer, res, weights,
+                                                                            biases);
             } else {
                 compute_depthwise_output_buffer_1d<data_T, res_T, CONFIG_T>(data.read(), res, weights, biases);
             }
@@ -73,22 +79,21 @@ void depthwise_conv_2d_buffer_cl(
     }
 }
 
-
-template<class data_T, class res_T, typename CONFIG_T>
-void pointwise_conv_2d_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+template <class data_T, class res_T, typename CONFIG_T>
+void pointwise_conv_2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                          typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
+                          typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
 {
     assert(CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0);
     assert(CONFIG_T::filt_height == 1 && CONFIG_T::filt_width == 1);
 
-    #pragma HLS ARRAY_PARTITION variable=weights complete
-    #pragma HLS ARRAY_PARTITION variable=biases complete
+#pragma HLS ARRAY_PARTITION variable=weights complete
+#pragma HLS ARRAY_PARTITION variable=biases complete
 
-    ReadInputHeight: for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
-        ReadInputWidth: for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_chan); i_iw++) {
+ReadInputHeight:
+    for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
+    ReadInputWidth:
+        for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width / (data_T::size / CONFIG_T::n_chan); i_iw++) {
             if (CONFIG_T::strategy == nnet::latency && data_T::size / CONFIG_T::n_chan == 1) {
                 #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
             }
@@ -101,32 +106,36 @@ void pointwise_conv_2d_cl(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void separable_conv_2d_cl(
-    hls::stream<data_T> &data,
-    hls::stream<res_T>  &res,
-    typename CONFIG_T::depthwise_config::weight_t depthwise_weights[CONFIG_T::depthwise_config::filt_height * CONFIG_T::depthwise_config::filt_width * CONFIG_T::depthwise_config::n_chan],
-    typename CONFIG_T::pointwise_config::weight_t pointwise_weights[CONFIG_T::pointwise_config::n_chan * CONFIG_T::pointwise_config::n_filt],
-    typename CONFIG_T::depthwise_config::bias_t   depthwise_biases[CONFIG_T::depthwise_config::n_chan],
-    typename CONFIG_T::pointwise_config::bias_t   pointwise_biases[CONFIG_T::pointwise_config::n_filt]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void
+separable_conv_2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                     typename CONFIG_T::depthwise_config::weight_t depthwise_weights
+                         [CONFIG_T::depthwise_config::filt_height * CONFIG_T::depthwise_config::filt_width *
+                          CONFIG_T::depthwise_config::n_chan],
+                     typename CONFIG_T::pointwise_config::weight_t pointwise_weights
+                         [CONFIG_T::pointwise_config::n_chan * CONFIG_T::pointwise_config::n_filt],
+                     typename CONFIG_T::depthwise_config::bias_t depthwise_biases[CONFIG_T::depthwise_config::n_chan],
+                     typename CONFIG_T::pointwise_config::bias_t pointwise_biases[CONFIG_T::pointwise_config::n_filt])
+{
     #pragma HLS DATAFLOW
 
     hls::stream<data_T> depthwise_res;
     unsigned res_depth = CONFIG_T::depthwise_config::out_height * CONFIG_T::depthwise_config::out_width;
     #pragma HLS STREAM variable=depthwise_res depth=res_depth
 
-    switch(CONFIG_T::depthwise_config::implementation){
-        case conv_implementation::linebuffer:
-            depthwise_conv_2d_buffer_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(data, depthwise_res, depthwise_weights, depthwise_biases);
-            break;
-        case conv_implementation::encoded:
-            depthwise_conv_2d_encoded_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(data, depthwise_res, depthwise_weights, depthwise_biases);
-            break;
-    } 
+    switch (CONFIG_T::depthwise_config::implementation) {
+    case conv_implementation::linebuffer:
+        depthwise_conv_2d_buffer_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(
+            data, depthwise_res, depthwise_weights, depthwise_biases);
+        break;
+    case conv_implementation::encoded:
+        depthwise_conv_2d_encoded_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(
+            data, depthwise_res, depthwise_weights, depthwise_biases);
+        break;
+    }
 
-    pointwise_conv_2d_cl<data_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights, pointwise_biases);
+    pointwise_conv_2d_cl<data_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights,
+                                                                             pointwise_biases);
 }
-
 }
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_sepconv_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_sepconv_stream.h
@@ -7,13 +7,11 @@
 
 namespace nnet {
 
-template<class data_T, class res_T, typename CONFIG_T>
-void depthwise_product(
-    data_T    data[CONFIG_T::kernel_size * CONFIG_T::n_chan],
-    res_T     res[CONFIG_T::n_chan],
-    typename CONFIG_T::weight_t  weights[CONFIG_T::kernel_size * CONFIG_T::n_chan],
-    typename CONFIG_T::bias_t biases[CONFIG_T::n_chan]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void depthwise_product(data_T data[CONFIG_T::kernel_size * CONFIG_T::n_chan], res_T res[CONFIG_T::n_chan],
+                       typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan],
+                       typename CONFIG_T::bias_t biases[CONFIG_T::n_chan])
+{
     #pragma HLS INLINE
 
     typename CONFIG_T::accum_t mult[CONFIG_T::kernel_size * CONFIG_T::n_chan];
@@ -26,65 +24,76 @@ void depthwise_product(
 
     #pragma HLS ARRAY_PARTITION variable=mult complete
 
-    int multiplier_limit  = ceil(float(CONFIG_T::kernel_size * CONFIG_T::n_chan) / float(CONFIG_T::reuse_factor)) - floor(float(CONFIG_T::n_zeros) / float(CONFIG_T::reuse_factor));
-    CONFIG_T::mult_config::template product<data_T, typename CONFIG_T::mult_config::weight_t, typename CONFIG_T::mult_config::accum_t>::limit(multiplier_limit);
+    int multiplier_limit = ceil(float(CONFIG_T::kernel_size * CONFIG_T::n_chan) / float(CONFIG_T::reuse_factor)) -
+                           floor(float(CONFIG_T::n_zeros) / float(CONFIG_T::reuse_factor));
+    CONFIG_T::mult_config::template product<data_T, typename CONFIG_T::mult_config::weight_t,
+                                            typename CONFIG_T::mult_config::accum_t>::limit(multiplier_limit);
 
-    // Do the matrix-multiply
-    Product: for(int ii = 0; ii < CONFIG_T::kernel_size * CONFIG_T::n_chan; ii++) {
+// Do the matrix-multiply
+Product:
+    for (int ii = 0; ii < CONFIG_T::kernel_size * CONFIG_T::n_chan; ii++) {
         #pragma HLS UNROLL
-        mult[ii] = CONFIG_T::mult_config::template product<data_T, typename CONFIG_T::mult_config::weight_t, typename CONFIG_T::mult_config::accum_t>::product(data[ii], weights[ii]);
+        mult[ii] =
+            CONFIG_T::mult_config::template product<data_T, typename CONFIG_T::mult_config::weight_t,
+                                                    typename CONFIG_T::mult_config::accum_t>::product(data[ii],
+                                                                                                      weights[ii]);
     }
 
-    // Initialize accumulator with input biases
-    ResetAccum: for(int iacc = 0; iacc < CONFIG_T::n_chan; iacc++) {
+// Initialize accumulator with input biases
+ResetAccum:
+    for (int iacc = 0; iacc < CONFIG_T::n_chan; iacc++) {
         #pragma HLS UNROLL
-        acc[iacc] = (typename CONFIG_T::accum_t) biases[iacc];
+        acc[iacc] = (typename CONFIG_T::accum_t)biases[iacc];
     }
 
-    // Accumulate multiplication result
-    Accum1: for(int ii = 0; ii < CONFIG_T::kernel_size; ii++) {
-        Accum2: for(int jj = 0; jj < CONFIG_T::n_chan; jj++) {
+// Accumulate multiplication result
+Accum1:
+    for (int ii = 0; ii < CONFIG_T::kernel_size; ii++) {
+    Accum2:
+        for (int jj = 0; jj < CONFIG_T::n_chan; jj++) {
             int index = ii * CONFIG_T::n_chan + jj;
             acc[jj] += mult[index];
         }
     }
 
-    // Cast to "res_t" type
-    Result: for(int ires = 0; ires < CONFIG_T::n_chan; ires++){
+// Cast to "res_t" type
+Result:
+    for (int ires = 0; ires < CONFIG_T::n_chan; ires++) {
         #pragma HLS UNROLL
         res[ires] = cast<data_T, res_T, CONFIG_T>(acc[ires]);
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void depthwise_mult_buffer(
-    hls::stream<typename data_T::value_type> data_window[CONFIG_T::kernel_size * CONFIG_T::n_chan],
-    res_T& res_pack,
-    hls::stream<res_T>& res_stream,
-    unsigned & outputs_ready,
-    typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan],
-    typename CONFIG_T::bias_t biases[CONFIG_T::n_chan]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void
+depthwise_mult_buffer(hls::stream<typename data_T::value_type> data_window[CONFIG_T::kernel_size * CONFIG_T::n_chan],
+                      res_T &res_pack, hls::stream<res_T> &res_stream, unsigned &outputs_ready,
+                      typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan],
+                      typename CONFIG_T::bias_t biases[CONFIG_T::n_chan])
+{
     #pragma HLS INLINE
 
     typename data_T::value_type data[CONFIG_T::kernel_size * CONFIG_T::n_chan];
     #pragma HLS ARRAY_PARTITION variable=data complete
     typename res_T::value_type res[CONFIG_T::n_chan];
-    #pragma HLS ARRAY_PARTITION variable=res complete
+#pragma HLS ARRAY_PARTITION variable=res complete
 
-    InitData: for (int id = 0; id < CONFIG_T::kernel_size * CONFIG_T::n_chan; id++) {
+InitData:
+    for (int id = 0; id < CONFIG_T::kernel_size * CONFIG_T::n_chan; id++) {
         #pragma HLS UNROLL
         data[id] = data_window[id].read();
     }
 
     #pragma HLS INLINE region
     if (CONFIG_T::strategy == nnet::latency) {
-        depthwise_product<typename data_T::value_type, typename res_T::value_type, CONFIG_T>(data, res, weights, biases);
+        depthwise_product<typename data_T::value_type, typename res_T::value_type, CONFIG_T>(data, res, weights,
+                                                                                             biases);
     } else {
         assert("Resource strategy for DepthwiseConv2D is not supported." && false);
     }
 
-    CastLoop: for (unsigned jj = 0; jj < CONFIG_T::n_chan; jj++) {
+CastLoop:
+    for (unsigned jj = 0; jj < CONFIG_T::n_chan; jj++) {
         #pragma HLS UNROLL
         if (res_T::size / CONFIG_T::n_chan == 1) {
             res_pack[jj] = res[jj];
@@ -105,26 +114,27 @@ void depthwise_mult_buffer(
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class res_T, typename CONFIG_T>
 void compute_depthwise_output_encoded(
-    const data_T& in_elem,
+    const data_T &in_elem,
     hls::stream<typename data_T::value_type> data_window[CONFIG_T::kernel_size * CONFIG_T::n_chan],
-    hls::stream<res_T> &res,
-    res_T &res_pack,
-    unsigned &outputs_ready,
+    hls::stream<res_T> &res, res_T &res_pack, unsigned &outputs_ready,
     typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan],
-    typename CONFIG_T::bias_t biases[CONFIG_T::n_chan],
-    ap_uint<CONFIG_T::kernel_size> *pixel_idx
-) {
-    #pragma HLS INLINE
+    typename CONFIG_T::bias_t biases[CONFIG_T::n_chan], ap_uint<CONFIG_T::kernel_size> *pixel_idx)
+{
+#pragma HLS INLINE
 
-    MultLoop: for (unsigned p = 0; p < data_T::size / CONFIG_T::n_chan; p++) {
-        #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
-        CopyDataFilt: for (unsigned f = 0; f < CONFIG_T::kernel_size; f++) {
-            #pragma HLS UNROLL
-            CopyDataChan: for (unsigned c = 0; c < CONFIG_T::n_chan; c++) {
+MultLoop:
+    for (unsigned p = 0; p < data_T::size / CONFIG_T::n_chan; p++) {
+    #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
+    CopyDataFilt:
+        for (unsigned f = 0; f < CONFIG_T::kernel_size; f++) {
+        #pragma HLS UNROLL
+        CopyDataChan:
+            for (unsigned c = 0; c < CONFIG_T::n_chan; c++) {
                 #pragma HLS UNROLL
-                if (pixel_idx[p][f]) data_window[f * CONFIG_T::n_chan + c].write(in_elem[p * CONFIG_T::n_chan + c]);
+                if (pixel_idx[p][f])
+                    data_window[f * CONFIG_T::n_chan + c].write(in_elem[p * CONFIG_T::n_chan + c]);
             }
         }
         if (pixel_idx[p][CONFIG_T::kernel_size - 1]) {
@@ -133,14 +143,11 @@ void compute_depthwise_output_encoded(
     }
 }
 
-
-template<class data_T, class res_T, typename CONFIG_T>
-void pointwise_mult_buffer(
-    const data_T &data_pack,
-    hls::stream<res_T> &res_stream,
-    typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
-    typename CONFIG_T::bias_t biases[CONFIG_T::n_filt]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void pointwise_mult_buffer(const data_T &data_pack, hls::stream<res_T> &res_stream,
+                           typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
+                           typename CONFIG_T::bias_t biases[CONFIG_T::n_filt])
+{
     #pragma HLS INLINE
 
     typename data_T::value_type data[CONFIG_T::n_chan];
@@ -150,21 +157,25 @@ void pointwise_mult_buffer(
     #pragma HLS ARRAY_PARTITION variable=res complete
 
     res_T res_pack;
-    #pragma HLS DATA_PACK variable=res_pack
+#pragma HLS DATA_PACK variable=res_pack
 
-    InitData: for (int id = 0; id < CONFIG_T::n_chan; id++) {
+InitData:
+    for (int id = 0; id < CONFIG_T::n_chan; id++) {
         #pragma HLS UNROLL
         data[id] = data_pack[id];
     }
 
     #pragma HLS INLINE region
     if (CONFIG_T::strategy == nnet::latency) {
-        dense_latency<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(data, res, weights, biases);
+        dense_latency<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(
+            data, res, weights, biases);
     } else {
-        dense_resource<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(data, res, weights, biases);
+        dense_resource<typename data_T::value_type, typename res_T::value_type, typename CONFIG_T::mult_config>(
+            data, res, weights, biases);
     }
 
-    CastLoop: for (unsigned jj = 0; jj < CONFIG_T::n_filt; jj++) {
+CastLoop:
+    for (unsigned jj = 0; jj < CONFIG_T::n_filt; jj++) {
         #pragma HLS UNROLL
         res_pack[jj] = res[jj];
     }
@@ -173,13 +184,11 @@ void pointwise_mult_buffer(
 }
 
 // Line Buffer Implementation (Phil's)
-template<class data_T, class res_T, typename CONFIG_T>
-void compute_depthwise_output_buffer_1d(
-    const data_T& in_elem,
-    hls::stream<res_T> &res_stream,
-    typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan],
-    typename CONFIG_T::bias_t biases[CONFIG_T::n_chan]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void compute_depthwise_output_buffer_1d(const data_T &in_elem, hls::stream<res_T> &res_stream,
+                                        typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan],
+                                        typename CONFIG_T::bias_t biases[CONFIG_T::n_chan])
+{
     #pragma HLS INLINE
 
     // Thresholds
@@ -202,44 +211,46 @@ void compute_depthwise_output_buffer_1d(
     nnet::kernel_shift_1d<data_T, CONFIG_T>(in_elem, kernel_data);
 
     // Check to see if we have a full kernel
-    if ((sX - lShiftX) == 0 && pX > lShiftX - 1) { 
-      // Dense multiply
-      #pragma HLS INLINE region
-      if (CONFIG_T::strategy == nnet::latency) {
-        depthwise_product<typename data_T::value_type, typename res_T::value_type, CONFIG_T>(kernel_data, res_out, weights, biases);
-      } else {
-        assert("Resource strategy for DepthwiseConv1D is not supported." && false);
-      }
+    if ((sX - lShiftX) == 0 && pX > lShiftX - 1) {
+        // Dense multiply
+        #pragma HLS INLINE region
+        if (CONFIG_T::strategy == nnet::latency) {
+            depthwise_product<typename data_T::value_type, typename res_T::value_type, CONFIG_T>(kernel_data, res_out,
+                                                                                                 weights, biases);
+        } else {
+            assert("Resource strategy for DepthwiseConv1D is not supported." && false);
+        }
 
-      // Pack output
-      CastLoop: for (unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
-          #pragma HLS UNROLL
-          res_pack[i_ic] = res_out[i_ic];
-      }
+    // Pack output
+    CastLoop:
+        for (unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
+            #pragma HLS UNROLL
+            res_pack[i_ic] = res_out[i_ic];
+        }
 
-      // Write output to stream when output ready
-      res_stream.write(res_pack);
+        // Write output to stream when output ready
+        res_stream.write(res_pack);
     }
 
     // Pointer Housekeeping
-    if (pX + 1 == CONFIG_T::in_width)  // Includes padding, end of line (padded)
+    if (pX + 1 == CONFIG_T::in_width) // Includes padding, end of line (padded)
     {
         pX = 0;
         sX = 0;
     } else {
         pX = pX + 1;
-        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1; 
+        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1;
     }
-  }
+}
 
-template<class data_T, class res_T, typename CONFIG_T>
-void compute_depthwise_output_buffer_2d(
-    const data_T& in_elem,
-    ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[MAX(CONFIG_T::filt_height - 1,1)][CONFIG_T::n_chan],
-    hls::stream<res_T> &res_stream,
-    typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan],
-    typename CONFIG_T::bias_t biases[CONFIG_T::n_chan]
-) {
+template <class data_T, class res_T, typename CONFIG_T>
+void compute_depthwise_output_buffer_2d(const data_T &in_elem,
+                                        ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer
+                                            [MAX(CONFIG_T::filt_height - 1, 1)][CONFIG_T::n_chan],
+                                        hls::stream<res_T> &res_stream,
+                                        typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan],
+                                        typename CONFIG_T::bias_t biases[CONFIG_T::n_chan])
+{
     #pragma HLS INLINE
 
     // Thresholds
@@ -266,42 +277,43 @@ void compute_depthwise_output_buffer_2d(
     nnet::shift_line_buffer<data_T, CONFIG_T>(in_elem, line_buffer, kernel_data);
 
     // Check to see if we have a full kernel
-    if ((sX - lShiftX) == 0 && (sY - lShiftY) == 0 && pY > lShiftY - 1 && pX > lShiftX - 1) { 
-      // Dense multiply
-      #pragma HLS INLINE region
-      if (CONFIG_T::strategy == nnet::latency) {
-        depthwise_product<typename data_T::value_type, typename res_T::value_type, CONFIG_T>(kernel_data, res_out, weights, biases);
-      } else {
-        assert("Resource strategy for DepthwiseConv2D is not supported." && false);
-      }
+    if ((sX - lShiftX) == 0 && (sY - lShiftY) == 0 && pY > lShiftY - 1 && pX > lShiftX - 1) {
+        // Dense multiply
+        #pragma HLS INLINE region
+        if (CONFIG_T::strategy == nnet::latency) {
+            depthwise_product<typename data_T::value_type, typename res_T::value_type, CONFIG_T>(kernel_data, res_out,
+                                                                                                 weights, biases);
+        } else {
+            assert("Resource strategy for DepthwiseConv2D is not supported." && false);
+        }
 
-      // Pack output
-      CastLoop: for (unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
-          #pragma HLS UNROLL
-          res_pack[i_ic] = res_out[i_ic];
-      }
+    // Pack output
+    CastLoop:
+        for (unsigned i_ic = 0; i_ic < CONFIG_T::n_filt; i_ic++) {
+            #pragma HLS UNROLL
+            res_pack[i_ic] = res_out[i_ic];
+        }
 
-      // Write output to stream when output ready
-      res_stream.write(res_pack);
+        // Write output to stream when output ready
+        res_stream.write(res_pack);
     }
 
     // Pointer Housekeeping
-    if (pX + 1 == CONFIG_T::in_width)  // Includes padding, end of line (padded)
+    if (pX + 1 == CONFIG_T::in_width) // Includes padding, end of line (padded)
     {
         pX = 0;
         sX = 0;
-        if (pY + 1 == CONFIG_T::in_height) {  // Reached bottom of image
+        if (pY + 1 == CONFIG_T::in_height) { // Reached bottom of image
             pY = 0;
             sY = 0;
         } else {
             pY = pY + 1;
-            sY = ((sY - lShiftY) == 0) ? sY - CONFIG_T::stride_height + 1 : sY + 1; 
+            sY = ((sY - lShiftY) == 0) ? sY - CONFIG_T::stride_height + 1 : sY + 1;
         }
     } else {
         pX = pX + 1;
-        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1; 
+        sX = ((sX - lShiftX) == 0) ? sX - CONFIG_T::stride_width + 1 : sX + 1;
     }
-  }
-
+}
 }
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_stream.h
@@ -6,26 +6,28 @@
 
 namespace nnet {
 
-struct broadcast_config
-{
-  static const unsigned in_height = 10;
-  static const unsigned in_width = 10;
-  static const unsigned n_chan = 1;
-  static const unsigned n_dupl = 2;
+struct broadcast_config {
+    static const unsigned in_height = 10;
+    static const unsigned in_width = 10;
+    static const unsigned n_chan = 1;
+    static const unsigned n_dupl = 2;
 };
 
-template<class data_T, class res_T, int N>
-void clone_stream(hls::stream<data_T> &data, hls::stream<res_T> &res1, hls::stream<res_T> &res2) {
-    CloneLoop: for (int i = 0; i < N / data_T::size; i++) {
+template <class data_T, class res_T, int N>
+void clone_stream(hls::stream<data_T> &data, hls::stream<res_T> &res1, hls::stream<res_T> &res2)
+{
+CloneLoop:
+    for (int i = 0; i < N / data_T::size; i++) {
         #pragma HLS PIPELINE
 
         data_T in_data = data.read();
         res_T out_data1;
         res_T out_data2;
-        #pragma HLS DATA_PACK variable=out_data1
-        #pragma HLS DATA_PACK variable=out_data2
+    #pragma HLS DATA_PACK variable=out_data1
+    #pragma HLS DATA_PACK variable=out_data2
 
-        ClonePack: for (int j = 0; j < data_T::size; j++) {
+    ClonePack:
+        for (int j = 0; j < data_T::size; j++) {
             #pragma HLS UNROLL
             out_data1[j] = in_data[j];
             out_data2[j] = in_data[j];
@@ -36,8 +38,8 @@ void clone_stream(hls::stream<data_T> &data, hls::stream<res_T> &res1, hls::stre
     }
 }
 
-template<class data_T, class res_T, int N>
-void repack_stream(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+template <class data_T, class res_T, int N> void repack_stream(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
     if (data_T::size == res_T::size) {
         for (int i = 0; i < N / data_T::size; i++) {
             #pragma HLS PIPELINE
@@ -98,9 +100,11 @@ void repack_stream(hls::stream<data_T> &data, hls::stream<res_T> &res) {
     }
 }
 
-template<class data_T, class res_T, typename CONFIG_T>
-void broadcast_stream(hls::stream<data_T> &data, hls::stream<res_T> &res) {
-    BroadcastLoop: for (int i = 0; i < CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan / data_T::size; i++) {
+template <class data_T, class res_T, typename CONFIG_T>
+void broadcast_stream(hls::stream<data_T> &data, hls::stream<res_T> &res)
+{
+BroadcastLoop:
+    for (int i = 0; i < CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan / data_T::size; i++) {
         #pragma HLS PIPELINE
         data_T in_data = data.read();
         for (int j = 0; j < CONFIG_T::n_dupl; j++) {

--- a/hls4ml/templates/vivado/nnet_utils/nnet_types.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_types.h
@@ -6,35 +6,36 @@
 namespace nnet {
 
 // Fixed-size array
-template<typename T, unsigned N>
-struct array {
+template <typename T, unsigned N> struct array {
     typedef T value_type;
     static const unsigned size = N;
 
     T data[N];
 
-    T& operator[](size_t pos) {
-        return data[pos];
-    }
-    
-    const T& operator[](size_t pos) const {
+    T &operator[](size_t pos)
+    {
         return data[pos];
     }
 
-    array& operator=(const array &other) {
-        if(&other == this)
+    const T &operator[](size_t pos) const
+    {
+        return data[pos];
+    }
+
+    array &operator=(const array &other)
+    {
+        if (&other == this)
             return *this;
 
         assert(N == other.size && "Array sizes must match.");
-        
+
         for (unsigned i = 0; i < N; i++) {
             #pragma HLS UNROLL
             data[i] = other[i];
         }
         return *this;
-    }  
+    }
 };
-
 }
 
 #endif

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -346,7 +346,6 @@ const config{index}::sublayer_t<{il}>::output_transform_biases_t (&config{index}
 garnet_stack_config_template = (garnet_stack_base_config_template, garnet_stack_sublayer_config_template)
 
 
-
 dense_function_template = 'nnet::dense<{input_t}, {output_t}, {config}>({input}, {output}, {w}, {b});'
 batchnorm_function_template = 'nnet::normalize<{input_t}, {output_t}, {config}>({input}, {output}, {scale}, {bias});'
 conv1d_function_template = 'nnet::conv_1d_{data_format}<{input_t}, {output_t}, {config}>({input}, {output}, {w}, {b});'
@@ -382,36 +381,51 @@ resize_include_list = ['nnet_utils/nnet_image.h', 'nnet_utils/nnet_image_stream.
 transpose_include_list = ['nnet_utils/nnet_array.h']
 garnet_include_list = ['nnet_utils/nnet_garnet.h']
 
+
 class VivadoBackend(Backend):
     def __init__(self):
         super(VivadoBackend, self).__init__('Vivado')
         self.register_templates('Dense', dense_function_template, dense_config_template, dense_include_list)
-        self.register_templates('BinaryDense'            , dense_function_template,       dense_config_template, dense_include_list)
-        self.register_templates('BatchNormalization'     , batchnorm_function_template,   batchnorm_config_template, batchnorm_include_list)
-        self.register_templates('Conv1D'                 , conv1d_function_template,      [conv1d_config_template, conv_mult_config_template], conv1d_include_list)
-        self.register_templates('Conv2D'                 , conv2d_function_template,      [conv2d_config_template, conv_mult_config_template], conv2d_include_list)
-        self.register_templates('Conv2DBatchnorm'        , conv2d_function_template,      [conv2d_config_template, conv_mult_config_template], conv2d_include_list)
-        self.register_templates('SeparableConv1D'        , sepconv1d_function_template,   [sepconv_config_template, conv1d_config_template, conv1d_config_template, conv_mult_config_template, conv_mult_config_template], sepconv1d_include_list)
-        self.register_templates('SeparableConv2D'        , sepconv2d_function_template,   [sepconv_config_template, conv2d_config_template, conv2d_config_template, conv_mult_config_template, conv_mult_config_template], sepconv2d_include_list)
-        self.register_templates('DepthwiseConv2D'        , depthconv2d_function_template, [conv2d_config_template, conv_mult_config_template], sepconv2d_include_list)
-        self.register_templates('Activation'             , activ_function_template,       activ_config_template, activ_include_list)
-        self.register_templates('ParametrizedActivation' , param_activ_function_template, activ_config_template, activ_include_list)
-        self.register_templates('PReLU'                  , param_activ_function_template, activ_config_template, activ_include_list)
-        self.register_templates('Softmax'                , activ_function_template,       softmax_config_template, activ_include_list)
-        self.register_templates('Pooling1D'              , pooling1d_function_template,   pooling1d_config_template, pooling_include_list)
-        self.register_templates('Pooling2D'              , pooling2d_function_template,   pooling2d_config_template, pooling_include_list)
-        self.register_templates('GlobalPooling1D'        , global_pooling1d_function_template,   global_pooling1d_config_template, pooling_include_list)
-        self.register_templates('GlobalPooling2D'        , global_pooling2d_function_template,   global_pooling2d_config_template, pooling_include_list)
-        self.register_templates('ZeroPadding1D'          , zeropad1d_function_template,   zeropad1d_config_template, padding_include_list)
-        self.register_templates('ZeroPadding2D'          , zeropad2d_function_template,   zeropad2d_config_template, padding_include_list)
-        self.register_templates('Merge'                  , merge_function_template,       merge_config_template, merge_include_list)
-        self.register_templates('Concatenate'            , merge_function_template,       concat_config_template, merge_include_list)
-        self.register_templates('Dot'                    , merge_function_template,       dot_config_template, merge_include_list)
-        self.register_templates('Resize'                 , resize_function_template,      resize_config_template, resize_include_list)
-        self.register_templates('Transpose'              , transpose_function_template,   transpose_config_template, transpose_include_list)
-        self.register_templates('GarNet'                 , garnet_function_template,      garnet_config_template, garnet_include_list)
-        self.register_templates('GarNetStack'            , garnet_stack_function_template,garnet_stack_config_template, garnet_include_list)        
-    
+        self.register_templates('BinaryDense', dense_function_template,       dense_config_template, dense_include_list)
+        self.register_templates('BatchNormalization', batchnorm_function_template,   batchnorm_config_template, batchnorm_include_list)
+        self.register_templates('Conv1D', conv1d_function_template,      [conv1d_config_template, conv_mult_config_template], conv1d_include_list)
+        self.register_templates('Conv2D', conv2d_function_template,      [conv2d_config_template, conv_mult_config_template], conv2d_include_list)
+        self.register_templates('Conv2DBatchnorm', conv2d_function_template,      [conv2d_config_template, conv_mult_config_template], conv2d_include_list)
+        self.register_templates('SeparableConv1D',
+                                sepconv1d_function_template,
+                                [sepconv_config_template,
+                                 conv1d_config_template,
+                                 conv1d_config_template,
+                                 conv_mult_config_template,
+                                 conv_mult_config_template],
+                                sepconv1d_include_list)
+        self.register_templates('SeparableConv2D',
+                                sepconv2d_function_template,
+                                [sepconv_config_template,
+                                 conv2d_config_template,
+                                 conv2d_config_template,
+                                 conv_mult_config_template,
+                                 conv_mult_config_template],
+                                sepconv2d_include_list)
+        self.register_templates('DepthwiseConv2D', depthconv2d_function_template, [conv2d_config_template, conv_mult_config_template], sepconv2d_include_list)
+        self.register_templates('Activation', activ_function_template,       activ_config_template, activ_include_list)
+        self.register_templates('ParametrizedActivation', param_activ_function_template, activ_config_template, activ_include_list)
+        self.register_templates('PReLU', param_activ_function_template, activ_config_template, activ_include_list)
+        self.register_templates('Softmax', activ_function_template,       softmax_config_template, activ_include_list)
+        self.register_templates('Pooling1D', pooling1d_function_template,   pooling1d_config_template, pooling_include_list)
+        self.register_templates('Pooling2D', pooling2d_function_template,   pooling2d_config_template, pooling_include_list)
+        self.register_templates('GlobalPooling1D', global_pooling1d_function_template,   global_pooling1d_config_template, pooling_include_list)
+        self.register_templates('GlobalPooling2D', global_pooling2d_function_template,   global_pooling2d_config_template, pooling_include_list)
+        self.register_templates('ZeroPadding1D', zeropad1d_function_template,   zeropad1d_config_template, padding_include_list)
+        self.register_templates('ZeroPadding2D', zeropad2d_function_template,   zeropad2d_config_template, padding_include_list)
+        self.register_templates('Merge', merge_function_template,       merge_config_template, merge_include_list)
+        self.register_templates('Concatenate', merge_function_template,       concat_config_template, merge_include_list)
+        self.register_templates('Dot', merge_function_template,       dot_config_template, merge_include_list)
+        self.register_templates('Resize', resize_function_template,      resize_config_template, resize_include_list)
+        self.register_templates('Transpose', transpose_function_template,   transpose_config_template, transpose_include_list)
+        self.register_templates('GarNet', garnet_function_template,      garnet_config_template, garnet_include_list)
+        self.register_templates('GarNetStack', garnet_stack_function_template, garnet_stack_config_template, garnet_include_list)
+
     def get_valid_reuse_factors(self, layer):
         n_in = 0
         n_out = 0
@@ -453,7 +467,7 @@ class VivadoBackend(Backend):
 
     def get_closest_reuse_factor(self, valid_rf, chosen_rf):
         """
-        Returns closest value to chosen_rf. valid_rf is sorted (obtained from get_valid_reuse_factors()) 
+        Returns closest value to chosen_rf. valid_rf is sorted (obtained from get_valid_reuse_factors())
         If two numbers are equally close, return the smallest number.
         """
         pos = bisect_left(valid_rf, chosen_rf)
@@ -474,32 +488,31 @@ class VivadoBackend(Backend):
         if chosen_rf not in valid_rf:
             closest_rf = self.get_closest_reuse_factor(valid_rf, chosen_rf)
             print('WARNING: Invalid ReuseFactor={} with "Resource" strategy in layer "{}". Using ReuseFactor={} instead. Valid ReuseFactor(s): {}.'
-                .format(chosen_rf, layer.name, closest_rf, ','.join(map(str, valid_rf))))
+                  .format(chosen_rf, layer.name, closest_rf, ','.join(map(str, valid_rf))))
             layer.reuse_factor = closest_rf
-    
+
     def set_target_reuse_factor(self, layer):
         targ_cycles = layer.target_cycles
 
-        shuffle_cycles = 6 # Number of clock cycles to move data around
+        shuffle_cycles = 6  # Number of clock cycles to move data around
         if targ_cycles is not None:
-            if 'Dense' in layer.__class__.__name__: 
+            if 'Dense' in layer.__class__.__name__:
                 kernel_multiplies = layer.get_attr('n_out')
-            elif 'Conv1D' in layer.__class__.__name__:  
+            elif 'Conv1D' in layer.__class__.__name__:
                 kernel_multiplies = layer.get_attr('out_width')
-            elif 'Conv2D' in layer.__class__.__name__: 
+            elif 'Conv2D' in layer.__class__.__name__:
                 kernel_multiplies = layer.get_attr('out_height') * layer.get_attr('out_width')
-            else: 
+            else:
                 print('Target cycles unsupported layer')
                 return
 
-            if targ_cycles < shuffle_cycles*kernel_multiplies: # 6 clock min (6 * out_height * out_width)
+            if targ_cycles < shuffle_cycles*kernel_multiplies:  # 6 clock min (6 * out_height * out_width)
                 print("Latency can not be achieved with current target %d. Mininum %d." % (targ_cycles, shuffle_cycles*kernel_multiplies+1))
                 return
-            else: 
-                rf = targ_cycles - shuffle_cycles*kernel_multiplies # subtract data shuffling overhead
+            else:
+                rf = targ_cycles - shuffle_cycles*kernel_multiplies  # subtract data shuffling overhead
 
             layer.reuse_factor = float(rf) / kernel_multiplies
-
 
     def convert_precision_string(self, precision):
         '''
@@ -547,7 +560,7 @@ class VivadoBackend(Backend):
             # if binary
             if isinstance(weight_T, XnorPrecisionType) and isinstance(data_T, XnorPrecisionType):
                 product = 'both_binary'
-            elif isinstance(weight_T, XnorPrecisionType): # data is not xnor-binary
+            elif isinstance(weight_T, XnorPrecisionType):  # data is not xnor-binary
                 product = 'weight_binary'
             elif isinstance(weight_T, IntegerPrecisionType) and weight_T.width == 2 and weight_T.signed:
                 product = 'weight_ternary'
@@ -584,7 +597,7 @@ class VivadoBackend(Backend):
 
         for i in range(min_W):
             windows_int.append((int(''.join(str(p) for p in reversed(windows_bin[i])), 2)))
-        
+
         return (min_W, windows_int)
 
     def compute_conv2d_instructions(self, in_H, in_W, in_C, kernel_size=3, stride=1, pad=0):
@@ -612,7 +625,7 @@ class VivadoBackend(Backend):
             min_H = (math.ceil(kernel_height / stride_height) - 1) * stride_height + kernel_height
         else:
             min_H = (math.ceil(stride_height / kernel_height) - 1) * stride_height + kernel_height
-        
+
         if kernel_width >= stride_width:
             min_W = (math.ceil(kernel_width / stride_width) - 1) * stride_width + kernel_width
         else:
@@ -635,15 +648,15 @@ class VivadoBackend(Backend):
         if kernel_height == 1 and kernel_width == 1 and stride == 1 and scaled_H == in_H and scaled_W == in_W:
             return (1, 1, map(str, [1]))
         if kernel_height == 3 and kernel_width == 3 and stride == 1 and scaled_H == in_H and scaled_W == in_W:
-            return (5, 5, map(str, [1,3,7,6,4,9,27,63,54,36,73,219,511,438,292,72,216,504,432,288,64,192,448,384,256]))
+            return (5, 5, map(str, [1, 3, 7, 6, 4, 9, 27, 63, 54, 36, 73, 219, 511, 438, 292, 72, 216, 504, 432, 288, 64, 192, 448, 384, 256]))
         if kernel_height == 5 and kernel_width == 5 and stride == 1 and scaled_H == in_H and scaled_W == in_W:
-            return (9, 9, map(str, [1,3,7,15,31,30,28,24,16,33,99,231,495,1023,990,924,792,528,1057,3171,7399,15855,
-                             32767,31710,29596,25368,16912,33825,101475,236775,507375,1048575,1014750,947100,
-                             811800,541200,1082401,3247203,7576807,16236015,33554431,32472030,30307228,25977624,
-                             17318416,1082400,3247200,7576800,16236000,33554400,32472000,30307200,25977600,17318400,
-                             1082368,3247104,7576576,16235520,33553408,32471040,30306304,25976832,17317888,1081344,
-                             3244032,7569408,16220160,33521664,32440320,30277632,25952256,17301504,1048576,3145728,
-                             7340032,15728640,32505856,31457280,29360128,25165824,16777216]))
+            return (9, 9, map(str, [1, 3, 7, 15, 31, 30, 28, 24, 16, 33, 99, 231, 495, 1023, 990, 924, 792, 528, 1057, 3171, 7399, 15855,
+                                    32767, 31710, 29596, 25368, 16912, 33825, 101475, 236775, 507375, 1048575, 1014750, 947100,
+                                    811800, 541200, 1082401, 3247203, 7576807, 16236015, 33554431, 32472030, 30307228, 25977624,
+                                    17318416, 1082400, 3247200, 7576800, 16236000, 33554400, 32472000, 30307200, 25977600, 17318400,
+                                    1082368, 3247104, 7576576, 16235520, 33553408, 32471040, 30306304, 25976832, 17317888, 1081344,
+                                    3244032, 7569408, 16220160, 33521664, 32440320, 30277632, 25952256, 17301504, 1048576, 3145728,
+                                    7340032, 15728640, 32505856, 31457280, 29360128, 25165824, 16777216]))
 
         windows_bin = [[0 for _ in range(kernel_height * kernel_width)] for _ in range(min_H * min_W)]
 
@@ -659,5 +672,5 @@ class VivadoBackend(Backend):
         for i in range(min_H):
             for j in range(min_W):
                 windows_int.append((int(''.join(str(p) for p in reversed(windows_bin[i * min_W + j])), 2)))
-        
+
         return (min_H, min_W, windows_int)

--- a/hls4ml/utils/example_models.py
+++ b/hls4ml/utils/example_models.py
@@ -4,6 +4,7 @@ import pprint
 import json
 import yaml
 
+
 def _load_data_config_avai(model_name):
     """
     Check data and configuration availability for each model from this file:
@@ -12,13 +13,14 @@ def _load_data_config_avai(model_name):
     """
 
     link_to_list = 'https://raw.githubusercontent.com/hls-fpga-machine-learning/example-models/master/available_data_config.json'
-    
+
     temp_file, _ = urlretrieve(link_to_list)
-    
+
     # Read data from file:
     data = json.load(open(temp_file))
 
     return data[model_name]
+
 
 def _data_is_available(model_name):
 
@@ -26,24 +28,27 @@ def _data_is_available(model_name):
 
     return data['example_data']
 
+
 def _config_is_available(model_name):
 
     data = _load_data_config_avai(model_name)
 
     return data['example_config']
 
+
 def _create_default_config(model_name, model_config):
 
-    #Initiate the configuration file
+    # Initiate the configuration file
     config = create_vivado_config()
 
-    #Additional configuration parameters
+    # Additional configuration parameters
     config[model_config] = model_name
     config['HLSConfig']['Model'] = {}
     config['HLSConfig']['Model']['Precision'] = 'ap_fixed<16,6>'
     config['HLSConfig']['Model']['ReuseFactor'] = '1'
 
     return config
+
 
 def _filter_name(model_name):
     """
@@ -57,6 +62,7 @@ def _filter_name(model_name):
         filtered_name = model_name[:-3]
 
     return filtered_name
+
 
 def _load_example_data(model_name):
 
@@ -73,24 +79,26 @@ def _load_example_data(model_name):
     urlretrieve(link_to_input, input_file_name)
     urlretrieve(link_to_output, output_file_name)
 
+
 def _load_example_config(model_name):
 
     print("Downloading configuration files ...")
 
     filtered_name = _filter_name(model_name)
 
-    config_name =  filtered_name + "_config.yml"
+    config_name = filtered_name + "_config.yml"
 
     link_to_config = 'https://raw.githubusercontent.com/hls-fpga-machine-learning/example-models/master/config-files/' + config_name
 
-    #Load the configuration as dictionary from file
+    # Load the configuration as dictionary from file
     urlretrieve(link_to_config, config_name)
 
-    #Load the configuration from local yml file
+    # Load the configuration from local yml file
     with open(config_name, 'r') as ymlfile:
         config = yaml.load(ymlfile)
 
     return config
+
 
 def fetch_example_model(model_name):
     """
@@ -102,17 +110,17 @@ def fetch_example_model(model_name):
 
     Args:
         - model_name: string, name of the example model in the repo. Example: fetch_example_model('KERAS_3layer.json')
-    
+
     Return:
         - Dictionary that stores the configuration to the model
     """
 
-    #Initilize the download link and model type
+    # Initilize the download link and model type
     download_link = 'https://raw.githubusercontent.com/hls-fpga-machine-learning/example-models/master/'
     model_type = None
     model_config = None
 
-    #Check for model's type to update link
+    # Check for model's type to update link
     if '.json' in model_name:
         model_type = 'keras'
         model_config = 'KerasJson'
@@ -121,21 +129,20 @@ def fetch_example_model(model_name):
         model_config = 'PytorchModel'
     elif '.onnx' in model_name:
         model_type = 'onnx'
-        model_config ='OnnxModel'
+        model_config = 'OnnxModel'
     elif '.pb' in model_name:
         model_type = 'tensorflow'
         model_config = 'TensorFlowModel'
     else:
         raise TypeError('Model type is not supported in hls4ml.')
-    
 
     download_link_model = download_link + model_type + '/' + model_name
-    
-    #Download the example model
+
+    # Download the example model
     print("Downloading example model files ...")
     urlretrieve(download_link_model, model_name)
 
-    #Check if the example data and configuration for the model are available
+    # Check if the example data and configuration for the model are available
     if _data_is_available(model_name):
         _load_example_data(model_name)
 
@@ -144,26 +151,27 @@ def fetch_example_model(model_name):
     else:
         config = _create_default_config(model_name, model_config)
 
-    #If the model is a keras model then have to download its weight file as well
+    # If the model is a keras model then have to download its weight file as well
     if model_type == 'keras':
         model_weight_name = model_name[:-5] + "_weights.h5"
 
         download_link_weight = download_link + model_type + '/' + model_weight_name
         urlretrieve(download_link_weight, model_weight_name)
 
-        config['KerasH5'] =  model_weight_name #Set configuration for the weight file
-    
+        config['KerasH5'] = model_weight_name  # Set configuration for the weight file
+
     return config
 
+
 def fetch_example_list():
-    
+
     link_to_list = 'https://raw.githubusercontent.com/hls-fpga-machine-learning/example-models/master/available_models.json'
-    
+
     temp_file, _ = urlretrieve(link_to_list)
-    
+
     # Read data from file:
     data = json.load(open(temp_file))
-    
+
     # Print in fancy format
     pp = pprint.PrettyPrinter(indent=4)
     pp.pprint(data)

--- a/hls4ml/utils/plot.py
+++ b/hls4ml/utils/plot.py
@@ -70,7 +70,7 @@ def model_to_dot(model,
             return
         else:
             raise ImportError('Failed to import pydot. You must install pydot'
-                            ' and graphviz for `pydotprint` to work.')
+                              ' and graphviz for `pydotprint` to work.')
 
     if subgraph:
         dot = pydot.Cluster(style='dashed', graph_name=model.name)
@@ -106,8 +106,8 @@ def model_to_dot(model,
         if show_shapes:
             def format_shape(shape):
                 return str(tuple(shape)).replace(str(None), '?')
-            
-            input_labels = '?' 
+
+            input_labels = '?'
             try:
                 output_labels = format_shape(layer.get_output_variable().shape)
             except AttributeError:
@@ -146,13 +146,13 @@ def model_to_dot(model,
                 tensors.update(layer.variables)
             for tensor_name, var in tensors.items():
                 if show_shapes:
-                    #tensor_label = '{} {}: {}'.format(tensor_name,
+                    # tensor_label = '{} {}: {}'.format(tensor_name,
                     tensor_label = '<tr><td align="left">{} {}:</td><td align="left">{}</td></tr>'.format(
                         tensor_name,
                         format_shape(var.shape),
                         format_precision(var.type.precision))
                 else:
-                    #tensor_label = '{}: {}'.format(tensor_name,
+                    # tensor_label = '{}: {}'.format(tensor_name,
                     tensor_label = '<tr><td align="left">{}:</td><td align="left">{}</td></tr>'.format(
                         tensor_name,
                         format_precision(var.type.precision))
@@ -186,7 +186,7 @@ def plot_model(model,
                rankdir='TB',
                dpi=96):
     """Converts a HLS model to dot format and save to a file.
-  
+
     Arguments:
         model: A HLS model instance
         to_file: File name of the plot image.
@@ -198,7 +198,7 @@ def plot_model(model,
             'TB' creates a vertical plot;
             'LR' creates a horizontal plot.
         dpi: Dots per inch.
-  
+
     Returns:
         A Jupyter notebook Image object if Jupyter is installed.
         This enables in-line display of the model plots in notebooks.
@@ -211,7 +211,7 @@ def plot_model(model,
                        dpi=dpi)
     if dot is None:
         return
-    
+
     if to_file is not None:
         _, extension = os.path.splitext(to_file)
         if not extension:

--- a/hls4ml/writer/writers.py
+++ b/hls4ml/writer/writers.py
@@ -6,13 +6,16 @@ class Writer(object):
     def write_hls(self, model):
         raise NotImplementedError
 
+
 writer_map = {}
+
 
 def register_writer(name, writer_cls):
     if name in writer_map:
         raise Exception('Writer {} already registered'.format(name))
-    
+
     writer_map[name] = writer_cls
+
 
 def get_writer(name):
     return writer_map[name]()

--- a/p-clang-format
+++ b/p-clang-format
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Copyright (c) 2017, Medicine Yeh
+# MIT License
+
+# Turn on this to replace any pragma
+REPLACE_ANY_PRAGMA=1
+
+function replace_all()
+{
+    local prefix="$1"
+    local keywords=("${!2}")
+    local pattern="$3"
+    local file_pathes=("${!4}")
+
+    # echo "Keywords     : ${keywords[*]}"
+    # echo "Pattern      : ${pattern}"
+    # echo "File Path    : ${file_pathes[*]}"
+
+    for file_path in "${file_pathes[@]}"; do
+        [[ ! -r "$file_path" ]] && continue
+        for w in "${keywords[@]}"; do
+            # echo "Replace '${prefix}$w' in '$file_path'"
+            sed -i "s/${prefix}${w}/${pattern}${prefix}${w}/g" "${file_path}"
+        done
+    done
+}
+
+function re_replace_all()
+{
+    local prefix="$1"
+    local keywords=("${!2}")
+    local pattern="$3"
+    local file_pathes=("${!4}")
+
+    # echo "Keywords     : ${keywords[*]}"
+    # echo "Anti-Pattern : ${pattern}"
+    # echo "File Path    : ${file_pathes[*]}"
+
+    for file_path in "${file_pathes[@]}"; do
+        [[ ! -r "$file_path" ]] && continue
+        for w in "${keywords[@]}"; do
+            # echo "Re:replace '${prefix}$w' in '$file_path'"
+            sed -i "s/${pattern}${prefix}${w}/${prefix}${w}/g" "${file_path}"
+        done
+    done
+}
+
+function format()
+{
+    clang-format "$@"
+}
+
+function main()
+{
+    # This is the pattern for replacing to comments
+    local comment_pattern="\/\/"
+    # This is the pattern for replacing comments back to original string
+    local re_comment_pattern="\/\/ *"
+    # The path of files
+    local file_pathes=()
+    # Define the keywords of pragma to be escaped from formatting
+    local pragma_prefix="#pragma "
+    local pragma_key_words=()
+    # Loop specific
+    pragma_key_words+=(omp simd loop unroll ivdep vector)
+    # Memory specific
+    pragma_key_words+=(alloc_section)
+    # Misc.
+    pragma_key_words+=("cilk grainsize" offload)
+
+    # Turn on the following line to indent any pragma
+    [[ "$REPLACE_ANY_PRAGMA" == "1" ]] && pragma_key_words=("")
+
+    # Find all files in the arguments
+    for var in "$@"; do
+        if [[ ! "$var" =~ ^-.* ]]; then
+            file_pathes+=("$var")
+        fi
+    done
+
+    replace_all "$pragma_prefix" "pragma_key_words[@]" "$comment_pattern" "file_pathes[@]"
+    format "$@"
+    re_replace_all "$pragma_prefix" "pragma_key_words[@]" "$re_comment_pattern" "file_pathes[@]"
+}
+
+main "$@"
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [metadata]
 description-file = README.md
+
+[pep8]
+ignore = E121,E123,E126,E226,E24,E704,W503,W504
+max-line-length = 199


### PR DESCRIPTION
Ran autopep8 recursively on all python files with the `setup.cfg` in the repo:
```
autopep8 --in-place --aggressive --aggressive *.py -v
```

```
[pep8]
ignore = E121,E123,E126,E226,E24,E704,W503,W504
max-line-length = 199
```

We can combine this with a GitHub action to automatically check/correct PRs:
https://github.com/marketplace/actions/autopep8

Let me know what you think!