### PR TITLE
Command line tool and API consistency

### DIFF
--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -11,6 +11,8 @@ from collections import OrderedDict
 from hls4ml.writer.writers import Writer
 from hls4ml.model.hls_layers import XnorPrecisionType
 
+config_filename = 'hls4ml_config.yml'
+
 class VivadoWriter(Writer):
 
     def type_definition_cpp(self, model, atype):
@@ -610,6 +612,14 @@ class VivadoWriter(Writer):
 
         copytree(srcpath, dstpath)
 
+    def write_yml(self, model):
+        ###################
+        # YAML config file
+        ###################
+
+        with open(model.config.get_output_dir() + '/' + config_filename, 'w') as file:
+            yaml.dump(model.config.config, file)
+
     def write_tar(self, model):
         ###################
         # Tarball output
@@ -630,5 +640,6 @@ class VivadoWriter(Writer):
         self.write_bridge(model)
         self.write_build_script(model)
         self.write_nnet_utils(model)
+        self.write_yml(model)
         self.write_tar(model)
         print('Done')

--- a/scripts/hls4ml
+++ b/scripts/hls4ml
@@ -168,7 +168,7 @@ def build(args):
         backend = yamlConfig.get('Backend', 'Vivado')
         if backend == 'Vivado':
             found = os.system('command -v vivado_hls > /dev/null')
-            if found is not 0:
+            if found != 0:
                 print('Vivado HLS installation not found. Make sure "vivado_hls" is on PATH.')
                 sys.exit(1)
         elif backend == 'Intel':


### PR DESCRIPTION
Currently, when using API to write projects the projects don't keep the yml config in the output directory, so they can't be used by `hls4ml build` command. The changes ensure that we always write the yml in the output dir. I also made the minor change to get rid of the warning newer Python produces about comparing to a literal value.