### PR TITLE
Add set_data_types_from_keras_model() for automatic precision inference

### DIFF
--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -73,7 +73,7 @@ def set_data_types_from_keras_model(model, config, max_bits, test_data=None):
 
         for a in range(1, max_bits + 1):
             for b in range(0, a + 1):
-                max_possible = 2 ** (b - 1)
+                max_possible = 2 ** b - 2 ** (b - a)
                 min_possible = 2 ** (b - a)
 
                 if max_possible >= max_val and abs(min_possible - min_val) < distance_to_min:
@@ -82,7 +82,8 @@ def set_data_types_from_keras_model(model, config, max_bits, test_data=None):
 
                     distance_to_min = abs(min_possible - min_val)
 
-        return a_final, b_final
+        # An extra integer bit must be added for the number sign
+        return a_final + 1, b_final + 1
 
     for weight_info in weight_data:
         layer_name = weight_info['layer']

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -66,7 +66,23 @@ def set_data_types_from_keras_model(model, config, max_bits, test_data=None):
     }
 
     def find_optimal_a_b(max_val, min_val):
-        raise NotImplementedError
+        a_final = None
+        b_final = None
+
+        distance_to_min = math.inf
+
+        for a in range(1, max_bits + 1):
+            for b in range(0, a + 1):
+                max_possible = 2 ** (b - 1)
+                min_possible = 2 ** (b - a)
+
+                if max_possible >= max_val and abs(min_possible - min_val) < distance_to_min:
+                    a_final = a
+                    b_final = b
+
+                    distance_to_min = abs(min_possible - min_val)
+
+        return a_final, b_final
 
     for weight_info in weight_data:
         layer_name = weight_info['layer']

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -87,6 +87,10 @@ def set_data_types_from_keras_model(model, config, max_bits, test_data=None):
     for weight_info in weight_data:
         layer_name = weight_info['layer']
         suffix = weight_info['weight'].split('/')[1]
+
+        if suffix not in suffix_map:
+            continue
+
         min_value = weight_info['whislo']
         max_value = weight_info['whishi']
 


### PR DESCRIPTION
Profiling information gathered e.g. by `hls4ml.model.profiling.numerical()` can be used for setting data types in an HLSModel config heuristically so that the optimal precision configuration is achieved faster.

This PR adds `set_data_types_from_keras_model()` doing that with a Keras model.