### PR TITLE
Remove redundant profiling imports

### DIFF
--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -1,7 +1,5 @@
-import importlib
 from hls4ml.model.hls_model import HLSModel
 from hls4ml.model.hls_layers import IntegerPrecisionType, FixedPrecisionType
-import qkeras
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas


### PR DESCRIPTION
Remove two imports from `profiling` module which are no longer needed. With `qkeras` in the main import list, the profiling module could not be imported into an environment without `qkeras`. I think that's why the [`profiling` section](https://fastmachinelearning.org/hls4ml/autodoc/hls4ml.model.html#hls4ml-model-profiling-module) of the docs is blank. But it didn't need to be there anyway, since this [`try/except`](https://github.com/fastmachinelearning/hls4ml/blob/master/hls4ml/model/profiling.py#L12-L17) section handles it.

I also removed the `import importlib` since that's an artefact from when we handled the imports differently.
I checked that the `profiling` does still work and produce plots when `TF` and `qkeras` are there, too. 