### PR TITLE
[WIP] Added naive ability to parse vivado synthesis reports

### DIFF
--- a/hls4ml/report/vivado_report.py
+++ b/hls4ml/report/vivado_report.py
@@ -158,6 +158,23 @@ def parse_vivado_report(hls_dir):
     else:
         print('Synthesis report not found.')
 
+    vivado_syn_file = hls_dir + '/vivado_synth.rpt'
+    if os.path.isfile(vivado_syn_file):
+        vivado_synth_rpt = {}
+        with open(vivado_syn_file) as f:
+            for line in f.readlines():
+                if 'CLB LUTs' in line:
+                    vivado_synth_rpt['LUT'] = line.split('|')[2].strip()
+                elif 'CLB Registers' in line:
+                    vivado_synth_rpt['FF'] = line.split('|')[2].strip()
+                elif 'RAMB18 ' in line:
+                    vivado_synth_rpt['BRAM_18K'] = line.split('|')[2].strip()
+                elif 'DSPs' in line:
+                    vivado_synth_rpt['DSP48E'] = line.split('|')[2].strip()
+                elif 'URAM' in line:
+                    vivado_synth_rpt['URAM'] = line.split('|')[2].strip()
+        report['VivadoSynthReport'] = vivado_synth_rpt
+
     cosim_file = sln_dir + '/' + solutions[0] + '/sim/report/{}_cosim.rpt'.format(top_func_name)
     if os.path.isfile(cosim_file):
         with open(cosim_file, 'r') as f:


### PR DESCRIPTION
I noticed that the current `hls4ml.report.parse_vivado_report` doesn't support parsing the resulting `vivado_synth.rpt` if your model was built with `vsynth=True`. I'm currently in the process of trying to sweep a number of different designs for the purpose of determining whether they're feasible for my use case, and for that it is much more useful to have at least the post synthesis LUT and FF estimates as they are much more accurate than the Vivado HLS estimates.

However, after looking at the report's format, it made sense why `hls4ml` hasn't parsed it yet -- it's not necessarily output in the most machine readable format, and there don't seem to be other arguments to `report_utilization` that improve that.

Looking around online, [edalize](https://github.com/olofk/edalize/) has [an approach](https://github.com/olofk/edalize/blob/master/edalize/vivado_reporting.py) that uses [pyparsing](https://pypi.org/project/pyparsing/), but that seemed like quite a bit to either (i) pull in the whole `edalize` package as a dependency and use it here or (ii) go through their inheritance hierarchy, figure out how they're pulling off the parsing and repeat that internally here

So, for my own needs, I just threw together this small set of changes, and I figured I'd open up this PR to
- have at least something available if anyone else would benefit from similar functionality
- get some feedback on if anyone can think of a different/smarter/less hard-coded approach that I might be missing (or if the `edalize` approach seems like the best option after all)