### PR TITLE
Revert accum_t precision set to layer input type

### DIFF
--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -360,24 +360,9 @@ class Layer(object):
         self.weights = OrderedDict()
         self.variables = OrderedDict()
         self.precision = OrderedDict()
-
-        # We set 'accum' precision to match input tensor's precision if 'accum' was not explicitly set
-        def_type_obj, _ = self.model.config.get_precision(self, 'default')
-        acc_type_obj, acc_type_name = self.model.config.get_precision(self, 'accum')
-
-        inp = self.get_input_variable()
-        if inp is not None:
-            inp_type_obj = inp.type.precision
-        else:
-            inp_type_obj = def_type_obj
-
-        if acc_type_obj == def_type_obj: # 'accum' precision not defined in config
-            acc_type_obj = inp_type_obj # use input tensor's precision for 'accum'
-
-        accum_t = HLSType(acc_type_name, acc_type_obj) 
+        accum_t = HLSType(*reversed(self.model.config.get_precision(self, 'accum')))
         self.precision[accum_t.name] = accum_t
         self.set_attr('accum_t', accum_t.precision)
-
         self.reuse_factor = self.model.config.get_reuse_factor(self)
 
         layer_config = self.model.config.get_layer_config(self)


### PR DESCRIPTION
I reverted the change to hls_layers.py introduced by [this commit](https://github.com/fastmachinelearning/hls4ml/commit/913c146ddbba5634fa8ea96a53b71d4a617863b0).

The comment says "We set 'accum' precision to match input tensor's precision if 'accum' was not explicitly set", but it actually checks whether the data type is the same as the default type. So when I explicitly set `'ap_fixed<16,6>'` in the config, if the model default is also `'ap_fixed<16,6>'` then this code actually overrides that to change the accumulator type to the same as the layer input type regardless. In essence, it's not possible to explicitly set the accumulator data type now.


@maksgraczyk has implemented the automatic setting of accumulator type in PR #321 which can set the type to something better than the default precision in cases where that's appropriate.