### PR TITLE
Fix critical bugs in get_unoptimized_hlsmodel() in profiling.py

### DIFF
--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -34,6 +34,9 @@ def get_unoptimized_hlsmodel(model):
     while os.path.exists(new_output_dir):
         new_output_dir = uuid.uuid4().hex
 
+    if 'SkipOptimizers' in new_config['HLSConfig']:
+        del new_config['HLSConfig']['SkipOptimizers']
+
     new_config['HLSConfig']['Optimizers'] = []
     new_config['OutputDir'] = new_output_dir
 

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -7,6 +7,7 @@ import seaborn as sb
 import uuid
 import os
 import shutil
+import json
 from collections import defaultdict
 
 from hls4ml.model.hls_model import HLSModel
@@ -29,6 +30,8 @@ def get_unoptimized_hlsmodel(model):
     from hls4ml.converters import convert_from_config
 
     new_config = model.config.config.copy()
+    new_config['HLSConfig'] = json.loads(json.dumps(new_config['HLSConfig']))
+
     new_output_dir = uuid.uuid4().hex
 
     while os.path.exists(new_output_dir):


### PR DESCRIPTION
This PR fixes the following issues:

- When `hls4ml.model.profiling.numerical()` is called with a model, all 'Optimizers' and 'SkipOptimizers' entries in the model internal config are cleared or deleted instead of being left intact.
- When `hls4ml.model.profiling.numerical()` is called with a model that has 'SkipOptimizers' in its dictionary config, the function fails to obtain the unoptimised version of the model because of a crash.