### PR TITLE
Propagate correct shape for Flatten layer

### DIFF
--- a/hls4ml/converters/keras/reshape.py
+++ b/hls4ml/converters/keras/reshape.py
@@ -4,6 +4,18 @@ from hls4ml.converters.keras_to_hls import parse_default_keras_layer
 from hls4ml.converters.keras_to_hls import keras_handler
 from hls4ml.converters.utils import parse_data_format
 
+@keras_handler('Flatten')
+def parse_flatten_layer(keras_layer, input_names, input_shapes, data_reader, config):
+    assert(keras_layer["class_name"] == 'Flatten')
+
+    layer = parse_default_keras_layer(keras_layer, input_names)
+    
+    layer['class_name'] = 'Reshape'
+    layer['target_shape'] = [input_shapes[0][0], np.prod(input_shapes[0][1:])]
+    output_shape = layer['target_shape']
+    
+    return layer, output_shape
+
 @keras_handler('Reshape')
 def parse_reshape_layer(keras_layer, input_names, input_shapes, data_reader, config):
     assert(keras_layer["class_name"] == 'Reshape')

--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -228,7 +228,7 @@ def keras_to_hls(config):
     #print(model_arch)
 
     #Define layers to skip for conversion to HLS
-    skip_layers = ['Dropout', 'Flatten']
+    skip_layers = ['Dropout']
     #All supported layers
     supported_layers = get_supported_keras_layers() + skip_layers
 
@@ -293,10 +293,7 @@ def keras_to_hls(config):
                 #Skipped layers can follow each other (e.g., Dropout -> Flatten)
                 inputs_map[name] = inputs_map.get(parent_input, parent_input)
 
-            if keras_class == 'Flatten':
-                output_shapes[keras_layer['config']['name']] = [input_shapes[0][0], np.prod(input_shapes[0][1:])]
-            else:
-                output_shapes[keras_layer['config']['name']] = input_shapes[0]
+            output_shapes[keras_layer['config']['name']] = input_shapes[0]
 
             continue
 


### PR DESCRIPTION
The recent addition of supporting doing `Dense` over multi-dimensional tensors (#366) introduced an issue with the output shape of `Flatten` layer being ignored. Since `Flatten` is skipped, the optimizer would check for the preceding layer's output which can be the layer before `Flatten` and replace `Dense` with 1x1 `Conv`.

This is fixed by properly handling `Flatten` as a `Reshape`. This allows the optimzer to properly handle the shapes and `Reshape` is just a placeholder that has no impact on HLS.

[Test case](https://gist.github.com/vloncar/ff5864d9a1b7eee2665bc4f6b0d127ad).

Side note: this leaves `Dropout` as the only skipped layer. We might as well parse it and all other regularization layers properly into `HLSModel` and remove them in the `nop` optimizer where we have better ways of handling graph transformations.