### PR TITLE
PyTorch.Geometric to HLS4ML

### DIFF
--- a/contrib/interaction_network.py
+++ b/contrib/interaction_network.py
@@ -1,0 +1,77 @@
+import torch
+import torch_geometric
+from torch import Tensor
+
+import torch.nn as nn
+import torch.nn.functional as F
+import torch_geometric.transforms as T
+from torch_geometric.nn import MessagePassing
+from torch.nn import Sequential as Seq, Linear, ReLU, Sigmoid
+
+class RelationalModel(nn.Module):
+    def __init__(self, input_size, output_size, hidden_size):
+        super(RelationalModel, self).__init__()
+
+        self.layers = nn.Sequential(
+            nn.Linear(input_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, output_size),
+        )
+
+    def forward(self, m):
+        return self.layers(m)
+
+class ObjectModel(nn.Module):
+    def __init__(self, input_size, output_size, hidden_size):
+        super(ObjectModel, self).__init__()
+
+        self.layers = nn.Sequential(
+            nn.Linear(input_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, output_size),
+        )
+
+    def forward(self, C):
+        return self.layers(C)
+
+
+class InteractionNetwork(MessagePassing):
+    def __init__(self, aggr='add', flow='source_to_target', hidden_size=40):
+        super(InteractionNetwork, self).__init__(aggr=aggr,
+                                                 flow=flow)
+        self.R1 = RelationalModel(10, 4, hidden_size)
+        self.O = ObjectModel(7, 3, hidden_size)
+        self.R2 = RelationalModel(10, 1, hidden_size)
+        self.E: Tensor = Tensor()
+
+    def forward(self, x: Tensor, edge_index: Tensor, edge_attr: Tensor) -> Tensor:
+
+        # propagate_type: (x: Tensor, edge_attr: Tensor)
+        x_tilde = self.propagate(edge_index, x=x, edge_attr=edge_attr, size=None)
+
+        if self.flow == 'source_to_target':
+            r = edge_index[1]
+            s = edge_index[0]
+        else:
+            r = edge_index[0]
+            s = edge_index[1]
+
+        m2 = torch.cat([x_tilde[r],
+                        x_tilde[s],
+                        self.E], dim=1)
+        return torch.sigmoid(self.R2(m2))
+
+    def message(self, x_i, x_j, edge_attr):
+        # x_i --> incoming
+        # x_j --> outgoing        
+        m1 = torch.cat([x_i, x_j, edge_attr], dim=1)
+        self.E = self.R1(m1)
+        return self.E
+
+    def update(self, aggr_out, x):
+        c = torch.cat([x, aggr_out], dim=1)
+        return self.O(c) 

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -310,7 +310,7 @@ def check_forward_dict(model, forward_dictionary):
 def convert_from_pyg_model(model, forward_dictionary, n_node, node_dim,
                            n_edge, edge_dim, activate_final=None,
                            output_dir='my-hls-test', project_name='myproject',
-                           fpga_part='xcku115-flvb2104-2-i', clock_period=5, io_type='io_parallel', hls_config={}):
+                           part='xcku115-flvb2104-2-i', clock_period=5, io_type='io_parallel', hls_config={}):
     check_forward_dict(model, forward_dictionary)
     """
 
@@ -369,7 +369,7 @@ def convert_from_pyg_model(model, forward_dictionary, n_node, node_dim,
         Output directory to write hls codes.
     project_name : string, optional
         hls project name.
-    fpga_part : string, optional
+    part : string, optional
         The particular FPGA part number that you are considering.
     clock_period : int, optional
         The clock period, in ns, at which your algorithm runs.
@@ -405,10 +405,10 @@ def convert_from_pyg_model(model, forward_dictionary, n_node, node_dim,
 
     """
 
