### PR TITLE
Further cmdline and API changes

### DIFF
--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -202,8 +202,12 @@ def keras_to_hls(config):
 
     if 'KerasModel' in config:
         # Model instance passed in config from API
-        model_arch = json.loads(config['KerasModel'].to_json())
-        reader = KerasModelReader(config['KerasModel'])
+        keras_model = config['KerasModel']
+        if isinstance(keras_model, str):
+            from tensorflow.keras.models import load_model
+            keras_model = load_model(keras_model)
+        model_arch = json.loads(keras_model.to_json())
+        reader = KerasModelReader(keras_model)
     elif 'KerasJson' in config:
         # Extract model architecture from json
         with open(config['KerasJson']) as json_file:

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -617,6 +617,17 @@ class VivadoWriter(Writer):
         # YAML config file
         ###################
 
+        def keras_model_representer(dumper, keras_model):
+            model_path = model.config.get_output_dir() + '/keras_model.h5'
+            keras_model.save(model_path)
+            return dumper.represent_scalar(u'!keras_model', model_path)
+
+        try:
+            from tensorflow.keras import Model as KerasModel
+            yaml.add_multi_representer(KerasModel, keras_model_representer)
+        except:
+            pass
+
         with open(model.config.get_output_dir() + '/' + config_filename, 'w') as file:
             yaml.dump(model.config.config, file)
 

--- a/scripts/hls4ml
+++ b/scripts/hls4ml
@@ -21,11 +21,6 @@ hls4ml_description = """
    o────╚╤╤╤╝
 """
 
-def parse_config(config_file):
-    print('Loading configuration from', config_file)
-    config = open(config_file, 'r')
-    return yaml.load(config, Loader=yaml.SafeLoader)
-
 def main():
     parser = argparse.ArgumentParser(description=hls4ml_description, formatter_class=argparse.RawDescriptionHelpFormatter)
     subparsers = parser.add_subparsers()
@@ -137,14 +132,10 @@ def config(args):
         yaml.dump(config, sys.stdout, default_flow_style=False, sort_keys=False)
 
 def convert(args):
-    yamlConfig = parse_config(args.config)
-    model = hls4ml.converters.convert_from_yaml_config(yamlConfig)
+    model = hls4ml.converters.convert_from_config(args.config)
 
     if model is not None:
         model.write()
-
-    # Copy the config file to the generated folder
-    copyfile(args.config, yamlConfig['OutputDir'] + '/' + config_filename)
 
 def build(args):
     if args.project is None:
@@ -161,7 +152,7 @@ def build(args):
     if args.all:
         csim = synth = cosim = validation = export = vsynth = 1
     
-    yamlConfig = parse_config(args.project + '/' + config_filename)
+    yamlConfig = hls4ml.converters.parse_config(args.project + '/' + config_filename)
 
     # Check if vivado_hls is available
     if 'linux' in sys.platform or 'darwin' in sys.platform:


### PR DESCRIPTION
This PR handles the case when the API is used to convert the Keras model with `convert_from_keras_model`. The configuration dict will have a python object that is not serializable to YAML, so it cannot be used by `hls4ml convert` and `hls4ml build`, so we add a hook to PyYAML to serialize and deserialize such objects. I moved the `parse_config` from the `hls4ml` command to the converter, since the function is usable for API as well.