### PR TITLE
Make profiling return pre- and post-optimization plots (up to 4 plots in total)

### DIFF
--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -263,6 +263,7 @@ class HLSModel(object):
         self._top_function_lib = None
 
         self._make_graph(layer_list)
+        self.original_graph = self.graph.copy()
 
         self._optimize_model(self.config.optimizers)
 
@@ -418,8 +419,11 @@ class HLSModel(object):
         self.index += 1
         return self.index
 
-    def get_layers(self):
-        return self.graph.values()
+    def get_layers(self, before_optimization=False):
+        if before_optimization:
+            return self.original_graph.values()
+        else:
+            return self.graph.values()
 
     def get_input_variables(self):
         variables = []

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -263,7 +263,6 @@ class HLSModel(object):
         self._top_function_lib = None
 
         self._make_graph(layer_list)
-        self.original_graph = self.graph.copy()
 
         self._optimize_model(self.config.optimizers)
 
@@ -419,11 +418,8 @@ class HLSModel(object):
         self.index += 1
         return self.index
 
-    def get_layers(self, before_optimization=False):
-        if before_optimization:
-            return self.original_graph.values()
-        else:
-            return self.graph.values()
+    def get_layers(self):
+        return self.graph.values()
 
     def get_input_variables(self):
         variables = []

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -208,6 +208,31 @@ def weights_hlsmodel(model, fmt='longform', plot='boxplot'):
         data = pandas.DataFrame(data)
     return data
 
+
+def activations_hlsmodel(model, X, fmt='summary', plot='boxplot'):
+    if fmt == 'longform':
+        raise NotImplemented
+    elif fmt == 'summary':
+        data = []
+
+    _, trace = model.trace(np.ascontiguousarray(X))
+
+    if len(trace) == 0:
+        raise RuntimeError("HLSModel must have tracing on for at least 1 layer (this can be set in its config)")
+
+    for layer in trace.keys():
+        print("   {}".format(layer))
+
+        if fmt == 'summary':
+            y = trace[layer].flatten()
+            y = abs(y[y != 0])
+
+            data.append(array_to_summary(y, fmt=plot))
+            data[-1]['weight'] = layer
+
+    return data
+
+
 def weights_keras(model, fmt='longform', plot='boxplot'):
     suffix = ['w', 'b']
     if fmt == 'longform':

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -243,7 +243,12 @@ def weights_keras(model, fmt='longform', plot='boxplot'):
         name = layer.name
         weights = layer.get_weights()
         for i, w in enumerate(weights):
-            l = '{}/{}'.format(name, suffix[i])
+            if len(weights) != 2:
+                suf = i
+            else:
+                suf = suffix[i]
+
+            l = '{}/{}'.format(name, suf)
             w = w.flatten()
             w = abs(w[w != 0])
             n = len(w)
@@ -301,7 +306,12 @@ def weights_torch(model, fmt='longform', plot='boxplot'):
             name = layer.__class__.__name__
             weights = list(layer.parameters())
             for i, w in enumerate(weights):
-                l = '{}/{}'.format(name, suffix[i])
+                if len(weights) != 2:
+                    suf = i
+                else:
+                    suf = suffix[i]
+
+                l = '{}/{}'.format(name, suf)
                 w = weights[i].detach().numpy()
                 w = w.flatten()
                 w = abs(w[w != 0])

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -10,7 +10,6 @@ import shutil
 from collections import defaultdict
 
 from hls4ml.model.hls_model import HLSModel
-from hls4ml.converters import convert_from_config
 
 try:
     from tensorflow import keras
@@ -27,6 +26,8 @@ except ImportError:
 
 
 def get_unoptimized_hlsmodel(model):
+    from hls4ml.converters import convert_from_config
+
     new_config = model.config.config.copy()
     new_output_dir = uuid.uuid4().hex
 

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -371,10 +371,12 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
     Returns
     -------
     tuple
