### PR TITLE
Add STL vector to nnet_helpers.h

### DIFF
--- a/hls4ml/templates/vivado/nnet_utils/nnet_helpers.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_helpers.h
@@ -25,6 +25,7 @@
 #include <math.h>
 #include <fstream>
 #include <algorithm>
+#include <vector>
 #include <map>
 #include "hls_stream.h"
 


### PR DESCRIPTION
**Issue**

Vivado 2020.2 removed `vivado_hls` tool and now supports only `vitis_hls`
https://www.xilinx.com/support/documentation/sw_manuals/xilinx2020_2/ug973-vivado-release-notes-install-license.pdf
> This release introduces the new HLS product with support for both Vitis™ and Vivado®. As part of this the overall folder structure changes, whereby the Vitis_HLS folder is now at the same root location as Vivado® and Vitis™. You may need to update any custom setup scripts from the previous release.

But HLS project build with `vitis_hls`
```
/tools/Xilinx/Vitis_HLS/2020.2/bin/vitis_hls  -f build_prj.tcl "reset=1 csim=1 synth=1 cosim=1 validation=1 export=1 vsynth=0"
```

Fails due to missed `<vector>` header:

```
***** C/RTL SYNTHESIS *****
INFO: [HLS 200-1510] Running: csynth_design 
INFO: [HLS 200-111] Finished File checks and directory preparation: CPU user time: 0.01 seconds. CPU system time: 0.01 seconds. Elapsed time: 0.01 seconds; current allocated memory: 223.149 MB.
INFO: [HLS 200-10] Analyzing design file 'firmware/hls4ml_arcas.cpp' ... 
ERROR: [HLS 214-125] no member named 'vector' in namespace 'std': ../hls_project/firmware/nnet_utils/nnet_helpers.h:279
```

Proposed PR adds missed header