### PR TITLE
Resolve II and Latency issues

### DIFF
--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -221,6 +221,7 @@ void init_invert_table(typename CONFIG_T::inv_table_t table_out[CONFIG_T::table_
 
 template <class data_T, class res_T, typename CONFIG_T>
 void softmax_latency(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
+    #pragma HLS pipeline
     // Initialize the lookup tables
 #ifdef __HLS_SYN__
     bool initialized = false;
@@ -264,6 +265,7 @@ void softmax_latency(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
 
 template <class data_T, class res_T, typename CONFIG_T>
 void softmax_stable(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
+    #pragma HLS pipeline
     // Initialize the lookup tables
 #ifdef __HLS_SYN__
     bool initialized = false;
@@ -407,6 +409,7 @@ void  softmax_legacy(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 
 template<class data_T, class res_T, typename CONFIG_T>
 void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
+    #pragma HLS inline
     switch(CONFIG_T::implementation){
     case softmax_implementation::latency:
         softmax_latency<data_T, res_T, CONFIG_T>(data, res);

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense.h
@@ -41,6 +41,7 @@ void dense(
     typename CONFIG_T::weight_t  weights[CONFIG_T::n_in*CONFIG_T::n_out],
     typename CONFIG_T::bias_t    biases[CONFIG_T::n_out])
 {
+    #pragma HLS inline
     if (CONFIG_T::strategy == latency) {
         dense_latency<data_T, res_T, CONFIG_T>(data, res, weights, biases);
     } else {

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -130,6 +130,11 @@ class VivadoWriter(Writer):
         elif mode == 'stream':
             return '#pragma HLS STREAM variable={name} depth={depth}'.format(name=variable.name, depth=depth)
 
+    @staticmethod
+    def _make_stable_pragma(variable):
+        template = '#pragma HLS STABLE variable={name}'
+        return template.format(name=variable.name)
+
     def write_project_cpp(self, model):
         ###################
         ## myproject.cpp
@@ -211,6 +216,8 @@ class VivadoWriter(Writer):
                                 newline += '    ' + def_cpp + ';\n'
                                 if var.pragma:
                                     newline += '    ' + self._make_array_pragma(var) + '\n'
+                                if model.config.model_strategy == 'Resource':
+                                    newline += '    ' + self._make_stable_pragma(var) + '\n'
                     func = layer.function_cpp()
                     if func:
                         if len(func) == 1:


### PR DESCRIPTION
Reviewing #280 I saw that the latency and II of some of the test models is not as expected. 
e.g. the model [1] with RF=2 was synthesizing with II=19, and the model [2] with RF=112 synthesized with II= 117-min, 118-max. You can see this in [the reports](https://correlator2.fnal.gov:8080/blue/organizations/jenkins/hls4ml/detail/PR-280/4/pipeline) of #280. 
Basically, with ` Strategy: Resource`, some functions that should have been pipelined were not. These additional pragmas resolve that. Regarding the `inline` pragmas in the dense- and softmax-wrapper functions: those were automatically inlined in the `Strategy: Latency` tests, and only the wrapper function is inlined, not the actual dense or softmax implementation underneath.

I've marked the PR WIP since I still see a different min/max latency for the `Strategy: Resource` which we should also resolve. Although we could take these changes sooner if that one takes too long to find.

[1] KERAS_3layer-xcvu9p_flgb2104_2_e-c5-io_parallel-rf2-ap_fixed_16_6_-Resource-2020.1
[2] qkeras_mnist_dense-xcvu9p_flgb2104_2_e-c5-io_parallel-rf112-ap_fixed_16_6_-Resource-2020.1