-    config = create_vivado_config(
+    config = create_config(
         output_dir=output_dir,
         project_name=project_name,
-        fpga_part=fpga_part,
+        part=part,
         clock_period=clock_period,
         io_type=io_type
     )

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -302,7 +302,11 @@ def convert_from_pytorch_model(model, input_shape, output_dir='my-hls-test', pro
 
 def check_forward_dict(model, forward_dictionary):
     for key in forward_dictionary:
-        assert(hasattr(model, key))
+        try:
+            block = getattr(model, key)
+        except AttributeError:
+            raise AttributeError(f'Model is missing module "{key}" that is present in the provided forward dictionary; Check compatability')
+
 def convert_from_pyg_model(model, n_node, node_dim, n_edge, edge_dim,
                            forward_dictionary=None, activate_final=None,
                            output_dir='my-hls-test', project_name='myproject',

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -300,11 +300,14 @@ def convert_from_pytorch_model(model, input_shape, output_dir='my-hls-test', pro
     
     return pytorch_to_hls(config)
 
+def check_forward_dict(model, forward_dictionary):
+    for key in forward_dictionary:
+        assert(hasattr(model, key))
 def convert_from_pyg_model(model, n_node, node_dim, n_edge, edge_dim,
                            forward_dictionary=None, activate_final=None,
                            output_dir='my-hls-test', project_name='myproject',
                            fpga_part='xcku115-flvb2104-2-i', clock_period=5, io_type='io_parallel', hls_config={}):
-    
+    check_forward_dict(model, forward_dictionary)
     config = create_vivado_config(
         output_dir=output_dir,
         project_name=project_name,

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -307,8 +307,8 @@ def check_forward_dict(model, forward_dictionary):
         except AttributeError:
             raise AttributeError(f'Model is missing module "{key}" that is present in the provided forward dictionary; Check compatability')
 
-def convert_from_pyg_model(model, n_node, node_dim, n_edge, edge_dim,
-                           forward_dictionary=None, activate_final=None,
+def convert_from_pyg_model(model, forward_dictionary, n_node, node_dim,
+                           n_edge, edge_dim, activate_final=None,
                            output_dir='my-hls-test', project_name='myproject',
                            fpga_part='xcku115-flvb2104-2-i', clock_period=5, io_type='io_parallel', hls_config={}):
     check_forward_dict(model, forward_dictionary)
@@ -397,11 +397,9 @@ def convert_from_pyg_model(model, n_node, node_dim, n_edge, edge_dim,
     >>> forward_dictionary['R1'] = 'EdgeBlock'
     >>> forward_dictionary['O'] = 'NodeBlock'
     >>> forward_dictionary['R2'] = 'EdgeBlock'
-    >>> n_node, node_dim = 112, 3
-    >>> n_edge, edge_dim = 148, 4
-    >>> hls_model = hls4ml.converters.convert_from_pyg_model(model, n_node, node_dim,
-                                                             n_edge, edge_dim, 
-                                                             forward_dictionary, 
+    >>> graph_dimensions = {"n_node": 112, "node_dim": 3, "n_edge": 148, "edge_dim": 4}
+    >>> hls_model = hls4ml.converters.convert_from_pyg_model(model, forward_dictionary,
+                                                             **graph_dimensions,
                                                              activate_final='sigmoid'
                                                              hls_config=config)
 

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -11,7 +11,7 @@ from hls4ml.converters.keras_to_hls import keras_to_hls, get_supported_keras_lay
 #----------Make converters available if the libraries can be imported----------#       
 try:
     from hls4ml.converters.pytorch_to_hls import pytorch_to_hls, get_supported_pytorch_layers, register_pytorch_layer_handler
-    from hls4ml.converters.pyg_to_hls import pyg_to_hls
+    from hls4ml.converters.pyg_to_hls import pyg_to_hls, get_supported_pyg_blocks, register_pyg_block_handler
     __pytorch_enabled__ = True
 except ImportError:
     warnings.warn("WARNING: Pytorch converter is not enabled!")
@@ -32,7 +32,7 @@ except ImportError:
     __tensorflow_enabled__ = False
 
 #----------Layer handling register----------#
-model_types = ['keras', 'pytorch', 'onnx']
+model_types = ['keras', 'pytorch', 'onnx', 'pyg']
 
 for model_type in model_types:
     for module in os.listdir(os.path.dirname(__file__) + '/{}'.format(model_type)):
@@ -53,6 +53,8 @@ for model_type in model_types:
                             register_pytorch_layer_handler(layer, func)
                         elif model_type == 'onnx':
                             register_onnx_layer_handler(layer, func)
+                        elif model_type == 'pyg':
+                            register_pyg_block_handler(layer, func)
                             
         except ImportError:
             continue

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -312,6 +312,101 @@ def convert_from_pyg_model(model, n_node, node_dim, n_edge, edge_dim,
                            output_dir='my-hls-test', project_name='myproject',
                            fpga_part='xcku115-flvb2104-2-i', clock_period=5, io_type='io_parallel', hls_config={}):
     check_forward_dict(model, forward_dictionary)
+    """
+
+    Convert a Pytorch.Geometric model to an hls model.
+
+    Parameters
+    ----------
+    model : Pytorch.geometric model object.
+        Model to be converted to hls model object.
+    n_node, n_edge: int, int
+        These parameters define the size of the graphs that your hls GNN 
+        accepts as input. Inputs must be truncated or zero-padded to this 
+        size before feeding them to your model. This is necessary because 
+        each layer of the hls/hardware implementation has a fixed size 
+        and cannot be resized. 
+    node_dim, edge_dim: int, int
+        node_dim defines the length of the vector used to represent each 
+        node in the graph-input. For example, if each node is represented 
+        as a 1x3 vector, node_dim=3. 
+        Likewise, edge_dim defines the length of the vector used to 
+        represent each edge in the graph-input.
+        
+    forward_dictionary: OrderedDict object of the form {string: string}
+        Use this dictionary to define the order in which your model's
+        forward() method calls on the model's submodules. The keys
+        of the dictionary should be the names of your model's submodules, and the 
+        value stored in each key should indicate whether that submodule is an 
+        'EdgeBlock' (i.e. it predicts messages/edge-updates) or whether its a
+        'NodeBlock' (i.e. it predicts node-updates). 
+        
+        For example, consider this InteractionNetwork (https://github.com/GageDeZoort/interaction_network_paper/blob/pytorch_geometric/models/interaction_network.py),
+        whose forward() method calls on its submodules in the following order:
+        1. An EdgeBlock named 'R1'
+        2. A NodeBlock named 'O'
+        3. An EdgeBlock named 'R2'
+        
+        One would define its forward dictionary as such:
+        >>> forward_dictionary = OrderedDict()
+        >>> forward_dictionary['R1'] = 'EdgeBlock'
+        >>> forward_dictionary['O'] = 'NodeBlock'
+        >>> forward_dictionary['R2'] = 'EdgeBlock'
+        
+        It is really important to define the submodules in the same order with which the 
+        forward() method calls on them. hls4ml has no other way of inferring this order. 
+      
+    activate_final: string, optional 
+        If the activation of the final output is not already a layer in the corresponding
+        submodule, name the type of the activation function here. In the preceding example, 
+        one would pass the value 'sigmoid', because the final output of the model 
+        is the sigmoid-activated output of 'R2' (the last submodule called by the
+        forward() method). In other words, the model returns torch.sigmoid(self.R2(m2)). 
+        Other accepted values for this parameter include: 
+                                ['linear', 'relu', 'elu', 'selu', 'prelu', 'leaky_relu', 'softmax', 'tanh', 'softplus',  
+                                'softsign', 'hard_sigmoid','thresholded_relu', 'binary_tanh', 'ternary_tanh']
+    output_dir : string, optional
+        Output directory to write hls codes.
+    project_name : string, optional
+        hls project name.
+    fpga_part : string, optional
+        The particular FPGA part number that you are considering.
+    clock_period : int, optional
+        The clock period, in ns, at which your algorithm runs.
+    io_type : string, optional
+        Your options are 'io_parallel' or 'io_serial' where this really 
+        defines if you are pipelining your algorithm or not.
+    hls_config : dict, optional
+        Additional configuration dictionary for hls model.
+
+    Returns
+    -------
+    hls_model : hls4ml model object.
+
+    See Also
+    --------
+    hls4ml.convert_from_pytorch_model, hls4ml.convert_from_keras_model, 
+    hls4ml.convert_from_onnx_model
+
+    Example
+    --------
+    >>> import hls4ml
+    >>> config = hls4ml.utils.config_from_pyg_model(model, granularity='model')
+    >>>
+    >>> forward_dictionary = OrderedDict()
+    >>> forward_dictionary['R1'] = 'EdgeBlock'
+    >>> forward_dictionary['O'] = 'NodeBlock'
+    >>> forward_dictionary['R2'] = 'EdgeBlock'
+    >>> n_node, node_dim = 112, 3
+    >>> n_edge, edge_dim = 148, 4
+    >>> hls_model = hls4ml.converters.convert_from_pyg_model(model, n_node, node_dim,
+                                                             n_edge, edge_dim, 
+                                                             forward_dictionary, 
+                                                             activate_final='sigmoid'
+                                                             hls_config=config)
+
+    """
+
     config = create_vivado_config(
         output_dir=output_dir,
         project_name=project_name,

--- a/hls4ml/converters/pyg/interaction_network_blocks.py
+++ b/hls4ml/converters/pyg/interaction_network_blocks.py
@@ -58,9 +58,3 @@ def parse_EdgeAggregate(block_name, config, update_dict, index, n_node, n_edge, 
                   "outputs": [f"layer{index}_out"]}
     update_dict["last_edge_aggr_update"] = f"layer{index}_out"
     return layer_dict, update_dict
-
-IN_handlers = {
-    "NodeBlock": parse_NodeBlock,
-    "EdgeBlock": parse_EdgeBlock,
-    "EdgeAggregate": parse_EdgeAggregate
-}

--- a/hls4ml/converters/pyg/interaction_network_blocks.py
+++ b/hls4ml/converters/pyg/interaction_network_blocks.py
@@ -45,10 +45,10 @@ def parse_EdgeBlock(block_name, config, update_dict, index, n_node, n_edge, node
     update_dict["last_edge_update"] = f"layer{index}_out"
     return layer_dict, update_dict
 
-@pyg_handler('Aggregate')
-def parse_Aggregate(block_name, config, update_dict, index, n_node, n_edge, node_dim, edge_dim):
+@pyg_handler('EdgeAggregate')
+def parse_EdgeAggregate(block_name, config, update_dict, index, n_node, n_edge, node_dim, edge_dim):
     layer_dict = {"name": f"aggr{index}",
-                  "class_name": "Aggregate",
+                  "class_name": "EdgeAggregate",
                   "n_node": n_node,
                   "n_edge": n_edge,
                   "node_dim": node_dim,
@@ -62,5 +62,5 @@ def parse_Aggregate(block_name, config, update_dict, index, n_node, n_edge, node
 IN_handlers = {
     "NodeBlock": parse_NodeBlock,
     "EdgeBlock": parse_EdgeBlock,
-    "Aggregate": parse_Aggregate
+    "EdgeAggregate": parse_EdgeAggregate
 }

--- a/hls4ml/converters/pyg/interaction_network_blocks.py
+++ b/hls4ml/converters/pyg/interaction_network_blocks.py
@@ -1,0 +1,66 @@
+import numpy as np
+from hls4ml.converters.pyg_to_hls import pyg_handler
+
+def parse_GraphBlock(block_name, config, n_node, n_edge, node_dim, edge_dim):
+    layer_dict = {
+        "name": block_name,
+        "n_node": n_node,
+        "n_edge": n_edge,
+        "node_dim": node_dim,
+        "edge_dim": edge_dim,
+    }
+
+    # get n_layers, out_dim
+    model = config['PytorchModel']
+    torch_block = getattr(model, block_name)
+    try:
+        torch_layers = torch_block.layers._modules
+    except AttributeError:
+        torch_layers = torch_block._modules
+
+    lcount = 0
+    for lname, l in torch_layers.items():
+        if l.__class__.__name__=="Linear":
+            lcount += 1
+            last_layer = l
+    layer_dict["n_layers"] = lcount
+    layer_dict["out_dim"] = last_layer.out_features
+    return layer_dict
+
+@pyg_handler('NodeBlock')
+def parse_NodeBlock(block_name, config, update_dict, index, n_node, n_edge, node_dim, edge_dim):
+    layer_dict = parse_GraphBlock(block_name, config, n_node, n_edge, node_dim, edge_dim)
+    layer_dict["class_name"] = "NodeBlock"
+    layer_dict["inputs"] = [update_dict["last_node_update"], update_dict["last_edge_aggr_update"]]
+    layer_dict["outputs"] = [f"layer{index}_out"]
+    update_dict["last_node_update"] = f"layer{index}_out"
+    return layer_dict, update_dict
+
+@pyg_handler('EdgeBlock')
+def parse_EdgeBlock(block_name, config, update_dict, index, n_node, n_edge, node_dim, edge_dim):
+    layer_dict = parse_GraphBlock(block_name, config, n_node, n_edge, node_dim, edge_dim)
+    layer_dict["class_name"] = "EdgeBlock"
+    layer_dict["inputs"] = [update_dict["last_node_update"], update_dict["last_edge_update"], "edge_index"]
+    layer_dict["outputs"] = [f"layer{index}_out"]
+    update_dict["last_edge_update"] = f"layer{index}_out"
+    return layer_dict, update_dict
+
+@pyg_handler('Aggregate')
+def parse_Aggregate(block_name, config, update_dict, index, n_node, n_edge, node_dim, edge_dim):
+    layer_dict = {"name": f"aggr{index}",
+                  "class_name": "Aggregate",
+                  "n_node": n_node,
+                  "n_edge": n_edge,
+                  "node_dim": node_dim,
+                  "edge_dim": edge_dim,
+                  "out_dim": edge_dim,
+                  "inputs": [update_dict["last_edge_update"], "edge_index"],
+                  "outputs": [f"layer{index}_out"]}
+    update_dict["last_edge_aggr_update"] = f"layer{index}_out"
+    return layer_dict, update_dict
+
+IN_handlers = {
+    "NodeBlock": parse_NodeBlock,
+    "EdgeBlock": parse_EdgeBlock,
+    "Aggregate": parse_Aggregate
+}

--- a/hls4ml/converters/pyg_to_hls.py
+++ b/hls4ml/converters/pyg_to_hls.py
@@ -116,14 +116,12 @@ def pyg_to_hls(config):
     aggr_count = 0
     forward_dict_new = OrderedDict()
     for key, val in forward_dict.items():
-        if val=="NodeBlock":
+        if val == "NodeBlock":
             aggr_count += 1
             aggr_key = f"aggr{aggr_count}"
             aggr_val = "Aggregate"
             forward_dict_new[aggr_key] = aggr_val
         forward_dict_new[key] = val
-    print(f"forward_dict: {forward_dict}")
-    print(f"forward_dict_new: {forward_dict_new}")
 
     # complete the layer list
     for i, (key, val) in enumerate(forward_dict_new.items()):

--- a/hls4ml/converters/pyg_to_hls.py
+++ b/hls4ml/converters/pyg_to_hls.py
@@ -1,0 +1,191 @@
+from __future__ import print_function
+import torch
+
+from hls4ml.converters.pytorch_to_hls import PyTorchModelReader
+from hls4ml.model.hls_model import HLSModel
+from hls4ml.templates import get_backend
+
+
+class PygModelReader(PyTorchModelReader):
+    def __init__(self, config):
+        super().__init__(config)
+        self.n_node = config['InputShape']['NodeAttr'][0]
+        self.n_edge = config['InputShape']['EdgeAttr'][0]
+        self.node_dim = config['InputShape']['NodeAttr'][1]
+        self.edge_dim = config['InputShape']['EdgeAttr'][1]
+
+    def get_weights_data(self, layer_name, var_name, module_name=None):
+        data = None
+
+        # Parameter mapping from pytorch to keras
+        torch_paramap = {
+            # Conv
+            'kernel': 'weight',
+            # Batchnorm
+            'gamma': 'weight',
+            'beta': 'bias',
+            'moving_mean': 'running_mean',
+            'moving_variance': 'running_var'}
+
+        if var_name not in list(torch_paramap.keys()) + ['weight', 'bias']:
+            raise Exception('Pytorch parameter not yet supported!')
+
+        if module_name is not None:
+            if var_name in list(torch_paramap.keys()):
+                var_name = torch_paramap[var_name]
+
+            try:
+                data = self.state_dict[module_name + '.' + layer_name + '.' + var_name].numpy().transpose()
+            except KeyError:
+                data = self.state_dict[module_name + '.layers.' + layer_name + '.' + var_name].numpy().transpose()
+
+        else:
+            if var_name in list(torch_paramap.keys()):
+                var_name = torch_paramap[var_name]
+
+            data = self.state_dict[layer_name + '.' + var_name].numpy().transpose()  # Look at transpose when systhesis produce lousy results. Might need to remove it.
+
+        return data
+
+def pyg_to_hls(config):
+
+    forward_dict = config['ForwardDictionary']
+    activate_final = config['ActivateFinal']
+
+    # get precisions
+    backend = get_backend(config.get('Backend', 'Vivado'))
+    fp_type = backend.convert_precision_string(config['HLSConfig']['Model']['Precision'])
+    int_type = backend.convert_precision_string(config['HLSConfig']['Model']['IndexPrecision'])
+
+    # make reader
+    reader = PygModelReader(config)
+    n_node = reader.n_node
+    n_edge = reader.n_edge
+    node_dim = reader.node_dim
+    edge_dim = reader.edge_dim
+
+
+    # initiate layer list with inputs: node_attr, edge_attr, edge_index
+    layer_list = []
+    input_shapes = reader.input_shape
+    NodeAttr_layer = {
+        'name': 'node_attr',
+        'class_name': 'InputLayer',
+        'input_shape': input_shapes['NodeAttr'],
+        'inputs': 'input',
+        'dim_names': ['N_NODE', 'NODE_DIM'],
+        'precision': fp_type
+    }
+    layer_list.append(NodeAttr_layer)
+    EdgeAttr_layer = {
+        'name': 'edge_attr',
+        'class_name': 'InputLayer',
+        'input_shape': input_shapes['EdgeAttr'],
+        'inputs': 'input',
+        'dim_names': ['N_EDGE', 'EDGE_DIM'],
+        'precision': fp_type
+    }
+    layer_list.append(EdgeAttr_layer)
+    EdgeIndex_layer = {
+        'name': 'edge_index',
+        'class_name': 'InputLayer',
+        'input_shape': input_shapes['EdgeIndex'],
+        'inputs': 'input',
+        'dim_names': ['N_EDGE', 'TWO'],
+        'precision': int_type
+    }
+    layer_list.append(EdgeIndex_layer)
+    last_node_update = "node_attr"
+    last_edge_update = "edge_attr"
+
+    # If the first block is a NodeBlock, we need a layer to construct the initial edge_aggregates
+    if forward_dict[list(forward_dict.keys())[0]] == "NodeBlock":
+        aggr_layer = {"name": "aggr1",
+                       "class_name": "Aggregate",
+                       "n_node": n_node,
+                       "n_edge": n_edge,
+                       "node_dim": node_dim,
+                       "edge_dim": edge_dim,
+                       "precision": fp_type,
+                       "out_dim": edge_dim,
+                       "inputs": ["edge_attr", "edge_index"],
+                       "outputs": ["edge_attr_aggr"]}
+        layer_list.append(aggr_layer)
+        last_edge_aggr_update = "edge_attr_aggr"
+    else: last_edge_aggr_update = None
+
+    # complete the layer list
+    for i, (key, val) in enumerate(forward_dict.items()):
+        layer_dict = {
+            "name": key,
+            "class_name": val,
+            "n_node": n_node,
+            "n_edge": n_edge,
+            "node_dim": node_dim,
+            "edge_dim": edge_dim,
+            "precision": fp_type
+        }
+
+        # get n_layers, out_dim
+        model = config['PytorchModel']
+        torch_block = getattr(model, key)
+        try:
+            torch_layers = torch_block.layers._modules
+        except AttributeError:
+            torch_layers = torch_block._modules
+
+        lcount = 0
+        for lname, l in torch_layers.items():
+            if isinstance(l, torch.nn.modules.linear.Linear):
+                lcount += 1
+                last_layer = l
+        layer_dict["n_layers"] = lcount
+        layer_dict["out_dim"] = last_layer.out_features
+
+        # get inputs, outputs
+        if val == "NodeBlock":
+            index = len(layer_list) + 1
+            layer_dict["inputs"] = [last_node_update, last_edge_aggr_update]
+            layer_dict["outputs"] = [f"layer{index}_out"]
+            last_node_update = f"layer{index}_out"
+            layer_list.append(layer_dict)
+        elif val == "EdgeBlock":
+            index = len(layer_list) + 1
+            layer_dict["inputs"] = [last_node_update, last_edge_update, "edge_index"]
+            layer_dict["outputs"] = [f"layer{index}_out"]
+            last_edge_update = f"layer{index}_out"
+            layer_list.append(layer_dict)
+
+        # if val==EdgeBlock and this is not the final graph-block, follow it with an aggregation layer
+        if (val == "EdgeBlock") and (i < len(forward_dict) - 1):
+            index = len(layer_list) + 1
+            layer_dict = {"name": f"aggr{index}",
+                       "class_name": "Aggregate",
+                       "n_node": n_node,
+                       "n_edge": n_edge,
+                       "node_dim": node_dim,
+                       "edge_dim": edge_dim,
+                       "precision": fp_type,
+                       "out_dim": edge_dim,
+                       "inputs": [last_edge_update, "edge_index"],
+                       "outputs": [f"layer{index}_out"]}
+            last_edge_aggr_update = f"layer{index}_out"
+            layer_list.append(layer_dict)
+
+    if activate_final is not None:
+        act_dict = {
+            'name': 'final_act',
+            'class_name': 'Activation',
+            'inputs': [f"layer{len(layer_list)}_out"],
+            'activation': activate_final,
+            'precision': fp_type
+        }
+        layer_list.append(act_dict)
+        out = ["final_act"]
+    else:
+        out = [layer_list[-1]['outputs'][0]]
+
+    hls_model = HLSModel(config, reader, layer_list, inputs=['node_attr', 'edge_attr', 'edge_index'])
+    hls_model.outputs = out
+    return hls_model
+

--- a/hls4ml/converters/pyg_to_hls.py
+++ b/hls4ml/converters/pyg_to_hls.py
@@ -119,7 +119,7 @@ def pyg_to_hls(config):
         if val == "NodeBlock":
             aggr_count += 1
             aggr_key = f"aggr{aggr_count}"
-            aggr_val = "Aggregate"
+            aggr_val = "EdgeAggregate"
             forward_dict_new[aggr_key] = aggr_val
         forward_dict_new[key] = val
 

--- a/hls4ml/converters/pyg_to_hls.py
+++ b/hls4ml/converters/pyg_to_hls.py
@@ -55,7 +55,6 @@ def pyg_to_hls(config):
         'class_name': 'InputLayer',
         'input_shape': input_shapes['NodeAttr'],
         'inputs': 'input',
-        'dim_names': ['N_NODE', 'NODE_DIM'],
         'precision': fp_type
     }
     layer_list.append(NodeAttr_layer)
@@ -64,7 +63,6 @@ def pyg_to_hls(config):
         'class_name': 'InputLayer',
         'input_shape': input_shapes['EdgeAttr'],
         'inputs': 'input',
-        'dim_names': ['N_EDGE', 'EDGE_DIM'],
         'precision': fp_type
     }
     layer_list.append(EdgeAttr_layer)
@@ -73,7 +71,6 @@ def pyg_to_hls(config):
         'class_name': 'InputLayer',
         'input_shape': input_shapes['EdgeIndex'],
         'inputs': 'input',
-        'dim_names': ['N_EDGE', 'TWO'],
         'precision': int_type
     }
     layer_list.append(EdgeIndex_layer)

--- a/hls4ml/converters/pyg_to_hls.py
+++ b/hls4ml/converters/pyg_to_hls.py
@@ -13,39 +13,6 @@ class PygModelReader(PyTorchModelReader):
         self.node_dim = config['InputShape']['NodeAttr'][1]
         self.edge_dim = config['InputShape']['EdgeAttr'][1]
 
-    def get_weights_data(self, layer_name, var_name, module_name=None):
-        data = None
-
-        # Parameter mapping from pytorch to keras
-        torch_paramap = {
-            # Conv
-            'kernel': 'weight',
-            # Batchnorm
-            'gamma': 'weight',
-            'beta': 'bias',
-            'moving_mean': 'running_mean',
-            'moving_variance': 'running_var'}
-
-        if var_name not in list(torch_paramap.keys()) + ['weight', 'bias']:
-            raise Exception('Pytorch parameter not yet supported!')
-
-        if module_name is not None:
-            if var_name in list(torch_paramap.keys()):
-                var_name = torch_paramap[var_name]
-
-            try:
-                data = self.state_dict[module_name + '.' + layer_name + '.' + var_name].numpy().transpose()
-            except KeyError:
-                data = self.state_dict[module_name + '.layers.' + layer_name + '.' + var_name].numpy().transpose()
-
-        else:
-            if var_name in list(torch_paramap.keys()):
-                var_name = torch_paramap[var_name]
-
-            data = self.state_dict[layer_name + '.' + var_name].numpy().transpose()  # Look at transpose when systhesis produce lousy results. Might need to remove it.
-
-        return data
-
 # EdgeBlock/NodeBlock/Aggregate handlers
 block_handlers = {}
 

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -119,7 +119,7 @@ def pytorch_to_hls(config):
     -----
     Only sequential pytorch models are supported for now.
     """
-    
+
     #This is a list of dictionaries to hold all the layer info we need to generate HLS
     layer_list = []
 

--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -564,10 +564,7 @@ class Input(Layer):
         shape = self.attributes['input_shape']
         if shape[0] is None:
             shape = shape[1:]
-        try:
-            dims = self.attributes['dim_names']
-        except KeyError:
-            dims = ['N_INPUT_{}_{}'.format(i, self.index) for i in range(1, len(shape) + 1)]
+        dims = ['N_INPUT_{}_{}'.format(i, self.index) for i in range(1, len(shape) + 1)]
         if self.index == 1:
             default_type_name = 'input_t'
         else:
@@ -2281,7 +2278,7 @@ class EdgeAggregate(Layer):
 
         aggr_name = f"layer{self.index}_out"
         aggr_shape = [self.n_node, self.out_dim]
-        aggr_dims = ['N_NODE', f'LAYER{self.index}_OUT_DIM']
+        aggr_dims = ['N_NODE', f'LAYER{self.index}_OUT_DIM'] #todo: see if we can do without 'N_NODE'
         self.add_output_variable(shape=aggr_shape, dim_names=aggr_dims, out_name=aggr_name, var_name=aggr_name,
                                  precision=self.attributes.get('precision', None))
 

--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -2127,10 +2127,6 @@ class EdgeBlock(GraphBlock):
                                                                     n_rows=self.n_edge_cppname,
                                                                     n_cols=self.edge_dim_cppname)
 
-        configs['edge_index_config'] = matrix_config_template.format(matrix_name="edge_index",
-                                                                     n_rows=self.n_edge_cppname,
-                                                                     n_cols="TWO")
-
         configs['edge_update_config'] = matrix_config_template.format(matrix_name="edge_update",
                                                                       n_rows=self.n_edge_cppname,
                                                                       n_cols=f"LAYER{self.index}_OUT_DIM")
@@ -2351,19 +2347,9 @@ class EdgeAggregate(Layer):
                                                                     n_rows=self.n_edge_cppname,
                                                                     n_cols=self.edge_dim_cppname)
 
-        configs['edge_index_config'] = matrix_config_template.format(matrix_name="edge_index",
-                                                                     n_rows=self.n_edge_cppname,
-                                                                     n_cols="TWO")
-
         configs['edge_attr_aggr_config'] = matrix_config_template.format(matrix_name="edge_attr_aggr",
                                                                            n_rows=self.n_node_cppname,
                                                                            n_cols=f"LAYER{self.index}_OUT_DIM")
-
-        aggr_params = self.get_top_params()
-        nested_duplicate = self._config_template.format(**aggr_params).split('\n')
-        nested_duplicate[0] = "struct nested_duplicate: nnet::edge_aggregate_config{"
-        nested_duplicate = '\n'.join(nested_duplicate)
-        configs['nested_duplicate'] = nested_duplicate
 
         return configs
 

--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -2327,7 +2327,7 @@ class NodeBlock(GraphBlock):
         #expected outputs: node_update
         assert(len(self.outputs)==1)
 
-class Aggregate(Layer):
+class EdgeAggregate(Layer):
     def initialize(self):
         self.n_node = self.attributes['n_node']
         self.n_edge = self.attributes['n_edge']
@@ -2417,7 +2417,7 @@ class Aggregate(Layer):
 
         aggr_params = self.get_Aggregate_params()
         nested_duplicate = self._config_template.format(**aggr_params).split('\n')
-        nested_duplicate[0] = "struct nested_duplicate: nnet::aggregate_config{"
+        nested_duplicate[0] = "struct nested_duplicate: nnet::edge_aggregate_config{"
         nested_duplicate = '\n'.join(nested_duplicate)
         configs['nested_duplicate'] = nested_duplicate
 
@@ -2483,7 +2483,7 @@ layer_map = {
     'GarNetStack'            : GarNetStack,
     'EdgeBlock'              : EdgeBlock,
     'NodeBlock'              : NodeBlock,
-    'Aggregate'              : Aggregate,
+    'EdgeAggregate'              : EdgeAggregate,
     # TensorFlow-specific layers:
     'BiasAdd'                : BiasAdd,
 }

--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -564,7 +564,10 @@ class Input(Layer):
         shape = self.attributes['input_shape']
         if shape[0] is None:
             shape = shape[1:]
-        dims = ['N_INPUT_{}_{}'.format(i, self.index) for i in range(1, len(shape) + 1)]
+        try:
+            dims = self.attributes['dim_names']
+        except KeyError:
+            dims = ['N_INPUT_{}_{}'.format(i, self.index) for i in range(1, len(shape) + 1)]
         if self.index == 1:
             default_type_name = 'input_t'
         else:
@@ -646,6 +649,10 @@ class Dense(Layer):
         params['nonzeros'] = self.get_weights('weight').nonzeros
         params['product_type'] = self.model.config.backend.product_type(self.get_input_variable().type.precision, self.get_weights('weight').type.precision)
         params['strategy'] = self.get_attr('strategy')
+        if self.get_attr('remove_pipeline_pragma') is not None:
+            params['remove_pipeline_pragma'] = self.get_attr('remove_pipeline_pragma')
+        else:
+            params['remove_pipeline_pragma'] = "false"
 
         return self._config_template.format(**params)
 
@@ -1849,6 +1856,586 @@ class GarNetStack(GarNet):
 
         params['sublayer_configs'] = '\n'.join(sublayer_configs)
 
+class GraphBlock(Layer): #parent class for EdgeBlock, NodeBlock
+    def add_weights(self, quantizer=None, compression=False):
+        linear_count = 0
+
+        for name, module in self.submodules.items():
+            if module.__class__.__name__ == 'Linear':
+                data = self.model.get_weights_data(name, 'kernel', self.name).transpose()
+                var_name = f"{self.name}_w{linear_count}"
+                self.add_weights_variable(name=var_name, var_name=var_name, data=data, quantizer=quantizer,
+                                              compression=compression)
+                linear_count += 1
+
+        # DUMMIES
+        if linear_count <= 3:
+            for i in range(linear_count, 4):
+                self.add_weights_variable(name=f"{self.name}_w{i}", var_name=f"{self.name}_w{i}", data=data,
+                                              quantizer=quantizer, compression=compression)
+
+    def add_bias(self, quantizer=None):
+        precision = None
+        type_name = None
+        linear_count = 0
+
+        for name, module in self.submodules.items():
+            if module.__class__.__name__ == 'Linear':
+                data = self.model.get_weights_data(name, 'bias', self.name)
+                var_name = f"{self.name}_b{linear_count}"
+                self.add_weights_variable(name=var_name, var_name=var_name, type_name=type_name, precision=precision,
+                                              data=data, quantizer=quantizer)
+                linear_count += 1
+
+        # DUMMIES
+        if linear_count <= 3:
+            for i in range(linear_count, 4):
+                self.add_weights_variable(name=f"{self.name}_b{i}", var_name=f"{self.name}_b{i}", type_name=type_name,
+                                              precision=precision, data=data, quantizer=quantizer)
+
+    def get_dense_params(self, dense_layer, linear_count):  # hard-coded for now
+        params = {}
+        params['type'] = 'dense'
+        params['index'] = linear_count
+        params['n_in'] = dense_layer.in_features
+        params['n_out'] = dense_layer.out_features
+        params['iotype'] = 'io_parallel'
+        params['reuse'] = 1
+        params['nzeros'] = 0
+        params['remove_pipeline_pragma'] = 'true'
+
+        params['accum_t'] = f'layer{self.index}_t'
+        params['bias_t'] = f'layer{self.index}_t'
+        params['weight_t'] = f'layer{self.index}_t'
+
+        return params
+
+    def get_relu_params(self, relu_count, last_n_out):
+        params = {}
+        params['type'] = 'relu'
+        params['index'] = relu_count
+        params['n_in'] = last_n_out
+        params['table_size'] = 1024
+        params['iotype'] = 'io_parallel'
+        return params
+
+    def config_layer(self, layer_type, layer_params):
+        all_lines = self.model.config.backend.get_config_template(layer_type).split('\n')
+        all_lines[0] = re.sub('struct config{index}', 'struct {type}_config{index}', all_lines[0])
+        param_lines = []
+        out = []
+
+        for param in layer_params:
+            p_lines = [i for i in all_lines if "{%s}" % param in i]
+            if len(p_lines) == 1 and p_lines[0] not in param_lines:
+                param_lines.append(p_lines[0])
+            elif len(p_lines) < 1:
+                print(f"param {param} not found in {layer_type} config template")
+            else:
+                pass
+
+        for line in all_lines:
+            if line in param_lines:
+                out.append(line)
+            else:
+                param_search = line.find('{')
+                if param_search == -1:
+                    if 'template' not in line:
+                        out.append(line)
+
+        out = '\n'.join(out)
+        out = out.format(**layer_params)
+        return out
+
+    def _config_sublayers(self):
+        linear_count = 0
+        relu_count = 0
+        configs = OrderedDict()
+
+        for name, module in self.submodules.items():
+            if module.__class__.__name__==self.model.reader.torch_model.__class__.__name__:
+                continue
+
+            if module.__class__.__name__ == "Linear":
+                linear_count += 1
+                linear_params = self.get_dense_params(module, linear_count)
+                linear_config = self.config_layer('Dense', linear_params)
+                configs[f"dense_config{linear_count}"] = linear_config
+                last_n_out = linear_params['n_out']
+
+            elif module.__class__.__name__ == "ReLU":
+                relu_count += 1
+                relu_params = self.get_relu_params(relu_count, last_n_out)
+                relu_config = self.config_layer('Activation', relu_params)
+                configs[f"relu_config{relu_count}"] = relu_config
+                last_n_out = relu_params['n_in']
+
+        # DUMMIES
+        if linear_count < 4:
+            for i in range(linear_count + 1, 5):
+                linear_config_i = linear_config.split('\n')
+                linear_config_i[0] = re.sub(f"dense_config{linear_count}", f"dense_config{i}", linear_config_i[0])
+                linear_config_i = "\n".join(linear_config_i)
+                configs[f"dense_config{i}"] = linear_config_i
+
+        if relu_count < 4:
+            for i in range(relu_count + 1, 5):
+                relu_config_i = relu_config.split('\n')
+                relu_config_i[0] = re.sub(f"relu_config{relu_count}", f"relu_config{i}", relu_config_i[0])
+                relu_config_i = '\n'.join(relu_config_i)
+                configs[f"relu_config{i}"] = relu_config_i
+
+        return configs
+
+class EdgeBlock(GraphBlock):
+    def initialize(self):
+        self.n_node = self.attributes['n_node']
+        self.n_edge = self.attributes['n_edge']
+        self.node_dim = self.attributes['node_dim']
+        self.edge_dim = self.attributes['edge_dim']
+        self.out_dim = self.attributes['out_dim']
+        self._check_inputs()
+
+        self.n_edge_cppname, self.edge_dim_cppname = self.model.get_layer_output_variable('edge_attr').dim_names
+        self.n_node_cppname, self.node_dim_cppname = self.model.get_layer_output_variable('node_attr').dim_names
+        self.out_dim_cppname = f"LAYER{self.index}_OUT_DIM"
+
+        self.torch_module = getattr(self.model.reader.torch_model, self.name)
+        submodules = OrderedDict()
+        try:
+            for name, module in self.torch_module.layers.named_modules():
+                submodules[name] = module
+        except AttributeError:
+            for name, module in self.torch_module.named_modules():
+                submodules[name] = module
+        self.submodules = submodules
+
+        # edge predictions
+        out_shape = [self.n_edge, self.out_dim]
+        out_dims = [self.n_edge_cppname, self.out_dim_cppname]
+        out_name = f"layer{self.index}_out"
+        self.add_output_variable(shape=out_shape, dim_names=out_dims, out_name=out_name, var_name=out_name, precision=self.attributes.get('precision', None), pragma='partition')
+
+        self.add_weights(quantizer=self.get_attr('weight_quantizer'),
+                         compression=self.model.config.get_compression(self))
+        self.add_bias(quantizer=self.get_attr('weight_quantizer'))
+
+        # Reshape the input/output variables
+        #for input_name in self.inputs:
+        #    input_array = self.get_input_variable(input_name)
+        #    partition_factor = input_array.shape[0]
+        #    if input_name in self.model.inputs:
+        #        input_array.pragma = ('reshape', 'block', partition_factor)
+        #    else:
+        #        input_array.pragma = ('partition', 'block', partition_factor)
+
+        #for output_name in self.outputs:
+        #    output_array = self.get_output_variable(output_name)
+        #    partition_factor = output_array.shape[0]
+        #    output_array.pragma = ('partition', 'block', partition_factor)
+
+    def function_cpp(self):
+        params = {}
+        params['config'] = 'config{}'.format(self.index)
+        params['input_t'] = self.model.get_layer_output_variable('edge_attr').type.name
+        params['index_t'] = self.model.get_layer_output_variable('edge_index').type.name
+        params['output_t'] = self.get_output_variable().type.name
+        params['node_attr'] = self.attributes['inputs'][0]
+        params['edge_attr'] = self.attributes['inputs'][1]
+        params['edge_index'] = self.attributes['inputs'][2]
+        params['out'] = f"layer{self.index}_out"
+
+        params['w0'] = self.get_weights(f"{self.name}_w0").name
+        params['b0'] = self.get_weights(f"{self.name}_b0").name
+        params['w1'] = self.get_weights(f"{self.name}_w1").name
+        params['b1'] = self.get_weights(f"{self.name}_b1").name
+        params['w2'] = self.get_weights(f"{self.name}_w2").name
+        params['b2'] = self.get_weights(f"{self.name}_b2").name
+        params['w3'] = self.get_weights(f"{self.name}_w3").name
+        params['b3'] = self.get_weights(f"{self.name}_b3").name
+
+        out = self._function_template.format(**params)
+        return [out]
+
+    def config_cpp(self):
+        top_params = self.get_EdgeBlock_params()
+        top_config = self._config_template.format(**top_params)
+        top_config = top_config.split('\n')[:-1]
+        top_config = '\n'.join(top_config)
+
+        sublayer_configs = self._config_sublayers()
+        sublayer_configs.update(self._config_misc())
+        for layer, config in sublayer_configs.items():
+            config = ['    ' + i for i in config.split('\n')]
+            config = '\n'.join(config)
+
+            top_config += '\n\n'
+            top_config += config
+
+        top_config += '\n};'
+        return top_config
+
+    def get_EdgeBlock_params(self):  # hard-coded for now
+        params = {}
+        params['index'] = self.index
+        params['bias_t'] = f'layer{self.index}_t'
+        params['weight_t'] = f'layer{self.index}_t'
+        params['table_t'] = f'layer{self.index}_t'
+        params['n_node'] = self.n_node_cppname
+        params['n_edge'] = self.n_edge_cppname
+        params['node_dim'] = self.node_dim_cppname
+        params['edge_dim'] = self.edge_dim_cppname
+        params['out_dim'] = self.out_dim
+        params['n_layers'] = self.attributes["n_layers"]
+        params['io_type'] = 'io_parallel'
+        params['reuse'] = self.reuse_factor
+        params['n_zeros'] = 0
+
+        flow_map = {
+            "source_to_target": 0,
+            "target_to_source": 1
+        }
+        params["flow"] = flow_map[self.attributes.get("flow", self.model.reader.torch_model.flow)]
+
+        return params
+
+    def _config_misc(self):
+        configs = OrderedDict()
+
+        # matrix configs
+        matrix_config_template = """struct {matrix_name}_config: nnet::matrix_config{{
+                    static const unsigned n_rows = {n_rows};
+                    static const unsigned n_cols = {n_cols};
+                }};"""
+
+        configs['node_attr_config'] = matrix_config_template.format(matrix_name="node_attr",
+                                                                    n_rows=self.n_node_cppname,
+                                                                    n_cols=self.node_dim_cppname)
+
+        configs['edge_attr_config'] = matrix_config_template.format(matrix_name="edge_attr",
+                                                                    n_rows=self.n_edge_cppname,
+                                                                    n_cols=self.edge_dim_cppname)
+
+        configs['edge_index_config'] = matrix_config_template.format(matrix_name="edge_index",
+                                                                     n_rows=self.n_edge_cppname,
+                                                                     n_cols="TWO")
+
+        configs['edge_update_config'] = matrix_config_template.format(matrix_name="edge_update",
+                                                                      n_rows=self.n_edge_cppname,
+                                                                      n_cols=f"LAYER{self.index}_OUT_DIM")
+
+        # concatenation configs
+        concat_config_template = self.model.config.backend.get_config_template('Concatenate')
+        concat_config_template = re.sub('config{index}', 'merge_config{index}', concat_config_template)
+
+        merge_config1_params = {
+                    'index': 1,
+                    'n_elem1_0': self.node_dim_cppname,
+                    'n_elem1_1': 1,
+                    'n_elem1_2': 0,
+                    'n_elem2_0': self.node_dim_cppname,
+                    'n_elem2_1': 1,
+                    'n_elem2_2': 0,
+                    'axis': 0
+                }
+        merge_config1 = concat_config_template.format(**merge_config1_params)
+        configs['merge_config1'] = merge_config1
+
+        merge_config2_params = {
+                    'index': 2,
+                    'n_elem1_0': f"2*{self.node_dim_cppname}",
+                    'n_elem1_1': 1,
+                    'n_elem1_2': 0,
+                    'n_elem2_0': self.edge_dim_cppname,
+                    'n_elem2_1': 1,
+                    'n_elem2_2': 0,
+                    'axis': 0
+                }
+        merge_config2 = concat_config_template.format(**merge_config2_params)
+        configs['merge_config2'] = merge_config2
+
+        return configs
+
+    def _check_inputs(self):
+        #expected inputs: node_attr, edge_attr, edge_index
+        assert (len(self.inputs) == 3)
+
+        node_attr = self.model.get_layer_output_variable(self.inputs[0])
+        assert(node_attr.shape==[self.n_node, self.node_dim])
+
+        edge_attr = self.model.get_layer_output_variable(self.inputs[1])
+        assert(edge_attr.shape==[self.n_edge, self.edge_dim])
+
+        edge_index = self.model.get_layer_output_variable(self.inputs[2])
+        assert(edge_index.shape==[self.n_edge, 2])
+
+        #expected outputs: edge_update, edge_update_aggr
+        assert (len(self.outputs) == 1)
+
+class NodeBlock(GraphBlock):
+    def initialize(self):
+        self.n_node = self.attributes['n_node']
+        self.n_edge = self.attributes['n_edge']
+        self.node_dim = self.attributes['node_dim']
+        self.edge_dim = self.attributes['edge_dim']
+        self.out_dim = self.attributes['out_dim']
+        self._check_inputs()
+
+        self.n_edge_cppname, self.edge_dim_cppname = self.model.get_layer_output_variable('edge_attr').dim_names
+        self.n_node_cppname, self.node_dim_cppname = self.model.get_layer_output_variable('node_attr').dim_names
+        self.out_dim_cppname = f"LAYER{self.index}_OUT_DIM"
+
+        self.torch_module = getattr(self.model.reader.torch_model, self.name)
+        submodules = OrderedDict()
+        try:
+            for name, module in self.torch_module.layers.named_modules():
+                submodules[name] = module
+        except AttributeError:
+            for name, module in self.torch_module.named_modules():
+                submodules[name] = module
+        self.submodules = submodules
+
+        # node predictions
+        out_shape = [self.n_node, self.out_dim]
+        out_dims = [self.n_node_cppname, self.out_dim_cppname]
+        out_name = f"layer{self.index}_out"
+        self.add_output_variable(shape=out_shape, dim_names=out_dims, out_name=out_name, var_name=out_name, precision=self.attributes.get('precision', None), pragma='partition')
+
+        self.add_weights(quantizer=self.get_attr('weight_quantizer'),
+                         compression=self.model.config.get_compression(self))
+        self.add_bias(quantizer=self.get_attr('weight_quantizer'))
+
+        # Reshape the input/output variables
+        #for input_name in self.inputs:
+        #    input_array = self.get_input_variable(input_name)
+        #    partition_factor = input_array.shape[0]
+        #    if input_name in self.model.inputs:
+        #        input_array.pragma = ('reshape', 'block', partition_factor)
+        #    else:
+        #        input_array.pragma = ('partition', 'block', partition_factor)
+
+        #for output_name in self.outputs:
+        #    output_array = self.get_output_variable(output_name)
+        #    partition_factor = output_array.shape[0]
+        #    output_array.pragma = ('partition', 'block', partition_factor)
+
+    def function_cpp(self):
+        params = {}
+        params['config'] = 'config{}'.format(self.index)
+        params['input_t'] = self.model.get_layer_output_variable('node_attr').type.name
+        params['output_t'] = self.get_output_variable().type.name
+        params['node_attr'] = self.attributes["inputs"][0]
+        params['edge_attr_aggr'] = self.attributes["inputs"][1]
+        params['out'] = f"layer{self.index}_out"
+
+        params['w0'] = self.get_weights(f"{self.name}_w0").name
+        params['b0'] = self.get_weights(f"{self.name}_b0").name
+        params['w1'] = self.get_weights(f"{self.name}_w1").name
+        params['b1'] = self.get_weights(f"{self.name}_b1").name
+        params['w2'] = self.get_weights(f"{self.name}_w2").name
+        params['b2'] = self.get_weights(f"{self.name}_b2").name
+        params['w3'] = self.get_weights(f"{self.name}_w3").name
+        params['b3'] = self.get_weights(f"{self.name}_b3").name
+
+        out = self._function_template.format(**params)
+        return [out]
+
+    def config_cpp(self):
+        top_params = self.get_NodeBlock_params()
+        top_config = self._config_template.format(**top_params)
+        top_config = top_config.split('\n')[:-1]
+        top_config = '\n'.join(top_config)
+
+        sublayer_configs = self._config_sublayers()
+        sublayer_configs.update(self._config_misc())
+        for layer, config in sublayer_configs.items():
+            config = ['    ' + i for i in config.split('\n')]
+            config = '\n'.join(config)
+
+            top_config += '\n\n'
+            top_config += config
+
+        top_config += '\n};'
+        return top_config
+
+    def get_NodeBlock_params(self):  # hard-coded for now
+        params = {}
+        params['index'] = self.index
+        params['bias_t'] = f'layer{self.index}_t'
+        params['weight_t'] = f'layer{self.index}_t'
+        params['table_t'] = f'layer{self.index}_t'
+        params['n_node'] = self.n_node_cppname
+        params['n_edge'] = self.n_edge_cppname
+        params['node_dim'] = self.node_dim_cppname
+        params['edge_dim'] = self.edge_dim_cppname
+        params['out_dim'] = self.out_dim
+        params['n_layers'] = self.attributes["n_layers"]
+        params['io_type'] = 'io_parallel'
+        params['reuse'] = self.reuse_factor
+        params['n_zeros'] = 0
+        return params
+
+    def _config_misc(self):
+        configs = OrderedDict()
+
+        # matrix configs
+        matrix_config_template = """struct {matrix_name}_config: nnet::matrix_config{{
+                            static const unsigned n_rows = {n_rows};
+                            static const unsigned n_cols = {n_cols};
+                        }};"""
+
+        configs['node_attr_config'] = matrix_config_template.format(matrix_name="node_attr",
+                                                                    n_rows=self.n_node_cppname,
+                                                                    n_cols=self.node_dim_cppname)
+
+        configs['edge_attr_aggr_config'] = matrix_config_template.format(matrix_name="edge_attr_aggr",
+                                                                         n_rows=self.n_node_cppname,
+                                                                         n_cols=f"LAYER{self.index - 1}_OUT_DIM")
+
+        configs['node_update_config'] = matrix_config_template.format(matrix_name="node_update",
+                                                                      n_rows=self.n_node_cppname,
+                                                                      n_cols=f"LAYER{self.index}_OUT_DIM")
+
+        # concatenation configs
+        concat_config_template = self.model.config.backend.get_config_template('Concatenate')
+        concat_config_template = re.sub('config{index}', 'merge_config{index}', concat_config_template)
+        merge_config1_params = {
+            'index': 1,
+            'n_elem1_0': self.node_dim_cppname,
+            'n_elem1_1': 1,
+            'n_elem1_2': 0,
+            'n_elem2_0': self.edge_dim_cppname,
+            'n_elem2_1': 1,
+            'n_elem2_2': 0,
+            'axis': 0
+        }
+        merge_config1 = concat_config_template.format(**merge_config1_params)
+        configs['merge_config1'] = merge_config1
+
+        return configs
+
+    def _check_inputs(self):
+        #expected inputs: node_attr, edge_attr_aggr
+        assert(len(self.inputs)==2)
+
+        node_attr = self.model.get_layer_output_variable(self.inputs[0])
+        assert(node_attr.shape==[self.n_node, self.node_dim])
+
+        edge_attr_aggr = self.model.get_layer_output_variable(self.inputs[1])
+        assert(edge_attr_aggr.shape==[self.n_node, self.edge_dim])
+
+        #expected outputs: node_update
+        assert(len(self.outputs)==1)
+
+class Aggregate(Layer):
+    def initialize(self):
+        self.n_node = self.attributes['n_node']
+        self.n_edge = self.attributes['n_edge']
+        self.node_dim = self.attributes['node_dim']
+        self.edge_dim = self.attributes['edge_dim']
+        self.out_dim = self.attributes['out_dim']
+        self._check_inputs()
+
+        self.n_edge_cppname, self.edge_dim_cppname = self.model.get_layer_output_variable('edge_attr').dim_names
+        self.n_node_cppname, self.node_dim_cppname = self.model.get_layer_output_variable('node_attr').dim_names
+
+        aggr_name = f"layer{self.index}_out"
+        aggr_shape = [self.n_node, self.out_dim]
+        aggr_dims = ['N_NODE', f'LAYER{self.index}_OUT_DIM']
+        self.add_output_variable(shape=aggr_shape, dim_names=aggr_dims, out_name=aggr_name, var_name=aggr_name,
+                                 precision=self.attributes.get('precision', None))
+
+    def function_cpp(self):
+        params = {}
+        params['config'] = 'aggregation_config{}'.format(self.index)
+        params['input_t'] = self.model.get_layer_output_variable('edge_attr').type.name
+        params['index_t'] = self.model.get_layer_output_variable('edge_index').type.name
+        params['output_t'] = self.get_output_variable().type.name
+
+        params['edge_attr'] = self.attributes["inputs"][0]
+        params['edge_index'] = self.attributes["inputs"][1]
+        params['out'] = f"layer{self.index}_out"
+        return [self._function_template.format(**params)]
+
+    def config_cpp(self):
+        params = self.get_Aggregate_params()
+
+        top_config = self._config_template.format(**params)
+        top_config = top_config.split('\n')[:-1]
+        top_config = '\n'.join(top_config)
+
+        sub_configs = self._config_misc()
+        for layer, config in sub_configs.items():
+            config = ['    ' + i for i in config.split('\n')]
+            config = '\n'.join(config)
+
+            top_config += '\n\n'
+            top_config += config
+
+        top_config += '\n};'
+        return top_config
+
+    def get_Aggregate_params(self):
+        params = {}
+        params["index"] = self.index
+        params['n_node'] = self.attributes['n_node']
+        params['node_dim'] = self.attributes['node_dim']
+        params['n_edge'] = self.attributes['n_edge']
+        params['edge_dim'] = self.attributes['edge_dim']
+        params['table_t'] = f'layer{self.index}_t'
+        params['reuse'] = self.reuse_factor
+
+        flow_map = {"source_to_target": 0, "target_to_source": 1}
+        params['flow'] = flow_map[self.model.reader.torch_model.flow]
+
+        aggr_map = {"add": 0, "mean": 1, "max": 2}
+        params['aggr'] = aggr_map[self.model.reader.torch_model.aggr]
+
+        params['io_type'] = 'io_parallel'
+
+        return params
+
+    def _config_misc(self):
+        # matrix configs
+        configs = {}
+        matrix_config_template = """struct {matrix_name}_config: nnet::matrix_config{{
+                            static const unsigned n_rows = {n_rows};
+                            static const unsigned n_cols = {n_cols};
+                        }};"""
+
+        configs['edge_attr_config'] = matrix_config_template.format(matrix_name="edge_attr",
+                                                                    n_rows=self.n_edge_cppname,
+                                                                    n_cols=self.edge_dim_cppname)
+
+        configs['edge_index_config'] = matrix_config_template.format(matrix_name="edge_index",
+                                                                     n_rows=self.n_edge_cppname,
+                                                                     n_cols="TWO")
+
+        configs['edge_attr_aggr_config'] = matrix_config_template.format(matrix_name="edge_attr_aggr",
+                                                                           n_rows=self.n_node_cppname,
+                                                                           n_cols=f"LAYER{self.index}_OUT_DIM")
+
+        aggr_params = self.get_Aggregate_params()
+        nested_duplicate = self._config_template.format(**aggr_params).split('\n')
+        nested_duplicate[0] = "struct nested_duplicate: nnet::aggregate_config{"
+        nested_duplicate = '\n'.join(nested_duplicate)
+        configs['nested_duplicate'] = nested_duplicate
+
+        return configs
+
+    def _check_inputs(self):
+        #expected inputs: edge_attr, edge_index
+        assert(len(self.inputs)==2)
+
+        edge_attr = self.model.get_layer_output_variable(self.inputs[0])
+        assert(edge_attr.shape==[self.n_edge, self.edge_dim])
+
+        edge_index = self.model.get_layer_output_variable(self.inputs[1])
+        assert(edge_index.shape==[self.n_edge, 2])
+
+        #expected outputs: edge_attr_aggr
+        assert(len(self.outputs)==1)
+
 layer_map = {
     'Input'                  : Input,
     'InputLayer'             : Input,
@@ -1894,6 +2481,9 @@ layer_map = {
     'Transpose'              : Transpose,
     'GarNet'                 : GarNet,
     'GarNetStack'            : GarNetStack,
+    'EdgeBlock'              : EdgeBlock,
+    'NodeBlock'              : NodeBlock,
+    'Aggregate'              : Aggregate,
     # TensorFlow-specific layers:
     'BiasAdd'                : BiasAdd,
 }

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -476,10 +476,7 @@ class HLSModel(object):
         self.outputs = model_outputs.tolist()
 
     def get_weights_data(self, layer_name, var_name, module_name=None):
-        if module_name is not None:
-            return self.reader.get_weights_data(layer_name, var_name, module_name)
-        else:
-            return self.reader.get_weights_data(layer_name, var_name)
+        return self.reader.get_weights_data(layer_name, var_name, module_name)
 
     def next_layer(self):
         self.index += 1

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -475,8 +475,11 @@ class HLSModel(object):
         model_outputs = node_outputs[np.isin(node_outputs, node_inputs, invert=True)]
         self.outputs = model_outputs.tolist()
 
-    def get_weights_data(self, layer_name, var_name):
-        return self.reader.get_weights_data(layer_name, var_name)
+    def get_weights_data(self, layer_name, var_name, module_name=None):
+        if module_name is not None:
+            return self.reader.get_weights_data(layer_name, var_name, module_name)
+        else:
+            return self.reader.get_weights_data(layer_name, var_name)
 
     def next_layer(self):
         self.index += 1

--- a/hls4ml/templates/vivado/nnet_utils/nnet_array.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_array.h
@@ -51,6 +51,36 @@ void transpose_3d(
     }
 }
 
+struct matrix_config{
+    static const unsigned n_rows = 10;
+    static const unsigned n_cols = 10;
+};
+template<class data_T, class res_T, typename CONFIG_T>
+void vec_to_mat( //faster (I think)
+    data_T vec[CONFIG_T::n_rows*CONFIG_T::n_cols],
+    res_T mat[CONFIG_T::n_rows][CONFIG_T::n_cols]
+) {
+    for (int r=0; r < CONFIG_T::n_rows; r++){
+      for (int c=0; c < CONFIG_T::n_cols; c++){
+        #pragma HLS UNROLL
+        mat[r][c] = vec[r*CONFIG_T::n_cols+c];
+      }
+    }
+}
+
+template<class data_T, class res_T, typename CONFIG_T>
+void mat_to_vec( //faster (I think)
+    data_T mat[CONFIG_T::n_rows][CONFIG_T::n_cols],
+    res_T vec[CONFIG_T::n_rows*CONFIG_T::n_cols]
+) {
+    for (int r=0; r < CONFIG_T::n_rows; r++){
+      for (int c=0; c<CONFIG_T::n_cols; c++){
+        #pragma HLS UNROLL
+        vec[r*CONFIG_T::n_cols+c] = mat[r][c];
+      }
+    }
+}
+
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense.h
@@ -28,6 +28,7 @@ struct dense_config
     static const unsigned reuse_factor = 1;
     static const bool store_weights_in_bram = false;
     static const unsigned n_zeros = 0;
+    static const bool remove_pipeline_pragma = false;
     // partitioning arrays cyclically to go with roll factors?
     // Product function to use
     template<class x_T, class y_T, class res_T>

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense_resource.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense_resource.h
@@ -62,7 +62,9 @@ void dense_resource_rf_leq_nin(
 
     ReuseLoop:
     for (int ir = 0; ir < rufactor; ir++) {
-        #pragma HLS PIPELINE II=1 rewind
+        if (!CONFIG_T::remove_pipeline_pragma) {
+            #pragma HLS PIPELINE II=1 rewind
+        }
 
         int w_index = ir;
         int in_index = ir;
@@ -149,7 +151,9 @@ void dense_resource_rf_gt_nin_rem0(
 
     ReuseLoop:
     for (int ir = 0; ir < rufactor; ir++) {
-        #pragma HLS PIPELINE II=1 rewind
+        if (!CONFIG_T::remove_pipeline_pragma) {
+            #pragma HLS PIPELINE II=1 rewind
+        }
 
         w_index = ir;
         out_index = outidx[ir]/*outstep*/;
@@ -213,7 +217,9 @@ void dense_resource_rf_gt_nin(
 
     ReuseLoop:
     for (int ir = 0; ir < rufactor; ir++) {
-        #pragma HLS PIPELINE II=1 rewind
+        if (!CONFIG_T::remove_pipeline_pragma) {
+            #pragma HLS PIPELINE II=1 rewind
+        }
         typename CONFIG_T::accum_t tmpmult[block_factor];
         #pragma HLS ARRAY_PARTITION variable=tmpmult complete
 

--- a/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
@@ -1,0 +1,439 @@
+#ifndef NNET_GRAPH_H_
+#define NNET_GRAPH_H_
+
+#include "nnet_common.h"
+#include "nnet_merge.h"
+#include "nnet_dense.h"
+#include "nnet_dense_resource.h"
+#include "nnet_activation.h"
+#include "nnet_array.h"
+#include <math.h>
+
+namespace nnet {
+  enum flow {source_to_target=0, target_to_source=1};
+  enum aggr {aggr_sum=0, aggr_mean=1, aggr_max=2};
+  
+  struct graph_config
+  {
+    // Internal data type definitions
+    typedef float bias_t;
+    typedef float weight_t;
+    typedef float table_t;
+    
+    // Layer Sizes
+    static const unsigned n_node = 10;
+    static const unsigned n_edge = 20;
+    static const unsigned n_features = 3;
+    static const unsigned e_features = 4;
+    static const unsigned n_out = 4;
+    static const unsigned n_layers = 3;
+
+    // message-passing parameters
+    static const unsigned aggr = aggr_sum;
+    static const unsigned flow = source_to_target;
+    
+    // Resource reuse info
+    static const unsigned io_type = io_parallel;
+    static const unsigned reuse_factor = 1;
+    static const unsigned n_zeros = 0;
+
+    static const bool no_aggr = false; //if no_aggr==true, then skip aggregation steps
+  };
+
+  struct aggregate_config
+  {
+     typedef float table_t;
+     static const unsigned n_node = 10;
+     static const unsigned n_edge = 20;
+     static const unsigned edge_dim = 4;
+     static const unsigned aggr = aggr_sum;
+     static const unsigned flow = source_to_target;
+  };
+
+  // division-LUT for mean-aggregation
+  inline float division(float input){
+    return 1.0/input;
+  }
+  template<typename CONFIG_T, int N_TABLE>
+  void init_div_table(typename CONFIG_T::table_t table_out[N_TABLE]){
+    int j = 0;
+    typename CONFIG_T::table_t k = 1;
+    table_out[j] = k;
+    for(int i=1; i<N_TABLE; i++){
+      float in_val = float(i);
+      typename CONFIG_T::table_t reciprocal = nnet::division(in_val);
+      table_out[i] = reciprocal;
+    }
+  }
+  template<class data_T, class index_T, class res_T, typename CONFIG_T>
+  void edge_divide(data_T edge_sum_i, index_T n_edges_i, res_T &edge_mean_i){
+    // initialize LUT
+  #ifdef __HLS_SYN__
+      bool initialized=false;
+      typename CONFIG_T::table_t div_table[CONFIG_T::n_edge];
+  #else
+      static bool initialized=false;
+      static typename CONFIG_T::table_t div_table[CONFIG_T::n_edge];
+  #endif
+
+      if(!initialized){
+        nnet::init_div_table<CONFIG_T, CONFIG_T::n_edge>(div_table);
+        initialized=true;
+      }
+
+      if(CONFIG_T::io_type==io_parallel){
+        #pragma HLS PIPELINE
+      }
+
+      data_T reciprocal;
+      reciprocal = div_table[n_edges_i];
+      edge_mean_i = edge_sum_i*reciprocal;
+  }
+
+  template<class data_T, class res_T, typename CONFIG_T>
+    void dense_mult_1lyr(
+			 data_T data[CONFIG_T::dense_config1::n_in],
+			 res_T res[CONFIG_T::dense_config1::n_out],
+			 typename CONFIG_T::dense_config1::weight_t weights0[CONFIG_T::dense_config1::n_in*CONFIG_T::dense_config1::n_out],
+			 typename CONFIG_T::dense_config1::bias_t   biases0[CONFIG_T::dense_config1::n_out])
+  {
+    nnet::dense_resource<data_T, res_T, typename CONFIG_T::dense_config1>(data, res, weights0, biases0);
+  }
+
+  template<class data_T, class res_T, typename CONFIG_T>
+    void dense_mult_2lyr(
+			 data_T data[CONFIG_T::dense_config1::n_in],
+			 res_T res[CONFIG_T::dense_config2::n_out],
+			 typename CONFIG_T::dense_config1::weight_t weights0[CONFIG_T::dense_config1::n_in*CONFIG_T::dense_config1::n_out],
+			 typename CONFIG_T::dense_config1::bias_t   biases0[CONFIG_T::dense_config1::n_out],
+			 typename CONFIG_T::dense_config2::weight_t weights1[CONFIG_T::dense_config2::n_in*CONFIG_T::dense_config2::n_out],
+			 typename CONFIG_T::dense_config2::bias_t   biases1[CONFIG_T::dense_config2::n_out])
+  {
+    data_T data0_logits[CONFIG_T::dense_config1::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data0_logits complete dim=0
+    nnet::dense_resource<data_T, data_T, typename CONFIG_T::dense_config1>(data, data0_logits, weights0, biases0);
+    data_T data0[CONFIG_T::dense_config1::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data0 complete dim=0
+    nnet::relu<data_T, data_T, typename CONFIG_T::relu_config1>(data0_logits, data0);
+
+    nnet::dense_resource<data_T, res_T, typename CONFIG_T::dense_config2>(data0, res, weights1, biases1);
+  }
+
+  template<class data_T, class res_T, typename CONFIG_T>
+    void dense_mult_3lyr(
+			 data_T data[CONFIG_T::dense_config1::n_in],
+			 res_T res[CONFIG_T::dense_config3::n_out],
+			 typename CONFIG_T::dense_config1::weight_t weights0[CONFIG_T::dense_config1::n_in*CONFIG_T::dense_config1::n_out],
+			 typename CONFIG_T::dense_config1::bias_t   biases0[CONFIG_T::dense_config1::n_out],
+			 typename CONFIG_T::dense_config2::weight_t weights1[CONFIG_T::dense_config2::n_in*CONFIG_T::dense_config2::n_out],
+			 typename CONFIG_T::dense_config2::bias_t   biases1[CONFIG_T::dense_config2::n_out],
+			 typename CONFIG_T::dense_config3::weight_t weights2[CONFIG_T::dense_config3::n_in*CONFIG_T::dense_config3::n_out],
+			 typename CONFIG_T::dense_config3::bias_t   biases2[CONFIG_T::dense_config3::n_out])
+  {
+    data_T data0_logits[CONFIG_T::dense_config1::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data0_logits complete dim=0
+    nnet::dense_resource<data_T, data_T, typename CONFIG_T::dense_config1>(data, data0_logits, weights0, biases0);
+    data_T data0[CONFIG_T::dense_config1::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data0 complete dim=0
+    nnet::relu<data_T, data_T, typename CONFIG_T::relu_config1>(data0_logits, data0);
+
+    data_T data1_logits[CONFIG_T::dense_config2::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data1_logits complete dim=0
+    nnet::dense_resource<data_T, data_T, typename CONFIG_T::dense_config2>(data0, data1_logits, weights1, biases1);
+    data_T data1[CONFIG_T::dense_config2::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data1 complete dim=0
+    nnet::relu<data_T, data_T, typename CONFIG_T::relu_config2>(data1_logits, data1);
+
+    nnet::dense_resource<data_T, res_T, typename CONFIG_T::dense_config3>(data1, res, weights2, biases2);
+  }
+
+  template<class data_T, class res_T, typename CONFIG_T>
+    void dense_mult_4lyr(
+			 data_T data[CONFIG_T::dense_config1::n_in],
+			 res_T res[CONFIG_T::dense_config4::n_out],
+			 typename CONFIG_T::dense_config1::weight_t weights0[CONFIG_T::dense_config1::n_in*CONFIG_T::dense_config1::n_out],
+			 typename CONFIG_T::dense_config1::bias_t   biases0[CONFIG_T::dense_config1::n_out],
+			 typename CONFIG_T::dense_config2::weight_t weights1[CONFIG_T::dense_config2::n_in*CONFIG_T::dense_config2::n_out],
+			 typename CONFIG_T::dense_config2::bias_t   biases1[CONFIG_T::dense_config2::n_out],
+			 typename CONFIG_T::dense_config3::weight_t weights2[CONFIG_T::dense_config3::n_in*CONFIG_T::dense_config3::n_out],
+			 typename CONFIG_T::dense_config3::bias_t   biases2[CONFIG_T::dense_config3::n_out],
+			 typename CONFIG_T::dense_config4::weight_t weights3[CONFIG_T::dense_config4::n_in*CONFIG_T::dense_config4::n_out],
+			 typename CONFIG_T::dense_config4::bias_t   biases3[CONFIG_T::dense_config4::n_out])
+  {
+    data_T data0_logits[CONFIG_T::dense_config1::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data0_logits complete dim=0
+    nnet::dense_resource<data_T, data_T, typename CONFIG_T::dense_config1>(data, data0_logits, weights0, biases0);
+    data_T data0[CONFIG_T::dense_config1::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data0 complete dim=0
+    nnet::relu<data_T, data_T, typename CONFIG_T::relu_config1>(data0_logits, data0);
+
+    data_T data1_logits[CONFIG_T::dense_config2::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data1_logits complete dim=0
+    nnet::dense_resource<data_T, data_T, typename CONFIG_T::dense_config2>(data0, data1_logits, weights1, biases1);
+    data_T data1[CONFIG_T::dense_config2::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data1 complete dim=0
+    nnet::relu<data_T, data_T, typename CONFIG_T::relu_config2>(data1_logits, data1);
+
+    data_T data2_logits[CONFIG_T::dense_config3::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data2_logits complete dim=0
+    nnet::dense_resource<data_T, data_T, typename CONFIG_T::dense_config3>(data1, data2_logits, weights2, biases2);
+    data_T data2[CONFIG_T::dense_config3::n_out];
+    #pragma HLS ARRAY_PARTITION variable=data2 complete dim=0
+    nnet::relu<data_T, data_T, typename CONFIG_T::relu_config3>(data2_logits, data2);
+
+    nnet::dense_resource<data_T, res_T, typename CONFIG_T::dense_config4>(data2, res, weights3, biases3);
+  }
+
+  template<class data_T, class index_T, class res_T, typename CONFIG_T>
+    void aggregate(
+            data_T    edge_attr_1D[CONFIG_T::n_edge*CONFIG_T::edge_dim],
+            index_T   edge_index_1D[CONFIG_T::n_edge*2],
+            res_T     edge_attr_aggr_1D[CONFIG_T::n_node*CONFIG_T::edge_dim])
+  {
+    //initialize arrays
+    // 1. edge_attr (input)
+    data_T edge_attr[CONFIG_T::n_edge][CONFIG_T::edge_dim];
+    #pragma HLS ARRAY_PARTITION variable=edge_attr complete dim=0
+    nnet::vec_to_mat<data_T, data_T, typename CONFIG_T::edge_attr_config>(edge_attr_1D, edge_attr);
+
+    // 2. edge_index (input)
+    index_T edge_index[CONFIG_T::n_edge][2];
+    #pragma HLS ARRAY_PARTITION variable=edge_index complete dim=0
+    nnet::vec_to_mat<index_T, index_T, typename CONFIG_T::edge_index_config>(edge_index_1D, edge_index);
+
+    //3. num_edge_per_node (intermediate), 4. edge_aggr_mask (intermediate)
+    index_T num_edge_per_node[CONFIG_T::n_node];
+    #pragma HLS ARRAY_PARTITION variable=num_edge_per_node complete dim=0
+    ap_uint<1> edge_aggr_mask[CONFIG_T::n_node];
+    #pragma HLS ARRAY_PARTITION variable=edge_aggr_mask complete dim=0
+    for(int i=0; i<CONFIG_T::n_node; i++){
+      #pragma HLS UNROLL
+      num_edge_per_node[i] = 0;
+      if(CONFIG_T::aggr==aggr_max){
+        edge_aggr_mask[i] = 0;
+      }
+    }
+
+    //4. edge_attr_aggr (output)
+    res_T edge_attr_aggr[CONFIG_T::n_node][CONFIG_T::edge_dim];
+    #pragma HLS ARRAY_PARTITION variable=edge_update_aggr complete dim=0
+    if((CONFIG_T::aggr==aggr_sum)||(CONFIG_T::aggr==aggr_mean)){
+      for(int i=0; i < CONFIG_T::n_node; i++){
+        for(int j=0; j<CONFIG_T::edge_dim; j++){
+          #pragma HLS UNROLL
+          edge_attr_aggr[i][j] = 0;
+        }
+      }
+    }
+    else{ //CONFIG_T:aggr==aggr_max, we want to initialize this with the most negative number we can represent
+      // note this only works for ap_ufixed types
+      res_T most_negative_num;
+      most_negative_num.V = 1;
+      most_negative_num.V <<= res_T::width - 1;
+
+      for(int i=0; i < CONFIG_T::n_node; i++){
+        for(int j=0; j<CONFIG_T::edge_dim; j++){
+          #pragma HLS UNROLL
+          edge_attr_aggr[i][j] = most_negative_num;
+        }
+      }
+    }
+
+    int receiver_col;
+    if(CONFIG_T::flow == source_to_target){
+      receiver_col = 1;
+    }
+    else{
+      receiver_col = 0;
+    }
+
+    #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
+    for(int i=0; i<CONFIG_T::n_edge; i++){
+      #pragma HLS UNROLL
+      index_T r = edge_index[i][receiver_col];
+      num_edge_per_node[r] += 1;
+      edge_aggr_mask[r] = 1;
+
+      if((CONFIG_T::aggr == aggr_sum)||(CONFIG_T::aggr==aggr_mean)){
+        for(int j=0; j<CONFIG_T::edge_dim; j++){
+          #pragma HLS UNROLL
+          edge_attr_aggr[r][j] += edge_attr[i][j];
+        }
+      }
+      else{ //CONFIG_T::aggr==aggr_max
+        for(int j=0; j<CONFIG_T::edge_dim; j++){
+          #pragma HLS UNROLL
+          edge_attr_aggr[r][j] = edge_attr[i][j] > edge_attr_aggr[r][j] ? edge_attr[i][j] : edge_attr_aggr[r][j];
+        }
+      }
+    }
+
+    // sum --> mean
+    if(CONFIG_T::aggr == aggr_mean){
+      for(int i=0; i < CONFIG_T::n_node; i++){
+        for (int j=0; j<CONFIG_T::edge_dim; j++){
+          #pragma HLS UNROLL
+          res_T edge_mean_j;
+          nnet::edge_divide<res_T, index_T, res_T, CONFIG_T>(edge_attr_aggr[i][j], num_edge_per_node[i], edge_mean_j);
+          edge_attr_aggr[i][j] = edge_mean_j;
+        }
+      }
+    }
+
+    // None --> max
+    if(CONFIG_T::aggr == aggr_max){ //note: the edge_update_aggr array has been initialized but IS NOT ZEROS
+      for(int i=0; i < CONFIG_T::n_node; i++){
+        for(int j=0; j<CONFIG_T::edge_dim; j++){
+          #pragma HLS UNROLL
+          edge_attr_aggr[i][j] = edge_aggr_mask[i]*edge_attr_aggr[i][j];
+        }
+      }
+    }
+
+    //output array --> output vec
+    nnet::mat_to_vec<res_T, res_T, typename CONFIG_T::edge_attr_aggr_config>(edge_attr_aggr, edge_attr_aggr_1D);
+  }
+
+  template<class data_T, class index_T, class res_T, typename CONFIG_T>
+    void edgeblock(
+            data_T    node_attr_1D[CONFIG_T::n_node*CONFIG_T::node_dim],
+			data_T    edge_attr_1D[CONFIG_T::n_edge*CONFIG_T::edge_dim],
+			index_T   edge_index_1D[CONFIG_T::n_edge*2],
+			res_T     edge_update_1D[CONFIG_T::n_edge*CONFIG_T::out_dim],
+			typename CONFIG_T::dense_config1::weight_t  core_edge_w0[CONFIG_T::dense_config1::n_in*CONFIG_T::dense_config1::n_out],
+			typename CONFIG_T::dense_config1::bias_t    core_edge_b0[CONFIG_T::dense_config1::n_out],
+			typename CONFIG_T::dense_config2::weight_t  core_edge_w1[CONFIG_T::dense_config2::n_in*CONFIG_T::dense_config2::n_out],
+			typename CONFIG_T::dense_config2::bias_t    core_edge_b1[CONFIG_T::dense_config2::n_out],
+			typename CONFIG_T::dense_config3::weight_t  core_edge_w2[CONFIG_T::dense_config3::n_in*CONFIG_T::dense_config3::n_out],
+			typename CONFIG_T::dense_config3::bias_t    core_edge_b2[CONFIG_T::dense_config3::n_out],
+			typename CONFIG_T::dense_config4::weight_t  core_edge_w3[CONFIG_T::dense_config4::n_in*CONFIG_T::dense_config4::n_out],
+			typename CONFIG_T::dense_config4::bias_t    core_edge_b3[CONFIG_T::dense_config4::n_out])
+  {
+    //initialize arrays
+    // 1. node_attr (input)
+    data_T node_attr[CONFIG_T::n_node][CONFIG_T::node_dim];
+    #pragma HLS ARRAY_PARTITION variable=node_attr complete dim=0
+    nnet::vec_to_mat<data_T, data_T, typename CONFIG_T::node_attr_config>(node_attr_1D, node_attr);
+
+    // 2. edge_attr (input)
+    data_T edge_attr[CONFIG_T::n_edge][CONFIG_T::edge_dim];
+    #pragma HLS ARRAY_PARTITION variable=edge_attr complete dim=0
+    nnet::vec_to_mat<data_T, data_T, typename CONFIG_T::edge_attr_config>(edge_attr_1D, edge_attr);
+
+    // 3. edge_index (input)
+    index_T edge_index[CONFIG_T::n_edge][2];
+    #pragma HLS ARRAY_PARTITION variable=edge_index complete dim=0
+    nnet::vec_to_mat<index_T, index_T, typename CONFIG_T::edge_index_config>(edge_index_1D, edge_index);
+
+    // 4. edge_update (output)
+    res_T edge_update[CONFIG_T::n_edge][CONFIG_T::out_dim];
+    #pragma HLS ARRAY_PARTITION variable=edge_update complete dim=0
+
+    int sender_col;
+    int receiver_col;
+    if(CONFIG_T::flow == source_to_target){
+      sender_col = 0;
+      receiver_col = 1;
+    }
+    else{
+      sender_col = 1;
+      receiver_col = 0;
+    }
+
+    #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
+    edge_loop: for(int i = 0; i < CONFIG_T::n_edge; i++) { //for each edge
+      #pragma HLS UNROLL
+
+      // get sender, receiver indices
+      index_T s = edge_index[i][sender_col];
+      index_T r = edge_index[i][receiver_col];
+
+      // construct NN input: <receiver, sender, edge>
+      data_T node_concat[2*CONFIG_T::node_dim];
+      #pragma HLS ARRAY_PARTITION variable=node_concat complete dim=0
+      nnet::concatenate1d<data_T, data_T, data_T, typename CONFIG_T::merge_config1>(node_attr[r], node_attr[s], node_concat);
+      data_T phi_input[CONFIG_T::edge_dim + 2*CONFIG_T::node_dim];
+      #pragma HLS ARRAY_PARTITION variable=phi_input complete dim=0
+      nnet::concatenate1d<data_T, data_T, data_T, typename CONFIG_T::merge_config2>(node_concat, edge_attr[i], phi_input);
+
+      // send it through NN
+        if(CONFIG_T::n_layers == 1){
+	      nnet::dense_mult_1lyr<data_T, data_T, CONFIG_T>(phi_input, edge_update[i], core_edge_w0, core_edge_b0);
+          }
+        else if(CONFIG_T::n_layers == 2){
+	      nnet::dense_mult_2lyr<data_T, data_T, CONFIG_T>(phi_input, edge_update[i], core_edge_w0, core_edge_b0, core_edge_w1, core_edge_b1);
+        }
+        else if(CONFIG_T::n_layers == 3){
+	      nnet::dense_mult_3lyr<data_T, data_T, CONFIG_T>(phi_input, edge_update[i], core_edge_w0, core_edge_b0, core_edge_w1, core_edge_b1, core_edge_w2, core_edge_b2);
+        }
+        else if(CONFIG_T::n_layers == 4){
+	      nnet::dense_mult_4lyr<data_T, res_T, CONFIG_T>(phi_input, edge_update[i], core_edge_w0, core_edge_b0, core_edge_w1, core_edge_b1, core_edge_w2, core_edge_b2, core_edge_w3, core_edge_b3);
+        }
+    }
+
+    //output arrays --> output vectors
+    // 1. edge_update_1D
+    nnet::mat_to_vec<res_T, res_T, typename CONFIG_T::edge_update_config>(edge_update, edge_update_1D);
+  }
+
+  template<class data_T, class res_T, typename CONFIG_T>
+    void nodeblock(
+			data_T    node_attr_1D[CONFIG_T::n_node*CONFIG_T::node_dim],
+			data_T    edge_attr_aggr_1D[CONFIG_T::n_node*CONFIG_T::edge_dim],
+			res_T     node_update_1D[CONFIG_T::n_node*CONFIG_T::out_dim],
+			typename CONFIG_T::dense_config1::weight_t  core_node_w0[CONFIG_T::dense_config1::n_in*CONFIG_T::dense_config1::n_out],
+			typename CONFIG_T::dense_config1::bias_t    core_node_b0[CONFIG_T::dense_config1::n_out],
+			typename CONFIG_T::dense_config2::weight_t  core_node_w1[CONFIG_T::dense_config2::n_in*CONFIG_T::dense_config2::n_out],
+			typename CONFIG_T::dense_config2::bias_t    core_node_b1[CONFIG_T::dense_config2::n_out],
+			typename CONFIG_T::dense_config3::weight_t  core_node_w2[CONFIG_T::dense_config3::n_in*CONFIG_T::dense_config3::n_out],
+			typename CONFIG_T::dense_config3::bias_t    core_node_b2[CONFIG_T::dense_config3::n_out],
+			typename CONFIG_T::dense_config4::weight_t  core_node_w3[CONFIG_T::dense_config4::n_in*CONFIG_T::dense_config4::n_out],
+			typename CONFIG_T::dense_config4::bias_t    core_node_b3[CONFIG_T::dense_config4::n_out])
+  {
+    //initialize arrays
+    //1. node_attr (input)
+    data_T node_attr[CONFIG_T::n_node][CONFIG_T::node_dim];
+    #pragma HLS ARRAY_PARTITION variable=node_attr complete dim=0
+    nnet::vec_to_mat<data_T, data_T, typename CONFIG_T::node_attr_config>(node_attr_1D, node_attr);
+
+    //2. edge_attr_aggr (input)
+    data_T edge_attr_aggr[CONFIG_T::n_node][CONFIG_T::edge_dim];
+    #pragma HLS ARRAY_PARTITION variable=edge_attr_aggr complete dim=0
+    nnet::vec_to_mat<data_T, data_T, typename CONFIG_T::edge_attr_aggr_config>(edge_attr_aggr_1D, edge_attr_aggr);
+
+    // 3. node_update (output)
+    res_T node_update[CONFIG_T::n_node][CONFIG_T::out_dim];
+    #pragma HLS ARRAY_PARTITION variable=node_update complete dim=0
+
+    #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
+    node_loop: for(int i = 0; i < CONFIG_T::n_node; i++){ //for each node
+      #pragma HLS UNROLL
+
+      // construct NN input: <node, edge_attr_aggr>
+      data_T phi_input[CONFIG_T::edge_dim + CONFIG_T::node_dim];
+      #pragma HLS ARRAY_PARTITION variable=phi_input complete dim=0
+      nnet::concatenate1d<data_T, data_T, data_T, typename CONFIG_T::merge_config1>(node_attr[i], edge_attr_aggr[i], phi_input);
+
+      // send it through NN
+        if(CONFIG_T::n_layers == 1){
+	      nnet::dense_mult_1lyr<data_T, res_T, CONFIG_T>(phi_input, node_update[i], core_node_w0, core_node_b0);
+        }
+        else if(CONFIG_T::n_layers == 2){
+	      nnet::dense_mult_2lyr<data_T, res_T, CONFIG_T>(phi_input, node_update[i], core_node_w0, core_node_b0, core_node_w1, core_node_b1);
+        }
+        else if(CONFIG_T::n_layers == 3){
+	      nnet::dense_mult_3lyr<data_T, res_T, CONFIG_T>(phi_input, node_update[i], core_node_w0, core_node_b0, core_node_w1, core_node_b1, core_node_w2, core_node_b2);
+        }
+        else { // CONFIG_T::n_layers == 4
+	      nnet::dense_mult_4lyr<data_T, res_T, CONFIG_T>(phi_input, node_update[i], core_node_w0, core_node_b0, core_node_w1, core_node_b1, core_node_w2, core_node_b2, core_node_w3, core_node_b3);
+        }
+    }
+
+    // output array --> output vector
+    nnet::mat_to_vec<res_T, res_T, typename CONFIG_T::node_update_config>(node_update, node_update_1D);
+
+  }
+
+}
+
+#endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
@@ -8,6 +8,7 @@
 #include "nnet_activation.h"
 #include "nnet_array.h"
 #include <math.h>
+#include <float.h>
 
 namespace nnet {
   enum flow {source_to_target=0, target_to_source=1};
@@ -221,10 +222,18 @@ namespace nnet {
       }
     }
     else{ //CONFIG_T:aggr==aggr_max, we want to initialize this with the most negative number we can represent
-      // note this only works for ap_ufixed types
+      // note: works for ap_fixed or float
       res_T most_negative_num;
-      most_negative_num.V = 1;
-      most_negative_num.V <<= res_T::width - 1;
+
+      std::ostringstream mnm_T_ss;
+      mnm_T_ss << typeid(most_negative_num).name();
+      if (mnm_T_ss.str()=="f"){
+        most_negative_num = -FLT_MAX+1;
+      }
+      else{
+        most_negative_num.V = 1;
+        most_negative_num.V <<= res_T::width - 1;
+      }
 
       for(int i=0; i < CONFIG_T::n_node; i++){
         for(int j=0; j<CONFIG_T::edge_dim; j++){

--- a/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
@@ -196,12 +196,7 @@ namespace nnet {
     #pragma HLS ARRAY_PARTITION variable=edge_attr complete dim=0
     nnet::vec_to_mat<data_T, data_T, typename CONFIG_T::edge_attr_config>(edge_attr_1D, edge_attr);
 
-    // 2. edge_index (input)
-    index_T edge_index[CONFIG_T::n_edge][2];
-    #pragma HLS ARRAY_PARTITION variable=edge_index complete dim=0
-    nnet::vec_to_mat<index_T, index_T, typename CONFIG_T::edge_index_config>(edge_index_1D, edge_index);
-
-    //3. num_edge_per_node (intermediate), 4. edge_aggr_mask (intermediate)
+    //2. num_edge_per_node (intermediate), 3. edge_aggr_mask (intermediate)
     index_T num_edge_per_node[CONFIG_T::n_node];
     #pragma HLS ARRAY_PARTITION variable=num_edge_per_node complete dim=0
     ap_uint<1> edge_aggr_mask[CONFIG_T::n_node];
@@ -250,7 +245,7 @@ namespace nnet {
     #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
     for(int i=0; i<CONFIG_T::n_edge; i++){
       #pragma HLS UNROLL
-      index_T r = edge_index[i][receiver_col];
+      index_T r = edge_index_1D[2*i+receiver_col];
       num_edge_per_node[r] += 1;
       edge_aggr_mask[r] = 1;
 
@@ -320,12 +315,7 @@ namespace nnet {
     #pragma HLS ARRAY_PARTITION variable=edge_attr complete dim=0
     nnet::vec_to_mat<data_T, data_T, typename CONFIG_T::edge_attr_config>(edge_attr_1D, edge_attr);
 
-    // 3. edge_index (input)
-    index_T edge_index[CONFIG_T::n_edge][2];
-    #pragma HLS ARRAY_PARTITION variable=edge_index complete dim=0
-    nnet::vec_to_mat<index_T, index_T, typename CONFIG_T::edge_index_config>(edge_index_1D, edge_index);
-
-    // 4. phi_input (intermediate)
+    // 3. phi_input (intermediate)
     int sender_col;
     int receiver_col;
     if(CONFIG_T::flow == source_to_target){
@@ -339,8 +329,8 @@ namespace nnet {
     data_T phi_input[CONFIG_T::n_edge][2*CONFIG_T::node_dim+CONFIG_T::n_edge];
     #pragma HLS ARRAY_PARTITION variable=phi_input complete dim=0
     for(int i=0; i<CONFIG_T::n_edge; i++){
-      index_T s = edge_index[i][sender_col];
-      index_T r = edge_index[i][receiver_col];
+      index_T s = edge_index_1D[2*i+sender_col];
+      index_T r = edge_index_1D[2*i+receiver_col];
 
       // phi_input_i = <receiver_i, sender_i, edge_i>
       for(int j=0; j<CONFIG_T::node_dim; j++){
@@ -354,7 +344,7 @@ namespace nnet {
       }
     }
 
-    // 5. edge_update (output)
+    // 4. edge_update (output)
     res_T edge_update[CONFIG_T::n_edge][CONFIG_T::out_dim];
     #pragma HLS ARRAY_PARTITION variable=edge_update complete dim=0
 

--- a/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
@@ -8,7 +8,7 @@
 #include "nnet_activation.h"
 #include "nnet_array.h"
 #include <math.h>
-#include <float.h>
+#include "utils/x_hls_utils.h"
 
 namespace nnet {
   enum flow {source_to_target=0, target_to_source=1};
@@ -222,19 +222,7 @@ namespace nnet {
       }
     }
     else{ //CONFIG_T:aggr==aggr_max, we want to initialize this with the most negative number we can represent
-      // note: works for ap_fixed or float
-      res_T most_negative_num;
-
-      std::ostringstream mnm_T_ss;
-      mnm_T_ss << typeid(most_negative_num).name();
-      if (mnm_T_ss.str()=="f"){
-        most_negative_num = -FLT_MAX+1;
-      }
-      else{
-        most_negative_num.V = 1;
-        most_negative_num.V <<= res_T::width - 1;
-      }
-
+      res_T most_negative_num = hls::numeric_limits<res_T>::min();
       for(int i=0; i < CONFIG_T::n_node; i++){
         for(int j=0; j<CONFIG_T::edge_dim; j++){
           #pragma HLS UNROLL

--- a/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
@@ -216,7 +216,7 @@ namespace nnet {
 
     //4. edge_attr_aggr (output)
     res_T edge_attr_aggr[CONFIG_T::n_node][CONFIG_T::edge_dim];
-    #pragma HLS ARRAY_PARTITION variable=edge_update_aggr complete dim=0
+    #pragma HLS ARRAY_PARTITION variable=edge_attr_aggr complete dim=0
     if((CONFIG_T::aggr==aggr_sum)||(CONFIG_T::aggr==aggr_mean)){
       for(int i=0; i < CONFIG_T::n_node; i++){
         for(int j=0; j<CONFIG_T::edge_dim; j++){
@@ -281,7 +281,7 @@ namespace nnet {
     }
 
     // None --> max
-    if(CONFIG_T::aggr == aggr_max){ //note: the edge_update_aggr array has been initialized but IS NOT ZEROS
+    if(CONFIG_T::aggr == aggr_max){ //note: the edge_attr_aggr array has been initialized but IS NOT ZEROS
       for(int i=0; i < CONFIG_T::n_node; i++){
         for(int j=0; j<CONFIG_T::edge_dim; j++){
           #pragma HLS UNROLL

--- a/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
@@ -222,7 +222,7 @@ namespace nnet {
       }
     }
     else{ //CONFIG_T:aggr==aggr_max, we want to initialize this with the most negative number we can represent
-      res_T most_negative_num = hls::numeric_limits<res_T>::min();
+      res_T most_negative_num = -hls::numeric_limits<res_T>::max();
       for(int i=0; i < CONFIG_T::n_node; i++){
         for(int j=0; j<CONFIG_T::edge_dim; j++){
           #pragma HLS UNROLL

--- a/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_graph.h
@@ -40,7 +40,7 @@ namespace nnet {
     static const bool no_aggr = false; //if no_aggr==true, then skip aggregation steps
   };
 
-  struct aggregate_config
+  struct edge_aggregate_config
   {
      typedef float table_t;
      static const unsigned n_node = 10;
@@ -185,7 +185,7 @@ namespace nnet {
   }
 
   template<class data_T, class index_T, class res_T, typename CONFIG_T>
-    void aggregate(
+    void edge_aggregate(
             data_T    edge_attr_1D[CONFIG_T::n_edge*CONFIG_T::edge_dim],
             index_T   edge_index_1D[CONFIG_T::n_edge*2],
             res_T     edge_attr_aggr_1D[CONFIG_T::n_node*CONFIG_T::edge_dim])

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -378,7 +378,7 @@ nodeblock_config_template = """struct config{index}: nnet::graph_config{{
     static const bool io_stream = false; 
 }};"""
 
-aggregate_config_template = """struct aggregation_config{index}: nnet::aggregate_config{{
+edge_aggregate_config_template = """struct aggregation_config{index}: nnet::edge_aggregate_config{{
     typedef {table_t} table_t;
     static const unsigned n_node = {n_node};
     static const unsigned n_edge = {n_edge};
@@ -413,7 +413,7 @@ garnet_function_template = 'nnet::garnet{impl}<{input_t}, {integer_input_t}, {ou
 garnet_stack_function_template = 'nnet::garnet_stack<{input_t}, {integer_input_t}, {output_t}, {config}>({input}, {nvtx}, {output});'
 edgeblock_function_template = 'nnet::edgeblock<{input_t}, {index_t}, {output_t}, {config}>({node_attr}, {edge_attr}, {edge_index}, {out}, {w0}, {b0}, {w1}, {b1}, {w2}, {b2}, {w3}, {b3});'
 nodeblock_function_template = 'nnet::nodeblock<{input_t}, {output_t}, {config}>({node_attr}, {edge_attr_aggr}, {out}, {w0}, {b0}, {w1}, {b1}, {w2}, {b2}, {w3}, {b3});'
-aggregate_function_template = 'nnet::aggregate<{input_t}, {index_t}, {output_t}, {config}>({edge_attr}, {edge_index}, {out});'
+edge_aggregate_function_template = 'nnet::edge_aggregate<{input_t}, {index_t}, {output_t}, {config}>({edge_attr}, {edge_index}, {out});'
 
 dense_include_list = ['nnet_utils/nnet_dense.h', 'nnet_utils/nnet_dense_compressed.h', 'nnet_utils/nnet_dense_stream.h']
 batchnorm_include_list = ['nnet_utils/nnet_batchnorm.h', 'nnet_utils/nnet_batchnorm_stream.h']
@@ -442,7 +442,7 @@ nodeblock_include_list = ['nnet_utils/nnet_common.h',
                           'nnet_utils/nnet_graph.h',
                           'nnet_utils/nnet_merge.h',
                           'nnet_utils/nnet_array.h']
-aggregate_include_list = ['nnet_utils/nnet_graph.h']
+edge_aggregate_include_list = ['nnet_utils/nnet_graph.h']
 
 class VivadoBackend(Backend):
     def __init__(self, name='Vivado'):
@@ -476,7 +476,7 @@ class VivadoBackend(Backend):
         self.register_templates('GarNetStack'            , garnet_stack_function_template,garnet_stack_config_template, garnet_include_list)        
         self.register_templates('EdgeBlock'              , edgeblock_function_template, edgeblock_config_template, edgeblock_include_list)
         self.register_templates('NodeBlock'              , nodeblock_function_template, nodeblock_config_template, nodeblock_include_list)
-        self.register_templates('Aggregate'              , aggregate_function_template, aggregate_config_template, aggregate_include_list)
+        self.register_templates('EdgeAggregate'              , edge_aggregate_function_template, edge_aggregate_config_template, edge_aggregate_include_list)
     
     def create_initial_config(self, part='xcku115-flvb2104-2-i', board=None, clock_period=5, io_type='io_parallel'):
         config = {}

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -19,6 +19,7 @@ dense_config_template = """struct config{index} : nnet::dense_config {{
     typedef {bias_t} bias_t;
     typedef {weight_t} weight_t;
     typedef {index_t} index_t;
+    static const bool remove_pipeline_pragma = {remove_pipeline_pragma};
     template<class x_T, class y_T, class res_T>
     using product = nnet::product::{product_type}<x_T, y_T, res_T>;
 }};\n"""
@@ -344,6 +345,50 @@ const config{index}::sublayer_t<{il}>::output_transform_biases_t (&config{index}
 
 garnet_stack_config_template = (garnet_stack_base_config_template, garnet_stack_sublayer_config_template)
 
+edgeblock_config_template = """struct config{index}: nnet::graph_config{{
+    typedef {bias_t} bias_t;
+    typedef {weight_t} weight_t;
+    typedef {table_t} table_t;
+    static const unsigned n_node = {n_node};
+    static const unsigned n_edge = {n_edge};
+    static const unsigned node_dim = {node_dim};
+    static const unsigned edge_dim = {edge_dim};
+    static const unsigned out_dim = {out_dim};
+    static const unsigned n_layers = {n_layers};
+    static const unsigned flow = {flow};
+    static const unsigned io_type = nnet::{io_type};
+    static const unsigned reuse_factor = {reuse};
+    static const unsigned n_zeros = {n_zeros};
+    static const bool io_stream = false; 
+}};"""
+
+nodeblock_config_template = """struct config{index}: nnet::graph_config{{
+    typedef {bias_t} bias_t;
+    typedef {weight_t} weight_t;
+    typedef {table_t} table_t;
+    static const unsigned n_node = {n_node};
+    static const unsigned n_edge = {n_edge};
+    static const unsigned node_dim = {node_dim}; 
+    static const unsigned edge_dim = {edge_dim};
+    static const unsigned out_dim = {out_dim};
+    static const unsigned n_layers = {n_layers};
+    static const unsigned io_type = nnet::{io_type};
+    static const unsigned reuse_factor = {reuse};
+    static const unsigned n_zeros = {n_zeros};
+    static const bool io_stream = false; 
+}};"""
+
+aggregate_config_template = """struct aggregation_config{index}: nnet::aggregate_config{{
+    typedef {table_t} table_t;
+    static const unsigned n_node = {n_node};
+    static const unsigned n_edge = {n_edge};
+    static const unsigned edge_dim = {edge_dim};
+    static const unsigned aggr = {aggr};
+    static const unsigned flow = {flow};
+    static const unsigned io_type = nnet::{io_type};
+    static const unsigned reuse_factor = {reuse};
+    static const bool io_stream = false;
+}};"""
 
 
 dense_function_template = 'nnet::dense<{input_t}, {output_t}, {config}>({input}, {output}, {w}, {b});'
@@ -366,6 +411,9 @@ resize_function_template = 'nnet::resize_{algorithm}<{input_t}, {config}>({input
 transpose_function_template = 'nnet::transpose_{dim}<{input_t}, {config}>({input}, {output});'
 garnet_function_template = 'nnet::garnet{impl}<{input_t}, {integer_input_t}, {output_t}, {config}>({input}, {nvtx}, {output});'
 garnet_stack_function_template = 'nnet::garnet_stack<{input_t}, {integer_input_t}, {output_t}, {config}>({input}, {nvtx}, {output});'
+edgeblock_function_template = 'nnet::edgeblock<{input_t}, {index_t}, {output_t}, {config}>({node_attr}, {edge_attr}, {edge_index}, {out}, {w0}, {b0}, {w1}, {b1}, {w2}, {b2}, {w3}, {b3});'
+nodeblock_function_template = 'nnet::nodeblock<{input_t}, {output_t}, {config}>({node_attr}, {edge_attr_aggr}, {out}, {w0}, {b0}, {w1}, {b1}, {w2}, {b2}, {w3}, {b3});'
+aggregate_function_template = 'nnet::aggregate<{input_t}, {index_t}, {output_t}, {config}>({edge_attr}, {edge_index}, {out});'
 
 dense_include_list = ['nnet_utils/nnet_dense.h', 'nnet_utils/nnet_dense_compressed.h', 'nnet_utils/nnet_dense_stream.h']
 batchnorm_include_list = ['nnet_utils/nnet_batchnorm.h', 'nnet_utils/nnet_batchnorm_stream.h']
@@ -380,6 +428,21 @@ merge_include_list = ['nnet_utils/nnet_merge.h', 'nnet_utils/nnet_merge_stream.h
 resize_include_list = ['nnet_utils/nnet_image.h', 'nnet_utils/nnet_image_stream.h']
 transpose_include_list = ['nnet_utils/nnet_array.h']
 garnet_include_list = ['nnet_utils/nnet_garnet.h']
+edgeblock_include_list = ['nnet_utils/nnet_common.h',
+                          'nnet_utils/nnet_dense.h',
+                          'nnet_utils/nnet_dense_resource.h',
+                          'nnet_utils/nnet_activation.h',
+                          'nnet_utils/nnet_graph.h',
+                          'nnet_utils/nnet_merge.h',
+                          'nnet_utils/nnet_array.h']
+nodeblock_include_list = ['nnet_utils/nnet_common.h',
+                          'nnet_utils/nnet_dense.h',
+                          'nnet_utils/nnet_dense_resource.h',
+                          'nnet_utils/nnet_activation.h',
+                          'nnet_utils/nnet_graph.h',
+                          'nnet_utils/nnet_merge.h',
+                          'nnet_utils/nnet_array.h']
+aggregate_include_list = ['nnet_utils/nnet_graph.h']
 
 class VivadoBackend(Backend):
     def __init__(self, name='Vivado'):
@@ -411,6 +474,9 @@ class VivadoBackend(Backend):
         self.register_templates('Transpose'              , transpose_function_template,   transpose_config_template, transpose_include_list)
         self.register_templates('GarNet'                 , garnet_function_template,      garnet_config_template, garnet_include_list)
         self.register_templates('GarNetStack'            , garnet_stack_function_template,garnet_stack_config_template, garnet_include_list)        
+        self.register_templates('EdgeBlock'              , edgeblock_function_template, edgeblock_config_template, edgeblock_include_list)
+        self.register_templates('NodeBlock'              , nodeblock_function_template, nodeblock_config_template, nodeblock_include_list)
+        self.register_templates('Aggregate'              , aggregate_function_template, aggregate_config_template, aggregate_include_list)
     
     def create_initial_config(self, part='xcku115-flvb2104-2-i', board=None, clock_period=5, io_type='io_parallel'):
         config = {}

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -342,6 +342,18 @@ def config_from_pytorch_model(model, granularity='model', default_precision='ap_
     
     return config
 
+def config_from_pyg_model(model, granularity='model', default_precision='ap_fixed<16,6>', default_index_precision='ap_uint<16>', default_reuse_factor=1):
+    config = {}
+
+    model_config = {}
+    model_config['Precision'] = default_precision
+    model_config['IndexPrecision'] = default_index_precision
+    model_config['ReuseFactor'] = default_reuse_factor
+    model_config['Strategy'] = 'Latency'
+    
+    config['Model'] = model_config
+
+    return config
 
 def config_from_onnx_model(model, granularity='model', default_precision='ap_fixed<16,6>', default_reuse_factor=1):
     """Generate configuration dictionary from an ONNX model.

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -662,11 +662,8 @@ class VivadoWriter(Writer):
             try:
                 yaml.dump(model.config.config, file)
             except:
-                import torch
-                model_path = model.config.get_output_dir() + "/torch_model_state_dict.pt"
-                torch.save(model.config.config["PytorchModel"].state_dict(), model_path)
-                model.config.config["PytorchModel"] = model_path
-                yaml.dump(model.config.config, file)
+                import warnings
+                warnings.warn("\nWARNING: hls4ml_config.yml file not YAML.dump-able\n")
 
     def write_tar(self, model):
         ###################

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -661,9 +661,14 @@ class VivadoWriter(Writer):
         with open(model.config.get_output_dir() + '/' + config_filename, 'w') as file:
             try:
                 yaml.dump(model.config.config, file)
-            except:
-                import warnings
-                warnings.warn("\nWARNING: hls4ml_config.yml file not YAML.dump-able\n")
+            except ValueError:
+                try:
+                    temp_config = model.config.config
+                    del temp_config["PytorchModel"]
+                    yaml.dump(temp_config, file)
+                except KeyError:
+                    import warnings
+                    warnings.warn("\nWARNING: hls4ml_config.yml file not YAML.dump-able\n")
 
     def write_tar(self, model):
         ###################

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -662,13 +662,12 @@ class VivadoWriter(Writer):
             try:
                 yaml.dump(model.config.config, file)
             except ValueError:
-                try:
-                    temp_config = model.config.config
-                    del temp_config["PytorchModel"]
-                    yaml.dump(temp_config, file)
-                except KeyError:
-                    import warnings
-                    warnings.warn("\nWARNING: hls4ml_config.yml file not YAML.dump-able\n")
+                temp_config = model.config.config
+                del temp_config["PytorchModel"]
+                yaml.dump(temp_config, file)
+            finally:
+                import warnings
+                warnings.warn("\nWARNING: hls4ml_config.yml file not YAML.dump-able\n")
 
     def write_tar(self, model):
         ###################

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -661,7 +661,7 @@ class VivadoWriter(Writer):
         with open(model.config.get_output_dir() + '/' + config_filename, 'w') as file:
             try:
                 yaml.dump(model.config.config, file)
-            except ValueError:
+            except:
                 import torch
                 model_path = model.config.get_output_dir() + "/torch_model_state_dict.pt"
                 torch.save(model.config.config["PytorchModel"].state_dict(), model_path)

--- a/test/pytest/ci-template.yml
+++ b/test/pytest/ci-template.yml
@@ -1,6 +1,6 @@
 .pytest:
   stage: test
-  image: gitlab-registry.cern.ch/fastmachinelearning/hls4ml-testing:0.2.base
+  image: gitlab-registry.cern.ch/fastmachinelearning/hls4ml-testing:0.3.base
   tags: 
     - docker
   before_script:

--- a/test/pytest/test_interaction_network.py
+++ b/test/pytest/test_interaction_network.py
@@ -1,0 +1,67 @@
+import numpy as np
+from contrib.interaction_network import InteractionNetwork
+import hls4ml
+from hls4ml.utils.config import config_from_pyg_model
+from hls4ml.converters import convert_from_pyg_model
+from collections import OrderedDict
+import pytest
+import torch
+
+flow = 'source_to_target'
+aggr = 'add'
+hidden_size = 8
+reuse_factor = 8
+n_node = 28
+n_edge = 56
+node_dim = 3
+edge_dim = 4
+
+@pytest.fixture(scope='module')
+def interaction_network_models():
+
+    model = InteractionNetwork(aggr=aggr, flow=flow, hidden_size=hidden_size)
+
+    # forward_dict: defines the order in which graph-blocks are called in the model's 'forward()' method
+    forward_dict = OrderedDict()
+    forward_dict["R1"] = "EdgeBlock"
+    forward_dict["O"] = "NodeBlock"
+    forward_dict["R2"] = "EdgeBlock"
+
+    graph_dims = {
+        "n_node": n_node,
+        "n_edge": n_edge,
+        "node_dim": node_dim,
+        "edge_dim": edge_dim
+    }
+
+    output_dir = 'hls4mlprj_interaction_network'
+    config = config_from_pyg_model(model,
+                                   default_precision='ap_fixed<16,6>',
+                                   default_index_precision='ap_uint<8>',
+                                   default_reuse_factor=reuse_factor)
+    hls_model = convert_from_pyg_model(model,
+                                       forward_dictionary=forward_dict,
+                                       activate_final='sigmoid',
+                                       output_dir=output_dir,
+                                       hls_config=config,
+                                       **graph_dims)
+    hls_model.compile()
+    return model, hls_model
+
+
+def test_accuracy(interaction_network_models):
+    model, hls_model = interaction_network_models
+    node_attr = (torch.rand(n_node, node_dim)-0.5)*2**6
+    edge_attr = (torch.rand(n_edge, edge_dim)-0.5)*2**6
+    edge_index = torch.randint(n_node, size=(2, n_edge))
+
+    y = model(node_attr,
+              edge_index,
+              edge_attr).detach().cpu().numpy()
+
+    node_attr, edge_attr, edge_index = node_attr.detach().cpu().numpy(), edge_attr.detach().cpu().numpy(), edge_index.transpose(0, 1).detach().cpu().numpy().astype(np.float32)
+    node_attr, edge_attr, edge_index = np.ascontiguousarray(node_attr), np.ascontiguousarray(edge_attr), np.ascontiguousarray(edge_index)
+    x_hls = [node_attr, edge_attr, edge_index]
+    y_hls = hls_model.predict(x_hls).reshape(y.shape)
+
+    np.testing.assert_allclose(y_hls, y, rtol=0, atol=0.02)


### PR DESCRIPTION
## Purpose
Add `pyg_to_hls` converter to parse an [Interaction Network](https://github.com/abdelabd/manual_GNN_conversion/blob/main/utils/models/interaction_network_pyg.py#L40) [PyTorch Geometric](https://pytorch-geometric.readthedocs.io/en/latest/) model which is composed of alternating EdgeBlocks (which applies a neural network to "edge features" to compute messages), Aggregate layers (which aggregates edge features for nodes that are connected to it), and NodeBlocks (which applies a neural network aggregated edge features. 

PyTorch Geometric models [expect input data](https://pytorch-geometric.readthedocs.io/en/latest/notes/introduction.html#data-handling-of-graphs) consisting of node attributes `node_attr` of size `[n_nodes, n_node_features]`, edge attributes `edge_attr` of size `[n_edges, n_edge_features]`, and an edge index `edge_index` of size `[2, n_edges]`, which specifies the data's connectivity. 

The currently supported network for charged particle tracking output edge weights of size `[n_edges, 1]`, which classify the edges as valid (part of a good track segment) or not.

## Slides 
https://docs.google.com/presentation/d/1C3EuVq4FaaayNSBeaRBHyHnWcujLbXASxAR2cqQyLVo/edit?usp=sharing

## Test script
Notebook to test the conversion: https://github.com/abdelabd/manual_GNN_conversion/blob/main/pyg_to_hls_walkthrough.ipynb
Script to test the conversion: https://github.com/abdelabd/manual_GNN_conversion/blob/main/convert_model.py
```
python convert_model.py conversion_config.yaml --n-graphs=100 --aggregation add --flow source_to_target --precision 'ap_fixed<16,8> --max-nodes=28 --max-edges=37 --n-neurons=8
```

or more fully featured code: https://github.com/abdelabd/manual_GNN_conversion
```
python test_model.py test_config.yaml --n-graphs 100 --aggregation add --flow source_to_target --precision 'ap_fixed<16,8>' --max-nodes 28 --max-edges 37 --n-neurons 8 --synth
```

## Changes


### Frontend
- added onto [`hls4ml.converters.__init__.py`](https://github.com/abdelabd/hls4ml/blob/pyg_to_hls_rebase/hls4ml/converters/__init__.py):
  - added `from hls4ml.converters.pyg_to_hls import pyg_to_hls`
  - added `convert_from_pyg_model()` function
  - registered the pyg `block_handlers`
- added `hls4ml/converters/pyg/__init__.py`
  - nothing here
- added [`hls4ml/converters/pyg/interaction_network_blocks.py`](https://github.com/abdelabd/hls4ml/blob/pyg_to_hls_rebase/hls4ml/converters/pyg/interaction_network_blocks.py)
  - has the pyg `block_handlers` (analogous to `layer_handlers`) for `NodeBlock, EdgeBlock, Aggregate`
- added [`hls4ml.converters.pyg_to_hls.py`](https://github.com/abdelabd/hls4ml/blob/pyg_to_hls_rebase/hls4ml/converters/pyg_to_hls.py)
  - has the class `PygModelReader(PyTorchModelReader)`
  - has the function `pyg_to_hls()`
  - has the pyg 'block_handlers'
- added onto [`hls4ml.utils.config.py`](https://github.com/abdelabd/hls4ml/blob/pyg_to_hls_rebase/hls4ml/utils/config.py)
  - added `config_from_pyg_model()` function 
- changed `hls4ml.writer.vivado_writer.py`
  - changed `VivadoWriter.write_defines()` method 
    - if certain macros are shared between different layers of an `HLSModel`, then these macros are not written multiple times in the `defines.h` file. 
  - changed `VivadoWriter.write_yml()` method 
    - If `yaml.dump()` has trouble writing a torch model with submodules composed of torch models themselves, then it writes the location of the model's state dictionary instead. 
- added onto [`hls4ml.model.hls_layers`](https://github.com/abdelabd/hls4ml/blob/pyg_to_hls_rebase/hls4ml/model/hls_layers.py)
  - added class `GraphBlock(Layer)`: parent class for `EdgeBlock` and `NodeBlock`. Allows hls4ml to handle an EdgeBlock or NodeBlock as if it were a single layer (like Dense, Convolution, etc.), rather than a submodule composed of several layers.
  - added class `EdgeBlock(GraphBlock)`
  - added class `NodeBlock(GraphBlock)`
  - added class `Aggregate(Layer)`
- [`hls4ml.model.hls_model`](https://github.com/abdelabd/hls4ml/blob/pyg_to_hls_rebase/hls4ml/model/hls_model.py)
  - changed `HLSModel.get_weights_data()`
    - handling for getting weights data if the layer in question doesn't belong directly to the torch model in question, but rather to a submodule of the torch model such as an EdgeBlock or NodeBlock

### Backend
- added onto [`nnet_utils/nnet_array.h`](https://github.com/abdelabd/hls4ml/blob/pyg_to_hls_rebase/hls4ml/templates/vivado/nnet_utils/nnet_array.h)
  - added `struct matrix_config` which specifies parameters for conversion functions
  - added `vec_to_mat()` function to convert from 1D unrolled arrays and 2D matrices
  - added `mat_to_vec()` function to convert from 2D matrices to 1D unrolled arrays
- changed [`nnet_utils/nnet_dense.h`](https://github.com/abdelabd/hls4ml/blob/pyg_to_hls_rebase/hls4ml/templates/vivado/nnet_utils/nnet_dense.h) and changed [`nnet_utils/nnet_dense_resource.h`](https://github.com/abdelabd/hls4ml/blob/pyg_to_hls_rebase/hls4ml/templates/vivado/nnet_utils/nnet_dense_resource.h)
  - added parameter `"static const bool remove_pipeline_pragma = false;"` to the `dense_config`
  - under the `ReuseLoop` for the `dense_resource_rf_leq_nin()`, `dense_resource_rf_gt_nin_rem0()`, and `dense_resource_rf_gt_nin()` functions: `"#pragma HLS PIPELINE II=1 rewind"` --> `if remove_pipeline_pragma=false then #pragma HLS PIPELINE II=1 rewind`.
    - This change allows the pipelining to happen at the GraphBlock layer level instead of the individual dense layer level
- added [`nnet_utils/nnet_graph.h`](https://github.com/abdelabd/hls4ml/blob/pyg_to_hls_rebase/hls4ml/templates/vivado/nnet_utils/nnet_graph.h)
  - has the backend code for the EdgeBlock, NodeBlock, and Aggregate layers. 