### PR TITLE
Fix AP_RND,AP_SAT swap

### DIFF
--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -489,9 +489,9 @@ class VivadoBackend(Backend):
             fields = 1
             signed = ~('u' in precision)
         if len(bits) > fields:
-            sat_mode = bits[fields]
+            round_mode = bits[fields]
         if len(bits) > fields+1:
-            round_mode = bits[fields+1]
+            sat_mode = bits[fields+1]
         if len(bits) > fields+2:
             sat_bits = int(bits[fields+2])
         if 'fixed' in precision:


### PR DESCRIPTION
If precision is specified (correctly) as `ap_fixed<total,int,AP_RND,AP_SAT`, interpretation would swap the two `AP_RND,AP_SAT` and print it incorrectly in the `defines.h` for the project.