-        The pair of produced figures. First weights and biases,
-        then activations
+        The quadruple of produced figures. First weights and biases
+        for the original model and HLSModel respectively,
+        then activations for the original model and HLSModel
+        respectively.
     """
-    wp, wph, ap = None, None, None
+    wp, wph, ap, aph = None, None, None, None
 
     print("Profiling weights (the original model)")
     data = None
@@ -389,19 +391,19 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
     if data is None:
         print("Only keras, PyTorch (Sequential) and HLSModel models " +
               "can currently be profiled")
-        return wp, wph, ap
+        return wp, wph, ap, aph
 
     wp = plots[plot](data, fmt='summary')  # weight plot
 
     plt.title("Distribution of (non-zero) weights (the original model)")
     plt.tight_layout()
 
+    print("Profiling weights (the HLS model)")
     data = None
     if hls_model is not None and isinstance(hls_model, HLSModel):
         data = weights_hlsmodel(hls_model, fmt='summary', plot=plot)
 
     if data is not None:
-        print("Profiling weights (the HLS model)")
         wph = plots[plot](data, fmt='summary')  # weight plot
         if isinstance(hls_model, HLSModel) and plot in types_plots:
             t_data = types_hlsmodel(hls_model)
@@ -423,11 +425,20 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
         plt.title("Distribution of (non-zero) activations (the original model)")
         plt.tight_layout()
 
-    # if X is not None and isinstance(hls_model, HLSModel):
-    #    t_data = activation_types_hlsmodel(hls_model)
-    #    types_plots[plot](t_data, fmt='summary')
+    print("Profiling activations (the HLS model)")
+    data = None
+    if X is not None and hls_model is not None and isinstance(hls_model, HLSModel):
+        data = activations_hlsmodel(hls_model, X, fmt='summary', plot=plot)
 
-    return wp, wph, ap
+    if data is not None:
+        aph = plots[plot](data, fmt='summary')
+        if X is not None and isinstance(hls_model, HLSModel):
+            t_data = activation_types_hlsmodel(hls_model)
+            types_plots[plot](t_data, fmt='summary')
+        plt.title("Distribution of (non-zero) activations (the HLS model)")
+        plt.tight_layout()
+
+    return wp, wph, ap, aph
 
 
 ########COMPARE OUTPUT IMPLEMENTATION########

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas
 import seaborn as sb
+from collections import defaultdict
 
 from hls4ml.model.hls_model import HLSModel
 from hls4ml.converters import convert_from_config
@@ -217,6 +218,32 @@ def weights_hlsmodel(model, fmt='longform', plot='boxplot'):
     return data
 
 
+def _keras_batchnorm(layer):
+    weights = layer.get_weights()
+    epsilon = layer.epsilon
+
+    gamma = weights[0]
+    beta = weights[1]
+    mean = weights[2]
+    var = weights[3]
+
+    scale = gamma / np.sqrt(var + epsilon)
+    bias = beta - gamma * mean / np.sqrt(var + epsilon)
+
+    return [scale, bias], ['s', 'b']
+
+
+def _keras_layer(layer):
+    return layer.get_weights(), ['w', 'b']
+
+
+keras_process_layer_map = defaultdict(lambda: _keras_layer,
+                                      {
+                                          'BatchNormalization': _keras_batchnorm,
+                                          'QBatchNormalization': _keras_batchnorm
+                                      })
+
+
 def activations_hlsmodel(model, X, fmt='summary', plot='boxplot'):
     if fmt == 'longform':
         raise NotImplemented
@@ -242,21 +269,16 @@ def activations_hlsmodel(model, X, fmt='summary', plot='boxplot'):
 
 
 def weights_keras(model, fmt='longform', plot='boxplot'):
-    suffix = ['w', 'b']
     if fmt == 'longform':
         data = {'x' : [], 'layer' : [], 'weight' : []}
     elif fmt == 'summary':
         data = []
     for layer in model.layers:
         name = layer.name
-        weights = layer.get_weights()
-        for i, w in enumerate(weights):
-            if len(weights) != 2:
-                suf = i
-            else:
-                suf = suffix[i]
+        weights, suffix = keras_process_layer_map[type(layer).__name__](layer)
 
-            l = '{}/{}'.format(name, suf)
+        for i, w in enumerate(weights):
+            l = '{}/{}'.format(name, suffix[i])
             w = w.flatten()
             w = abs(w[w != 0])
             n = len(w)
@@ -314,12 +336,7 @@ def weights_torch(model, fmt='longform', plot='boxplot'):
             name = layer.__class__.__name__
             weights = list(layer.parameters())
             for i, w in enumerate(weights):
-                if len(weights) != 2:
-                    suf = i
-                else:
-                    suf = suffix[i]
-
-                l = '{}/{}'.format(name, suf)
+                l = '{}/{}'.format(name, suffix[i])
                 w = weights[i].detach().numpy()
                 w = w.flatten()
                 w = abs(w[w != 0])


### PR DESCRIPTION
Currently, `hls4ml.model.profiling.numerical()` returns 2 profiling plots, most often showing HLSModel and Keras/PyTorch/... layers with HLSModel data types overlaid. These may be confusing because hls4ml applies optimizations resulting in differences between final HLSModel and Keras/PyTorch/... layers.

This PR attempts to resolve this problem by making `hls4ml.model.profiling.numerical()` return up to 4 plots instead of 2: predominantly weights of HLSModel layers before and after optimizations + activations/outputs of HLSModel/Keras/PyTorch/... layers before and after optimizations.