### PR TITLE
Fixes for inserted padding layer in ResNet-like models

### DIFF
--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -292,12 +292,33 @@ class HLSModel(object):
 
         return node
 
-    def insert_node(self, node):
+    def insert_node(self, node, before=None):
+        """ Insert a new node into the model graph.
+
+        The node to be inserted should be created with `make_node()` function. The optional 
+        parameter `before` can be used to specify the node that follows in case of ambiguities.
+
+        Args:
+            node (Layer): Node to insert
+            before (Layer, optional): The next node in sequence before which a
+                new node should be inserted. 
+        Raises:
+            Exception: If an attempt to insert a node with multiple inputs is made or if
+                `before` does not specify a correct node in sequence.
+
+        """
         if len(node.inputs) > 1:
             raise Exception('Cannot insert a node with more than one input (for now).')
 
         prev_node = self.graph.get(node.inputs[0])
-        next_node = next((x for x in self.graph.values() if x.inputs[0] == prev_node.outputs[0]), None)
+        next_nodes = [x for x in self.graph.values() if x.inputs[0] == prev_node.outputs[0]]
+        if before is None:
+            next_node = next((x for x in self.graph.values() if x.inputs[0] == prev_node.outputs[0]), None)
+        else:
+            if before not in next_nodes:
+                raise Exception('Cannot insert a node {} before {} (candidates: {}).'.format(node.name, before.name, ','.join([n.name for n in next_nodes])))
+            next_node = before
+
         if next_node is not None:
             next_node.inputs[0] = node.outputs[0]
 

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -283,6 +283,31 @@ class HLSModel(object):
         optimize_model(self, optimizers)
 
     def make_node(self, kind, name, attributes, inputs, outputs=None):
+        """ Make a new node not connected to the model graph.
+
+        The 'kind' should be a valid layer registered with `register_layer`. If no outputs
+        are specified, a default output named the same as the node will be created. The 
+        returned node should be added to the graph with `insert_node` or `replace_node`
+        functions.
+
+        Args:
+            kind (str): Type of node to add
+            name (str): Name of the node
+            attributes (dict): Initial set of attributes required to construct the node (Layer)
+            inputs (list): List of inputs to the layer
+            outputs (list, optional): The optional list of named outputs of the node
+
+        Raises:
+            Exception: If an attempt to insert a node with multiple inputs is made or if
+                `before` does not specify a correct node in sequence.
+
+        Returns:
+            Layer: The node created.
+        """
+
+        if kind not in layer_map:
+            raise Exception('Layer {} not found in registry.'.format(kind))
+
         node = layer_map[kind](self, name, attributes, inputs, outputs)
         for o in node.outputs:
             out_var = node.get_output_variable(output_name=o)
@@ -331,6 +356,21 @@ class HLSModel(object):
         self.graph = new_graph
 
     def remove_node(self, node, rewire=True):
+        """ Remove a node from a graph.
+
+        By default, this function can connect the outputs of previous node to the input of next one.
+        Note that when removing a leaf node `rewire` should be set to `False`.
+
+        Args:
+            node (Layer): The node to remove
+            rewire (bool, optional): If `True`, connects the outputs of the previous node
+                to the inputs of the next node
+
+        Raises:
+            Exception: If an attempt is made to rewire a leaf node or a node with multiple
+                inputs/outpus.
+
+        """
         if rewire:
             if len(node.inputs) > 1 or len(node.outputs) > 1:
                 raise Exception('Cannot rewire a node with multiple inputs/outputs')
@@ -354,6 +394,13 @@ class HLSModel(object):
         del self.graph[node.name]
 
     def replace_node(self, old_node, new_node):
+        """ Replace an existing node in the graph with a new one.
+
+        Args:
+            old_node (Layer): The node to replace
+            new_node (Layer): The new node
+
+        """
         prev_node = self.graph.get(old_node.inputs[0])
         next_node = next((x for x in self.graph.values() if x.inputs[0] == old_node.outputs[0]), None)
         if next_node is not None:

--- a/hls4ml/model/optimizer/passes/conv_same_pad.py
+++ b/hls4ml/model/optimizer/passes/conv_same_pad.py
@@ -86,6 +86,6 @@ class InsertZeroPaddingBeforeConv2D(OptimizerPass):
         # Insert new ZeroPadding2D node above Conv2D
         padding_layer = model.make_node('ZeroPadding2D', 'zp2d_' + node.name, attrs, node.inputs.copy())
         padding_layer.get_output_variable().type.precision = node.get_input_variable().type.precision
-        model.insert_node(padding_layer)
+        model.insert_node(padding_layer, before=node)
 
         return True

--- a/hls4ml/templates/vivado/nnet_utils/nnet_padding_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_padding_stream.h
@@ -17,6 +17,18 @@ void fill_zero(hls::stream<res_T> &res) {
 }
 
 template<class data_T, class res_T, typename CONFIG_T>
+void fill_data(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+    #pragma HLS INLINE
+    data_T data_part = data.read();
+    res_T res_part;
+    for (int c = 0; c < CONFIG_T::n_chan; c++) {
+        #pragma HLS UNROLL
+        res_part[c] = data_part[c];
+    }
+    res.write(res_part);
+}
+
+template<class data_T, class res_T, typename CONFIG_T>
 void zeropad1d_cl(
     hls::stream<data_T> &data,
     hls::stream<res_T>  &res
@@ -26,7 +38,7 @@ void zeropad1d_cl(
     }
 
     CopyMain: for (int i = 0; i < CONFIG_T::in_width; i++) {
-        res.write(data.read());
+        fill_data<data_T, res_T, CONFIG_T>(data, res);
     }
 
     PadRight: for (int i = 0; i < CONFIG_T::pad_right; i++) {
@@ -51,7 +63,7 @@ void zeropad2d_cl(
             fill_zero<res_T, CONFIG_T>(res);
         }
         CopyMain: for (int j = 0; j < CONFIG_T::in_width; j++) {
-            res.write(data.read());
+            fill_data<data_T, res_T, CONFIG_T>(data, res);
         }
         PadRight: for (int j = 0; j < CONFIG_T::pad_right; j++) {
             fill_zero<res_T, CONFIG_T>(res);


### PR DESCRIPTION
As observed in #305, padding layer may not compile if `data_T` and `res_T` types differ by one having rounding and saturation defined. The same model also demonstrates another issue: If we attempt to insert a new layer after a layer whose output is used more than once the new layer will always be inserted before the first use of that output. This trips up the insertion of `ZeroPadding` layers and they end up being applied on the same output. Both issues are fixed in this PR.