### PR TITLE
Remove STABLE pragma from activation tensors

### DIFF
--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -132,11 +132,6 @@ class VivadoWriter(Writer):
         elif mode == 'stream':
             return '#pragma HLS STREAM variable={name} depth={depth}'.format(name=variable.name, depth=depth)
 
-    @staticmethod
-    def _make_stable_pragma(variable):
-        template = '#pragma HLS STABLE variable={name}'
-        return template.format(name=variable.name)
-
     def write_project_cpp(self, model):
         ###################
         ## myproject.cpp
@@ -225,8 +220,6 @@ class VivadoWriter(Writer):
                                 newline += '    ' + def_cpp + ';\n'
                                 if var.pragma:
                                     newline += '    ' + self._make_array_pragma(var) + '\n'
-                                if model.config.model_strategy.lower() == 'resource':
-                                    newline += '    ' + self._make_stable_pragma(var) + '\n'
                     func = layer.function_cpp()
                     if func:
                         if len(func) == 1:


### PR DESCRIPTION
Stable pragma was introduced to fix some II issues with `Resource` strategy for simple DNN models but has caused multiple issues with the stream-based implementation, as observed in #351. In addition to that bug, it also causes cosim to either fail with a deadlock or to produce incorrect results (and thus fail validation step). This PR removes the pragma from the activation tensors. 

[Test case](https://gist.github.com/vloncar/471ef29ba0b2bfcd44ec83d1c05eb07f)