### PR TITLE
fix ap_ufixed interpretation

### DIFF
--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -482,12 +482,12 @@ class VivadoBackend(Backend):
             W = int(bits[0])
             I = int(bits[1])
             fields = 2
-            signed = ~('u' in precision)
+            signed = not ('u' in precision)
         elif 'int' in precision:
             W = int(bits[0])
             I = W
             fields = 1
-            signed = ~('u' in precision)
+            signed = not ('u' in precision)
         if len(bits) > fields:
             round_mode = bits[fields]
         if len(bits) > fields+1:


### PR DESCRIPTION
- `ap_ufixed` was never being interpreted correctly because `~ (True)` is not the same as `not (True)`