### PR TITLE
Fix graph for multiple model inputs

### DIFF
--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -385,7 +385,11 @@ class Layer(object):
 
     def get_input_node(self, input_name=None):
         if input_name is not None:
-            return self.model.graph.get(input_name)
+            nodes = [node for node in self.model.graph.values() if input_name in node.outputs]
+            if len(nodes) == 0:
+                return None
+            else:
+                return nodes[0]
         else:
             return self.model.graph.get(self.inputs[0])
 

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -323,7 +323,9 @@ class HLSModel(object):
             name = layer['name']
             inputs = layer.get('inputs', [])
             outputs = layer.get('outputs', [])
-            if len(inputs) == 0:
+            if kind in ['InputLayer', 'Input']:
+                inputs = ['input']
+            elif len(inputs) == 0:
                 inputs = [next(reversed(self.graph), 'input')]
             if len(outputs) == 0:
                 outputs = [name]

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -387,10 +387,10 @@ class HLSModel(object):
         if len(node.inputs) > 1:
             raise Exception('Cannot insert a node with more than one input (for now).')
 
-        prev_node = self.graph.get(node.inputs[0])
-        next_nodes = [x for x in self.graph.values() if x.inputs[0] == prev_node.outputs[0]]
+        prev_node = node.get_input_node(node.inputs[0])
+        next_nodes = [x for x in self.graph.values() if x.inputs[0] in prev_node.outputs]
         if before is None:
-            next_node = next((x for x in self.graph.values() if x.inputs[0] == prev_node.outputs[0]), None)
+            next_node = next((x for x in self.graph.values() if x.inputs[0] in prev_node.outputs), None)
         else:
             if before not in next_nodes:
                 raise Exception('Cannot insert a node {} before {} (candidates: {}).'.format(node.name, before.name, ','.join([n.name for n in next_nodes])))

--- a/hls4ml/model/optimizer/passes/repack_stream.py
+++ b/hls4ml/model/optimizer/passes/repack_stream.py
@@ -114,8 +114,10 @@ class BroadcastStream(OptimizerPass):
             attrs = {
                 'target_shape': inp2.shape
             }
-        brdcst_layer = model.make_node('Broadcast', 'broadcast_' + node.inputs[idx], attrs, [node.inputs[idx]].copy())
+        brdcst_inp = node.inputs[idx]
+        brdcst_out = 'broadcast_' + brdcst_inp
+        brdcst_layer = model.make_node('Broadcast', brdcst_out, attrs, [brdcst_inp].copy())
         model.insert_node(brdcst_layer)
-        node.inputs[idx] = 'broadcast_' + node.inputs[idx]
+        node.inputs[idx] = brdcst_out
 
         return True

--- a/test/pytest/test_graph.py
+++ b/test/pytest/test_graph.py
@@ -19,6 +19,19 @@ def base_model(output_dir='hls4mlprj_graph_base_model', iotype = 'io_parallel'):
   model = hls4ml.model.HLSModel(config, reader, layers)
   return model
 
+def branch_model(output_dir='hls4mlprj_graph_branch_model', iotype = 'io_parallel'):
+  layers = [{'class_name' : 'Input', 'name' : 'layer0_input0', 'input_shape' : [1], 'inputs': 'input'},
+            {'class_name' : 'Input', 'name' : 'layer0_input1', 'input_shape' : [1], 'inputs': 'input'},
+            {'class_name' : 'Merge', 'name' : 'layer0', 'inputs' : ['layer0_input0', 'layer0_input1'], 'op' : 'add'},
+            {'class_name' : 'Merge', 'name' : 'layer1', 'inputs' : ['layer0_input1', 'layer0'], 'op' : 'add'},
+            {'class_name' : 'Merge', 'name' : 'layer2', 'inputs' : ['layer0_input0', 'layer1'], 'op' : 'add'}]
+  config = {'HLSConfig':{'Model':{'Precision':'ap_fixed<32,16>','ReuseFactor' : 1}}}
+  config['OutputDir'] = output_dir
+  config['ProjectName'] = 'myprj'
+  config['IOType'] = iotype
+  model = hls4ml.model.HLSModel(config, reader, layers, inputs=['layer0_input0', 'layer0_input1'])
+  return model
+
 def do_nop(model, node, layers):
   return model, layers
 
@@ -79,3 +92,17 @@ def test_graph_manipulation(parameters, iotype):
   actual_layers = np.array([layer.name for layer in list(model.get_layers())])
   if not skip_layers_check: # skip check for this model since order changes
     np.testing.assert_array_equal(expected_layers, actual_layers)
+
+@pytest.mark.parametrize('iotype', ['io_parallel', 'io_stream'])
+def test_graph_branch(iotype):
+  odir = 'hls4mlprj_graph_branch_model'
+  model = branch_model(odir, iotype)
+  original_layers = np.array([layer.name for layer in list(model.get_layers())])
+  model.compile()
+  hls4ml.utils.plot_model(model, show_shapes=True, show_precision=True, to_file='{}/model.png'.format(odir))
+  X0 = np.random.rand(1,1)
+  X1 = np.random.rand(1,1)
+  y_expected = 2*(X0+X1)
+  y = model.predict([X0, X1]).reshape(y_expected.shape)
+  # check the output
+  np.testing.assert_allclose(y, y_expected, rtol=1, atol=2**-16)


### PR DESCRIPTION
Purpose: Fix graph for multiple model inputs. 

- Issue: Currently, the second model input assumes the first model input is also an input to it. This PR fixes that behavior.
- This bug has a practical effect in that it will result in unnecessarily clone the first model input (because it sees it is "input" to two different layers) and cause an issue synthesizing the resulting HLS.
- Incorrect graph before the fix:
![model_hls4ml](https://user-images.githubusercontent.com/4932543/128457650-a564ab51-5628-440e-9775-1add9e4b4496.png)
- Correct graph after the fix:
![model_hls4ml](https://user-images.githubusercontent.com/4932543/128457327-02b72f98-87ff-44b0-8381-1dceca6b29ff.png)
- Test showing this behavior (fails on `fastmachinelearning:master`, succeeds on `jmduarte:multiple_inputs_fixes`): https://gist.github.com/jmduarte/d9146904980b6574032e90621ef383fb
- There's also a related issue of plotting graphs with layers with multiple outputs that I will try to fix in this PR