### PR TITLE
Support special case of broadcasting during Merge layers

### DIFF
--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -1412,9 +1412,12 @@ class Merge(Layer):
         assert(len(self.inputs) == 2)
         inp1 = self.get_input_variable(self.inputs[0])
         inp2 = self.get_input_variable(self.inputs[1])
-        shape = inp1.shape
-        assert(inp1.shape == inp2.shape)
-        dims = inp1.dim_names
+        if np.prod(inp2.shape) > np.prod(inp1.shape):
+            shape = inp2.shape
+            dims = inp2.dim_names
+        else:
+            shape = inp1.shape
+            dims = inp1.dim_names
         self.add_output_variable(shape, dims)
 
     def function_cpp(self):
@@ -1432,7 +1435,12 @@ class Merge(Layer):
 
     def config_cpp(self):
         params = self._default_config_params()
-        params['n_elem'] = self.get_input_variable(self.inputs[0]).size_cpp()
+        inp1 = self.get_input_variable(self.inputs[0])
+        inp2 = self.get_input_variable(self.inputs[1])
+        if np.prod(inp2.shape) > np.prod(inp1.shape):
+            params['n_elem'] = inp2.size_cpp()
+        else:
+            params['n_elem'] = inp1.size_cpp()
 
         return self._config_template.format(**params)
 

--- a/hls4ml/model/optimizer/__init__.py
+++ b/hls4ml/model/optimizer/__init__.py
@@ -11,7 +11,7 @@ from hls4ml.model.optimizer.passes.conv_same_pad import InsertZeroPaddingBeforeC
 from hls4ml.model.optimizer.passes.conv_same_pad import InsertZeroPaddingBeforeConv2D
 from hls4ml.model.optimizer.passes.pointwise import OptimizePointwiseConv
 from hls4ml.model.optimizer.passes.clone import CloneOutput
-from hls4ml.model.optimizer.passes.repack_stream import ReshapeStream
+from hls4ml.model.optimizer.passes.repack_stream import ReshapeStream, BroadcastStream
 from hls4ml.model.optimizer.passes.multi_dense import ReplaceMultidimensionalDenseWithConv
 
 try:
@@ -33,6 +33,7 @@ register_pass('optimize_pointwise_conv', OptimizePointwiseConv)
 register_pass('clone_output', CloneOutput)
 register_pass('reshape_stream', ReshapeStream)
 register_pass('replace_multidense_conv', ReplaceMultidimensionalDenseWithConv)
+register_pass('broadcast_stream', BroadcastStream)
 
 if __qkeras_optimizers__:
     register_pass('output_rounding_saturation_mode', OutputRoundingSaturationMode)

--- a/hls4ml/model/optimizer/passes/repack_stream.py
+++ b/hls4ml/model/optimizer/passes/repack_stream.py
@@ -24,14 +24,47 @@ class Repack(Layer):
     def config_cpp(self):
         return None
 
+class Broadcast(Layer):
+    ''' Inserted between layers for broadcasting.'''
+
+    def initialize(self):
+        shape = self.attributes['target_shape']
+        if shape[0] is None:
+            shape = shape[1:]
+        dims = ['N_SIZE_{}_{}'.format(i, self.index) for i in range(1, len(shape) + 1)]
+        self.add_output_variable(shape, dims)
+
+    def function_cpp(self):
+        params = self._default_function_params()
+        return [self._function_template.format(**params)]
+
+    def config_cpp(self):
+        params = self._default_config_params()
+        params['in_height'] = self.get_input_variable().shape[0]
+        params['in_width'] = self.get_input_variable().shape[1]
+        params['n_chan'] = self.get_input_variable().shape[2]
+        params['n_dupl'] = int(np.prod(self.get_output_variable().shape)/np.prod(self.get_input_variable().shape))
+        return self._config_template.format(**params)
+
 repack_function_template = 'nnet::repack_stream<{input_t}, {output_t}, {size}>({input}, {output});'
 repack_include_list = ['nnet_utils/nnet_stream.h']
 
+broadcast_function_template = 'nnet::broadcast_stream<{input_t}, {output_t}, {config}>({input}, {output});'
+broadcast_config_template = """struct config{index} : nnet::broadcast_config {{
+static const unsigned in_width = {in_width};
+static const unsigned in_height = {in_height};
+static const unsigned n_chan = {n_chan};
+static const unsigned n_dupl = {n_dupl};
+}};\n"""
+broadcast_include_list = ['nnet_utils/nnet_stream.h']
+
 # Register the layer types to the layer map
 register_layer('Repack', Repack)
+register_layer('Broadcast', Broadcast)
 
 # Register the templates for config and function
 templates.get_backend('Vivado').register_templates('Repack', repack_function_template, None, repack_include_list)
+templates.get_backend('Vivado').register_templates('Broadcast', broadcast_function_template, broadcast_config_template, broadcast_include_list)
 
 
 class ReshapeStream(OptimizerPass):
@@ -51,5 +84,40 @@ class ReshapeStream(OptimizerPass):
         # Insert new Repack node instead of Reshape
         repack_layer = model.make_node('Repack', 'repack_' + node.name, attrs, node.inputs.copy())
         model.replace_node(node, repack_layer)
