### PR TITLE
Correctly check for resource strategy with lowercase

### DIFF
--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -218,7 +218,7 @@ class VivadoWriter(Writer):
                                 newline += '    ' + def_cpp + ';\n'
                                 if var.pragma:
                                     newline += '    ' + self._make_array_pragma(var) + '\n'
-                                if model.config.model_strategy == 'Resource':
+                                if model.config.model_strategy.lower() == 'resource':
                                     newline += '    ' + self._make_stable_pragma(var) + '\n'
                     func = layer.function_cpp()
                     if func:

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -191,7 +191,7 @@ class VivadoWriter(Writer):
                     # TODO discussed adding a handle for setting the interface mode for individual input and output arrays (16.03.2020)
                     # Probably the handle doesn't need to be exposed to the user but should be just set in hls_model.py
                     newline += indent + '#pragma HLS INTERFACE ap_vld port={},{} \n'.format(','.join(all_inputs), ','.join(all_outputs))
-                    if model.config.model_strategy == 'Resource':
+                    if model.config.model_strategy.lower() == 'resource':
                         newline += indent + '#pragma HLS DATAFLOW \n'
                     else:
                         newline += indent + '#pragma HLS PIPELINE \n'


### PR DESCRIPTION
If resource strategy for entire model was specified in lowercase in yml file like e.g. [here](https://github.com/fastmachinelearning/models/blob/master/keras/KERAS_dense/KERAS_dense_16x100x100x100x100x100x5-config.yml), this would confuse `vivado_writer.py` and make it behave as if strategy was `latency`. Observed with @chaitanyaPaikara 