### PR TITLE
Support doing Dense over n-dimensional (n>1) tensor with 1x1 Conv

### DIFF
--- a/hls4ml/converters/keras/core.py
+++ b/hls4ml/converters/keras/core.py
@@ -70,7 +70,8 @@ def parse_dense_layer(keras_layer, input_names, input_shapes, data_reader, confi
     else:
         layer['weight_quantizer'] = None
         layer['bias_quantizer'] = None
-    output_shape = [input_shapes[0][0], layer['n_out']]
+    output_shape = input_shapes[0][:]
+    output_shape[-1] = layer['n_out']
 
     return layer, output_shape
 

--- a/hls4ml/model/optimizer/__init__.py
+++ b/hls4ml/model/optimizer/__init__.py
@@ -12,6 +12,7 @@ from hls4ml.model.optimizer.passes.conv_same_pad import InsertZeroPaddingBeforeC
 from hls4ml.model.optimizer.passes.pointwise import OptimizePointwiseConv
 from hls4ml.model.optimizer.passes.clone import CloneOutput
 from hls4ml.model.optimizer.passes.repack_stream import ReshapeStream
+from hls4ml.model.optimizer.passes.multi_dense import ReplaceMultidimensionalDenseWithConv
 
 try:
     from hls4ml.model.optimizer.passes.qkeras import OutputRoundingSaturationMode
@@ -31,6 +32,7 @@ register_pass('conv2d_same_pad', InsertZeroPaddingBeforeConv2D)
 register_pass('optimize_pointwise_conv', OptimizePointwiseConv)
 register_pass('clone_output', CloneOutput)
 register_pass('reshape_stream', ReshapeStream)
+register_pass('replace_multidense_conv', ReplaceMultidimensionalDenseWithConv)
 
 if __qkeras_optimizers__:
     register_pass('output_rounding_saturation_mode', OutputRoundingSaturationMode)

--- a/hls4ml/model/optimizer/passes/multi_dense.py
+++ b/hls4ml/model/optimizer/passes/multi_dense.py
@@ -1,0 +1,52 @@
+from hls4ml.model.optimizer import OptimizerPass
+from hls4ml.model.hls_model import Dense
+
+
+class ReplaceMultidimensionalDenseWithConv(OptimizerPass):
+    def match(self, node):
+        return node.__class__.__name__ == 'Dense' and \
+            len(node.get_input_variable().shape) > 1
+
+    def transform(self, model, node):
+        dim = len(node.get_input_variable().shape) - 1        
+        input_shape = node.get_input_variable().shape
+
+        pointwise_attrs = {
+            'data_format': 'channels_last',
+            'padding': 'valid',
+            'n_chan': input_shape[-1],
+            'n_filt': node.get_attr('n_out'),
+        }
+
+        if dim == 1:
+            pointwise_attrs.update({
+                'in_width': input_shape[0],
+                'out_width': input_shape[0],
+                'filt_width': 1,
+                'stride_width': 1,
+                'pad_left': 0,
+                'pad_right': 0,
+            })
+        elif dim == 2:
+            pointwise_attrs.update({
+                'in_height': input_shape[0],
+                'in_width': input_shape[1],
+                'out_height': input_shape[0],
+                'out_width': input_shape[1],
+                'filt_height': 1,
+                'filt_width': 1,
+                'stride_height': 1,
+                'stride_width': 1,
+                'pad_top': 0,
+                'pad_bottom': 0,
+                'pad_left': 0,
+                'pad_right': 0,
+            })
+        else:
+            raise Exception('Cannot replace Dense over {dim}D tensor with Conv{dim}D.'.format(dim=dim))
+
+        class_name = 'PointwiseConv' + str(dim) + 'D'
+        pw_node = model.make_node(class_name, node.name, pointwise_attrs, node.inputs.copy())
+        model.replace_node(node, pw_node)
+        
+        return True

--- a/hls4ml/model/optimizer/passes/multi_dense.py
+++ b/hls4ml/model/optimizer/passes/multi_dense.py
@@ -1,6 +1,6 @@
 from hls4ml.model.optimizer import OptimizerPass
 from hls4ml.model.hls_model import Dense
-
+import numpy as np
 
 class ReplaceMultidimensionalDenseWithConv(OptimizerPass):
     def match(self, node):
@@ -47,6 +47,9 @@ class ReplaceMultidimensionalDenseWithConv(OptimizerPass):
 
         class_name = 'PointwiseConv' + str(dim) + 'D'
         pw_node = model.make_node(class_name, node.name, pointwise_attrs, node.inputs.copy())
+        if len(node.weights['weight'].data.shape) == 2: # This can happen if we assign weights of Dense layer to 1x1 Conv2D
+            pw_node.weights['weight'].data = np.expand_dims(node.weights['weight'].data, axis=(0,1))
+        pw_node.weights['bias'].data = node.weights['bias'].data
         model.replace_node(node, pw_node)
         
         return True

--- a/hls4ml/model/optimizer/passes/pointwise.py
+++ b/hls4ml/model/optimizer/passes/pointwise.py
@@ -51,6 +51,9 @@ class OptimizePointwiseConv(OptimizerPass):
     def transform(self, model, node):
         dim = node.__class__.__name__[-2:] # '1D' or '2D'
         pw_node = model.make_node('PointwiseConv' + dim, node.name, node.attributes.copy(), node.inputs.copy())
+        if len(node.weights['weight'].data.shape) == 2: # This can happen if we assign weights of Dense layer to 1x1 Conv2D
+            pw_node.weights['weight'].data = np.expand_dims(node.weights['weight'].data, axis=(0,1))
+        pw_node.weights['bias'].data = node.weights['bias'].data
         model.replace_node(node, pw_node)
         
         return True

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv2d_latency.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv2d_latency.h
@@ -281,5 +281,105 @@ void conv_2d_latency_cl(
 
 }//end conv2d
 
+template<class data_T, class res_T, typename CONFIG_T>
+void pointwise_conv_2d_cl(
+    data_T data[CONFIG_T::in_height*CONFIG_T::in_width*CONFIG_T::n_chan],
+    res_T  res[CONFIG_T::out_height*CONFIG_T::out_width*CONFIG_T::n_filt],
+    typename CONFIG_T::weight_t weights[CONFIG_T::n_chan * CONFIG_T::n_filt],
+    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
+{
+
+    typename CONFIG_T::accum_t mult[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan];
+    typename CONFIG_T::accum_t acc[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt];
+
+    #pragma HLS ARRAY_PARTITION variable=mult complete dim=0
+    #pragma HLS ARRAY_PARTITION variable=acc complete dim=0
+
+    // Use a function_instantiate in case it helps to explicitly optimize unchanging weights/biases
+    #pragma HLS function_instantiate variable=weights,biases
+
+    // Parallel mode
+    #pragma HLS PIPELINE
+    #pragma HLS ARRAY_PARTITION variable=biases complete dim=0
+
+    // Limit multipliers to control parallelization
+    const int multiplier_limit = compute_multiplier_limit_conv2d<CONFIG_T>(weights);
+    #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
+
+    // Convolve, saving all multiplication results to accumulate later
+    ConvOutHeight: for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
+        ConvOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            ConvFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                ConvChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+
+                    int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan
+                                   + ow*CONFIG_T::n_filt*CONFIG_T::n_chan
+                                   + ff*CONFIG_T::n_chan
+                                   + cc;
+
+                    int index_weight = cc*CONFIG_T::n_filt + ff;
+
+                    if ((oh*CONFIG_T::stride_height) < CONFIG_T::pad_top
+                    || (oh*CONFIG_T::stride_height) >= (CONFIG_T::pad_top+CONFIG_T::in_height)
+                    || (ow*CONFIG_T::stride_width) < CONFIG_T::pad_left
+                    || (ow*CONFIG_T::stride_width) >= (CONFIG_T::pad_left+CONFIG_T::in_width)) {
+                        mult[index_mult] = 0;
+                    } else {
+                        int index_data = (oh*CONFIG_T::stride_height-CONFIG_T::pad_top)*CONFIG_T::in_width*CONFIG_T::n_chan
+                                       + (ow*CONFIG_T::stride_width-CONFIG_T::pad_left)*CONFIG_T::n_chan
+                                       + cc;
+                        mult[index_mult] = data[index_data] * weights[index_weight];
+                    }
+
+                }
+            }
+        }
+    }
+
+
+    // Initialize accumulator with input biases
+    for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
+        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                acc[oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff]=biases[ff];
+            }
+        }
+    }
+
+
+    // Accumulate multiplication result
+    AccumOutHeight: for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
+        AccumOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            AccumFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                //Do "dot product" sum within filter and sum over channels
+                AccumChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++) {
+
+                    int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan
+                                    + ow*CONFIG_T::n_filt*CONFIG_T::n_chan
+                                    + ff*CONFIG_T::n_chan
+                                    + cc;
+                    int index_acc = oh*CONFIG_T::out_width*CONFIG_T::n_filt
+                                    + ow*CONFIG_T::n_filt
+                                    + ff;
+
+                    acc[index_acc] += mult[index_mult];
+
+                }
+            }
+        }
+    }
+
+    // Cast to "res_t" type
+    for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
+        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
+              for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                int index = oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff;
+                res[index] = (res_T)(acc[index]);
+            }
+        }
+    }
+
+}//end conv2d
+
 }
 #endif


### PR DESCRIPTION
As was discussed before, we currently don't support `Dense` layer being applied to `n`-dimensional tensor (with `n>1`, not counting the batch dimension). This operation is equivalent to doing 1x1 convolution over the same tensor, which we support as a special case. This PR does that by adding an optimizer that replaces `Dense` with `PointwiseConv1D/2D`. To support this, converter also had to be extended to properly handle the output shape as well as the `Dense` layer itself in the hls4ml IR.

Test case can be found [here](https://gist.github.com/vloncar/2b7bb326bb4b8878e6bb251612c8e670)