+
+        return True
+
+class BroadcastStream(OptimizerPass):
+    def match(self, node):
+        if node.__class__.__name__ == 'Merge':
+            try: 
+                inp1 = node.get_input_variable(node.inputs[0])
+                inp2 = node.get_input_variable(node.inputs[1])
+                return inp1.shape != inp2.shape
+            except:
+                return False
+        else:
+            return False
+        
+    def transform(self, model, node):
+        if model.config.backend.name not in ['Vivado'] or \
+            model.config.get_config_value('IOType') != 'io_stream':
+            return False
+            
+        inp1 = node.get_input_variable(node.inputs[0])
+        inp2 = node.get_input_variable(node.inputs[1])
+        if np.prod(inp1.shape) > np.prod(inp2.shape):
+            idx = 1
+            attrs = {
+                'target_shape': inp1.shape
+            }
+        else:
+            idx = 0
+            attrs = {
+                'target_shape': inp2.shape
+            }
+        brdcst_layer = model.make_node('Broadcast', 'broadcast_' + node.inputs[idx], attrs, [node.inputs[idx]].copy())
+        model.insert_node(brdcst_layer)
+        node.inputs[idx] = 'broadcast_' + node.inputs[idx]
 
         return True

--- a/hls4ml/model/optimizer/passes/repack_stream.py
+++ b/hls4ml/model/optimizer/passes/repack_stream.py
@@ -90,12 +90,9 @@ class ReshapeStream(OptimizerPass):
 class BroadcastStream(OptimizerPass):
     def match(self, node):
         if node.__class__.__name__ == 'Merge':
-            try: 
-                inp1 = node.get_input_variable(node.inputs[0])
-                inp2 = node.get_input_variable(node.inputs[1])
-                return inp1.shape != inp2.shape
-            except:
-                return False
+            inp1 = node.get_input_variable(node.inputs[0])
+            inp2 = node.get_input_variable(node.inputs[1])
+            return inp1.shape != inp2.shape
         else:
             return False
         

--- a/hls4ml/templates/vivado/nnet_utils/nnet_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_stream.h
@@ -6,6 +6,14 @@
 
 namespace nnet {
 
+struct broadcast_config
+{
+  static const unsigned in_height = 10;
+  static const unsigned in_width = 10;
+  static const unsigned n_chan = 1;
+  static const unsigned n_dupl = 2;
+};
+
 template<class data_T, class res_T, int N>
 void clone_stream(hls::stream<data_T> &data, hls::stream<res_T> &res1, hls::stream<res_T> &res2) {
     CloneLoop: for (int i = 0; i < N / data_T::size; i++) {
@@ -90,6 +98,23 @@ void repack_stream(hls::stream<data_T> &data, hls::stream<res_T> &res) {
     }
 }
 
+template<class data_T, class res_T, typename CONFIG_T>
+void broadcast_stream(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+    BroadcastLoop: for (int i = 0; i < CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan / data_T::size; i++) {
+        #pragma HLS PIPELINE
+        data_T in_data = data.read();
+	for (int j = 0; j < CONFIG_T::n_dupl; j++) {
+          #pragma HLS PIPELINE
+          res_T out_data;
+          #pragma HLS DATA_PACK variable=out_data
+	  for (int k = 0; k < res_T::size; k++) {
+            #pragma HLS UNROLL
+	    out_data[k] = in_data[k];
+          }
+	  res.write(out_data);
+        }
+    }
+}
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_stream.h
@@ -103,15 +103,15 @@ void broadcast_stream(hls::stream<data_T> &data, hls::stream<res_T> &res) {
     BroadcastLoop: for (int i = 0; i < CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan / data_T::size; i++) {
         #pragma HLS PIPELINE
         data_T in_data = data.read();
-	for (int j = 0; j < CONFIG_T::n_dupl; j++) {
-          #pragma HLS PIPELINE
-          res_T out_data;
-          #pragma HLS DATA_PACK variable=out_data
-	  for (int k = 0; k < res_T::size; k++) {
-            #pragma HLS UNROLL
-	    out_data[k] = in_data[k];
-          }
-	  res.write(out_data);
+        for (int j = 0; j < CONFIG_T::n_dupl; j++) {
+            #pragma HLS PIPELINE
+            res_T out_data;
+            #pragma HLS DATA_PACK variable=out_data
+            for (int k = 0; k < res_T::size; k++) {
+                #pragma HLS UNROLL
+                out_data[k] = in_data[k];
+            }
+            res.write(out_data);
         }
     }
 }


### PR DESCRIPTION
- Support special case of broadcasting during Merge layers
- The case is `Tensor(shape=[H, W, C]) + Tensor(shape=[1, 1, C]) = Tensor(shape=[H, W, C])`
- Was used for skip connections in small ResNet models
- Only for `io_stream`

We also have a use case for `io_parallel` and `Tensor(shape=[N, C]) + Tensor(shape=[N, 1]) = Tensor(shape=[N, C])` so it'd be great to generalize this PR to handle that as well