### PR TITLE
Update graph insert/remove/replace

### DIFF
--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -427,7 +427,12 @@ class HLSModel(object):
             if len(node.inputs) > 1 or len(node.outputs) > 1:
                 raise Exception('Cannot rewire a node with multiple inputs/outputs')
             prev_node = self.graph.get(node.inputs[0])
-            next_node = next((x for x in self.graph.values() if node.outputs[0] in x.inputs), None)
+            next_nodes = [x for x in self.graph.values() if node.outputs[0] in x.inputs]
+            if len(next_nodes) == 0:
+                if node.outputs[0] in self.outputs:
+                    self.outputs = [node.inputs[0] if x == node.outputs[0] else x for x in self.outputs] 
+                else:
+                    raise Exception('Cannot rewire a node which has no child nor is an output node')
             if prev_node is not None:
                 if next_node is not None:
                     for i,_ in enumerate(next_node.inputs):
@@ -453,15 +458,8 @@ class HLSModel(object):
             new_node (Layer): The new node
 
         """
-        prev_node = self.graph.get(old_node.inputs[0])
-        next_node = next((x for x in self.graph.values() if x.inputs[0] == old_node.outputs[0]), None)
-        if next_node is not None:
-            next_node.inputs[0] = new_node.outputs[0]
-        if prev_node is not None:
-            if new_node.inputs is None or len(new_node.inputs) == 0: # Check if already rewired
-                new_node.inputs = [prev_node.outputs[0]]
-
-        self.graph = OrderedDict((new_node.name, new_node) if k == old_node.name else (k, v) for k, v in self.graph.items())
+        self.insert_node(new_node, before=old_node)
+        self.remove_node(old_node, rewire=True)
 
     def get_weights_data(self, layer_name, var_name):
         return self.reader.get_weights_data(layer_name, var_name)


### PR DESCRIPTION
- In `remove_node`, when the node being removed is an output node, the model outputs need to be reconnected to the input of the removed node.
- In `remove_node`, we raise an exception that we cannot handle nodes with multiple outputs (nor inputs). However, even for a node with a single output, that output may be consumed my multiple other nodes. So I've added a loop over nodes connected to that output, reconnecting them to the removed node's input whereas previously only one node would have been reconnected
- Rather than `replace_node` duplicating that logic, I've modified it to use `insert_node` then `remove_node` directly.