### PR TITLE
Fix Concatenate on different axes

### DIFF
--- a/hls4ml/converters/keras/merge.py
+++ b/hls4ml/converters/keras/merge.py
@@ -10,13 +10,14 @@ def parse_merge_layer(keras_layer, input_names, input_shapes, data_reader, confi
 
     layer['op'] = layer['class_name'].lower()
 
+    output_shape = input_shapes[0][:]
     if layer['class_name'] == 'Concatenate':
         rank = len(input_shapes[0][1:])
         if rank > 3:
             raise Exception('ERROR: Concatenation of tensors with rank > 3 is not yet supported.')
         layer['op'] = layer['class_name'].lower() + '{}d'.format(rank)
         layer['axis'] = keras_layer['config']['axis']
-        #TODO handle output shape
+        output_shape[layer['axis']] += input_shapes[1][layer['axis']]
     elif layer['class_name'] == 'Dot':
         rank = len(input_shapes[0][1:])
         if rank > 1:
@@ -27,4 +28,4 @@ def parse_merge_layer(keras_layer, input_names, input_shapes, data_reader, confi
     if len(layer['inputs']) > 2:
         raise Exception('ERROR: Merging more than two tensors is not yet supported.')
 
-    return layer, input_shapes[0]
+    return layer, output_shape

--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -273,12 +273,12 @@ def keras_to_hls(config):
     for keras_layer in layer_config:
         if 'batch_input_shape' in keras_layer['config']:
             if 'inbound_nodes' in keras_layer and len(keras_layer['inbound_nodes']) > 0:
-                input_shapes = [output_shapes[inbound_node[0][0]] for inbound_node in keras_layer['inbound_nodes']]
+                input_shapes = [output_shapes[inbound_node[0]] for inbound_node in keras_layer['inbound_nodes'][0]]
             else:
                 input_shapes = [keras_layer['config']['batch_input_shape']]
         else:
             if 'inbound_nodes' in keras_layer:
-                input_shapes = [output_shapes[inbound_node[0][0]] for inbound_node in keras_layer['inbound_nodes']]
+                input_shapes = [output_shapes[inbound_node[0]] for inbound_node in keras_layer['inbound_nodes'][0]]
             else:
                 # Sequential model, so output_shape from the previous layer is still valid 
                 input_shapes = [output_shape]
@@ -311,7 +311,7 @@ def keras_to_hls(config):
 
         layer, output_shape = layer_handlers[keras_class](keras_layer, input_names, input_shapes, reader, config)
 
-        print('Layer name: {}, layer type: {}, current shape: {}'.format(layer['name'], layer['class_name'], input_shapes))
+        print('Layer name: {}, layer type: {}, input shapes: {}, output shape: {}'.format(layer['name'], layer['class_name'], input_shapes, output_shape))
         layer_list.append( layer )
         if 'activation' in layer and layer['class_name'] not in ['Activation', 'LeakyReLU', 'ThresholdedReLU', 'ELU', 'PReLU', 'Softmax']:# + qkeras_layers:
             act_layer = {}

--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -1453,6 +1453,7 @@ class Concatenate(Merge):
         inp1 = self.get_input_variable(self.inputs[0])
         inp2 = self.get_input_variable(self.inputs[1])
         axis = self.attributes['axis']
+        if axis > 0: axis -= 1
         shape = inp1.shape[:]
         shape[axis] += inp2.shape[axis]
         rank = len(shape)

--- a/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
@@ -199,7 +199,7 @@ void concatenate2d(
 	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
     res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1])
 {
-    if (CONFIG_T::axis == 1 || CONFIG_T::axis == -1) {
+    if (CONFIG_T::axis == 2 || CONFIG_T::axis == -1) {
         concatenate2d_1<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
     } else {
         concatenate2d_0<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
@@ -289,9 +289,9 @@ void concatenate3d(
 	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
     res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
 {
-    if (CONFIG_T::axis == 2 || CONFIG_T::axis == -1) {
+    if (CONFIG_T::axis == 3 || CONFIG_T::axis == -1) {
         concatenate3d_2<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
-    } else if (CONFIG_T::axis == 1) {
+    } else if (CONFIG_T::axis == 2 || CONFIG_T::axis == -2) {
         concatenate3d_1<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
     } else {
         concatenate3d_0<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -227,7 +227,7 @@ concat_config_template = """struct config{index} : nnet::concat_config {{
     static const unsigned n_elem2_1 = {n_elem2_1};
     static const unsigned n_elem2_2 = {n_elem2_2};
 
-    static const unsigned axis = {axis};
+    static const int axis = {axis};
 }};\n"""
 
 resize_config_template = """struct config{index} : nnet::resize_config {{


### PR DESCRIPTION
- Keras Concatenate layer assumes `axis=0` is the batch dimension, so if we are parsing that directly, we need to consider that, i.e.
  - for 2D concatenation, `axis = 2` or `axis = -1`, means we use `concatenate2d_1`; otherwise we use `concatenate2d_0`
  - for 3D concatenation, `axis = 3` or `axis = -1`, means we use `concatenate3d_2`; `axis = 2` or `axis = -2` means we use `concatenate3d_1`; otherwise we use `concatenate3d_0`
- Also fix shape inference 