### PR TITLE
Fixes to `QKerasFactorizeAlpha` for `Strategy: Resource`

### DIFF
--- a/hls4ml/model/optimizer/passes/qkeras.py
+++ b/hls4ml/model/optimizer/passes/qkeras.py
@@ -147,7 +147,10 @@ class QKerasFactorizeAlpha(OptimizerPass):
 
         # update the weights also applying the hls4ml quantizer
         # this is only needed for the binary layers which encode -1 as 0
-        node.weights['weight'].data = node.weights['weight'].quantizer(new_weights.numpy())
+        quantized_new_weights = node.weights['weight'].quantizer(new_weights.numpy())
+        if node.model.config.is_resource_strategy(node):
+            quantized_new_weights = quantized_new_weights.T
+        node.weights['weight'].data = quantized_new_weights
 
         # Move the biases from the Dense layer to the ApplyAlpha layer
         bias = node.weights['bias'].data

--- a/hls4ml/model/optimizer/passes/qkeras.py
+++ b/hls4ml/model/optimizer/passes/qkeras.py
@@ -131,7 +131,7 @@ class QKerasFactorizeAlpha(OptimizerPass):
         weights = node.weights['weight'].data_unquantized # get weights
         qweights = quantizer(tf.convert_to_tensor(weights))
         if isinstance(quantizer.scale, (int, float)):
-            scale = np.ones(shape=node.get_output_variable().shape) * quantizer.scale
+            scale = np.ones(shape=node.get_output_variable().shape[-1]) * quantizer.scale
         else:
             scale = quantizer.scale.numpy()
         unscale = 1. / scale

--- a/hls4ml/model/optimizer/passes/qkeras.py
+++ b/hls4ml/model/optimizer/passes/qkeras.py
@@ -149,7 +149,9 @@ class QKerasFactorizeAlpha(OptimizerPass):
         # this is only needed for the binary layers which encode -1 as 0
         quantized_new_weights = node.weights['weight'].quantizer(new_weights.numpy())
         if node.model.config.is_resource_strategy(node):
-            quantized_new_weights = quantized_new_weights.T
+            ndim = len(weights.shape) - 1
+            perm = [ndim] + [i for i in range(ndim)]
+            quantized_new_weights = np.transpose(quantized_new_weights, axes=perm)
         node.weights['weight'].data = quantized_new_weights
 
         # Move the biases from the Dense layer to the ApplyAlpha layer


### PR DESCRIPTION
`QKerasFactorizeAlpha` optimizer pass didn't handle the transposed weights of resource strategy layers. Uncovered by #335. This PR fixes that.

Also, when the `alpha` is a scalar, the inferred shape was wrong for CNN models. 