### PR TITLE
Support applying Softmax over multidimensional tensors

### DIFF
--- a/hls4ml/converters/keras/core.py
+++ b/hls4ml/converters/keras/core.py
@@ -86,18 +86,18 @@ def parse_activation_layer(keras_layer, input_names, input_shapes, data_reader, 
     if layer['class_name'] != 'Activation':
         layer['activation'] = layer['class_name']
     if layer['class_name'] == 'LeakyReLU':
-        layer['activ_param'] = keras_layer["config"].get('alpha', 0.3)
+        layer['activ_param'] = keras_layer['config'].get('alpha', 0.3)
     elif layer['class_name'] == 'ThresholdedReLU':
-        layer['activ_param'] = keras_layer["config"].get('theta', 1.)
+        layer['activ_param'] = keras_layer['config'].get('theta', 1.)
     elif layer['class_name'] == 'ELU':
-        layer['activ_param'] = keras_layer["config"].get('alpha', 1.)
+        layer['activ_param'] = keras_layer['config'].get('alpha', 1.)
     elif layer['class_name'] == 'ReLU':
         layer['class_name'] = 'Activation'
 
     if layer['class_name'] == 'Activation' and layer['activation'] == 'softmax':
         layer['class_name'] = 'Softmax'
-    if layer['class_name'] == 'ReLU':
-        layer['class_name'] = 'Activation'
+    if layer['class_name'] == 'Softmax':
+        layer['axis'] = keras_layer['config'].get('axis', -1)
     
     return layer, [shape for shape in input_shapes[0]]
 

--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -319,6 +319,7 @@ def keras_to_hls(config):
                 act_layer['class_name'] = layer['activation']
             elif layer['activation'] == 'softmax':
                 act_layer['class_name'] = 'Softmax'
+                act_layer['axis'] = -1
             else:
                 act_layer['class_name'] = 'Activation'
             inputs_map[layer['name']] = act_layer['name']

--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -1384,6 +1384,9 @@ class Softmax(Activation):
                 self.set_attr('implementation', 'latency')
             else:
                 self.set_attr('implementation', self.model.config.get_strategy(self).lower())
+            
+            if self.model.config.get_config_value('IOType') == 'io_parallel':
+                assert len(self.get_input_variable().shape) == 1, 'Softmax with io_parallel strategy cannot be used on multidimensional tensors.'
 
 class TernaryTanh(Activation):
     def initialize(self):

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -243,11 +243,11 @@ void softmax_latency(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
 
     // Calculate all the e^x's
     typename CONFIG_T::exp_table_t exp_res[CONFIG_T::n_in];
-	#pragma HLS array_partition variable=exp_res complete
+    #pragma HLS array_partition variable=exp_res complete
     typename CONFIG_T::exp_table_t exp_sum(0);
     for(unsigned i = 0; i < CONFIG_T::n_in; i++){
         #pragma HLS unroll
-    	unsigned x = softmax_idx_from_real_val<data_T, CONFIG_T>(data[i]);
+        unsigned x = softmax_idx_from_real_val<data_T, CONFIG_T>(data[i]);
         exp_res[i] = exp_table[x];
     }
 
@@ -298,11 +298,11 @@ void softmax_stable(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
 
     // Calculate all the e^x's
     typename CONFIG_T::exp_table_t exp_res[CONFIG_T::n_in];
-	#pragma HLS array_partition variable=exp_res complete
+    #pragma HLS array_partition variable=exp_res complete
     typename CONFIG_T::exp_table_t exp_sum(0);
     for(unsigned i = 0; i < CONFIG_T::n_in; i++){
         #pragma HLS unroll
-    	unsigned x = softmax_idx_from_real_val<data_T, CONFIG_T>(d_xi_xmax[i]);
+        unsigned x = softmax_idx_from_real_val<data_T, CONFIG_T>(d_xi_xmax[i]);
         exp_res[i] = exp_table[x];
     }
 
@@ -337,11 +337,11 @@ void init_invert_table_legacy(typename CONFIG_T::table_t table_out[N_TABLE])
     // Inversion function:
     //   result = 1/x
     for (int ii = 0; ii < N_TABLE; ii++) {
-      // First, convert from table index to X-value (signed 8-bit, range 0 to +64)
-	float in_val = 64.0*ii/float(N_TABLE);
+        // First, convert from table index to X-value (signed 8-bit, range 0 to +64)
+        float in_val = 64.0*ii/float(N_TABLE);
         // Next, compute lookup table function
-	if (in_val > 0.0) table_out[ii] = 1.0/in_val;
-	else table_out[ii] = 0.0;
+        if (in_val > 0.0) table_out[ii] = 1.0/in_val;
+        else table_out[ii] = 0.0;
     }
 }
 
@@ -376,33 +376,34 @@ void  softmax_legacy(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
     int data_round;
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-      data_cache[ii] = data[ii];
-      exp_res[ii] = 0;
+        data_cache[ii] = data[ii];
+        exp_res[ii] = 0;
     }
+
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-      if (CONFIG_T::io_type == io_serial){
-          #pragma HLS PIPELINE
-      }
-      for (int jj=0; jj<CONFIG_T::n_in; jj++) {
-	if (ii==jj) exp_diff_res = 1;
-	else {
-	  data_round = (data_cache[jj]-data_cache[ii])*CONFIG_T::table_size/16;
-	  index = data_round + 8*CONFIG_T::table_size/16;
-	  if (index < 0)   index = 0;
-	  if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;
-	  exp_diff_res = exp_table[index];
-	}
-	exp_res[ii] += exp_diff_res;
-      }
+        if (CONFIG_T::io_type == io_serial) {
+            #pragma HLS PIPELINE
+        }
+        for (int jj=0; jj<CONFIG_T::n_in; jj++) {
+            if (ii==jj) exp_diff_res = 1;
+            else {
+                data_round = (data_cache[jj]-data_cache[ii])*CONFIG_T::table_size/16;
+                index = data_round + 8*CONFIG_T::table_size/16;
+                if (index < 0)   index = 0;
+                if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;
+                exp_diff_res = exp_table[index];
+            }
+            exp_res[ii] += exp_diff_res;
+        }
     }
 
     //Second loop to invert
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-      int exp_res_index = exp_res[ii]*CONFIG_T::table_size/64;
-      if (exp_res_index < 0)   exp_res_index = 0;
-      if (exp_res_index > CONFIG_T::table_size-1) exp_res_index = CONFIG_T::table_size-1;
-      //typename CONFIG_T::table_t exp_res_invert = invert_table[exp_res_index];
-      res[ii] = (res_T) invert_table[exp_res_index];
+        int exp_res_index = exp_res[ii]*CONFIG_T::table_size/64;
+        if (exp_res_index < 0)   exp_res_index = 0;
+        if (exp_res_index > CONFIG_T::table_size-1) exp_res_index = CONFIG_T::table_size-1;
+        //typename CONFIG_T::table_t exp_res_invert = invert_table[exp_res_index];
+        res[ii] = (res_T) invert_table[exp_res_index];
     }
 
 }
@@ -420,7 +421,7 @@ void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
     case softmax_implementation::legacy:
         softmax_legacy<data_T, res_T, CONFIG_T>(data, res);
         break;
-    }    
+    }
 }
 
 // *************************************************
@@ -720,7 +721,7 @@ void  elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_
 template<class data_T, class res_T, typename CONFIG_T>
 void  elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-	elu<data_T, res_T, CONFIG_T>(data, 1.0, res);
+    elu<data_T, res_T, CONFIG_T>(data, 1.0, res);
 }
 
 // *************************************************
@@ -810,26 +811,22 @@ void  prelu(data_T data[CONFIG_T::n_in], data_T alpha[CONFIG_T::n_in], res_T res
 template<class data_T, class res_T, typename CONFIG_T>
 void  binary_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
+    if (CONFIG_T::io_type == io_parallel){
+        #pragma HLS PIPELINE
+    }
 
- if (CONFIG_T::io_type == io_parallel){
-     #pragma HLS PIPELINE
- }
-  
- data_T datareg;   
- res_T cache; 
- for (int ii=0; ii<CONFIG_T::n_in; ii++) {
+    data_T datareg;
+    res_T cache;
+    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS PIPELINE
+        }
+        datareg = data[ii];
+        if( datareg > 0 ) cache = 1;
+        else cache = -1;
 
-  if (CONFIG_T::io_type == io_serial){
-      #pragma HLS PIPELINE
-  }
-  datareg = data[ii];	 
-  if( datareg > 0 ) cache = 1;
-  else cache = -1;
-  
-  res[ii] = (res_T) cache;
- 
- }
- 
+        res[ii] = (res_T) cache;
+    }
 }
 
 // *************************************************
@@ -839,26 +836,23 @@ template<class data_T, class res_T, typename CONFIG_T>
 void  ternary_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
 
- if (CONFIG_T::io_type == io_parallel){
-     #pragma HLS PIPELINE
- }
-  
- data_T datareg;   
- res_T cache; 
- for (int ii=0; ii<CONFIG_T::n_in; ii++) {
+    if (CONFIG_T::io_type == io_parallel){
+        #pragma HLS PIPELINE
+    }
 
-  if (CONFIG_T::io_type == io_serial){
-      #pragma HLS PIPELINE
-  }
-  datareg = 2*data[ii];	 
-  if( datareg > 1 ) cache = 1;
-  else if( datareg > -1 && datareg <= 1) cache=0;
-  else cache = -1;
-  
-  res[ii] = (res_T) cache;
- 
- }
- 
+    data_T datareg;
+    res_T cache;
+    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS PIPELINE
+        }
+        datareg = 2*data[ii];
+        if( datareg > 1 ) cache = 1;
+        else if( datareg > -1 && datareg <= 1) cache=0;
+        else cache = -1;
+
+        res[ii] = (res_T) cache;
+    }
 }
 
 }

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -121,6 +121,7 @@ softmax_config_template = """struct {type}_config{index} : nnet::activ_config {{
     static const unsigned table_size = {table_size};
     static const unsigned io_type = nnet::{iotype};
     static const unsigned reuse_factor = {reuse};
+    static const unsigned axis = {axis};
     static const nnet::softmax_implementation implementation = nnet::softmax_implementation::{implementation};
     typedef {exp_table_t} exp_table_t;
     typedef {inv_table_t} inv_table_t;

--- a/test/pytest/test_softmax.py
+++ b/test/pytest/test_softmax.py
@@ -4,42 +4,53 @@ import numpy as np
 import pytest
 from sklearn.metrics import accuracy_score
 
-def flat_distribution(N, M):
-  return np.random.rand(N, M)
 
-def high_accuracy_distribution(N, M):
-  '''Start with a flat distribution, then pick a random member of each row to amplify'''
-  x = np.random.rand(N, M)
-  imax = np.random.randint(0,M,size=N)
-  x[:,imax] *= 10
-  return x
+def flat_distribution(shape):
+    return np.random.rand(*shape)
+
+
+def high_accuracy_distribution(shape):
+    '''Start with a flat distribution, then pick a random member of each row to amplify'''
+    x = np.random.rand(*shape)
+    imax = np.random.randint(0, shape[1], size=shape[0])
+    x[:, imax] *= 10
+    return x
+
 
 @pytest.fixture()
-def generate_data(function):
-  return function(1000,8)
+def generate_data(function, input_shape):
+    return function((1000, *input_shape))
+
 
 # TODO: include latency strategy with flat_distribution when it can be made to pass
-#@pytest.mark.parametrize('strategy,function', [('latency', flat_distribution),
+# @pytest.mark.parametrize('strategy,function', [('latency', flat_distribution),
 #                                               ('stable', flat_distribution),
 #                                               ('stable', high_accuracy_distribution)])
-@pytest.mark.parametrize('strategy,function', [('stable', flat_distribution),
-                                               ('stable', high_accuracy_distribution)])
-def test_softmax(strategy, generate_data):
-  X = generate_data
-  model = tf.keras.models.Sequential()
-  model.add(tf.keras.layers.Activation(input_shape=(8,), activation='softmax', name='softmax'))
-  model.compile()
-  cfg = hls4ml.utils.config_from_keras_model(model, granularity='name')
-  cfg['LayerName']['softmax']['Strategy'] = strategy
-  cfg['LayerName']['softmax']['inv_table_t'] = 'ap_fixed<18,8,AP_RND,AP_SAT>'
-  cfg['LayerName']['softmax']['exp_table_t'] = 'ap_fixed<18,8,AP_RND,AP_SAT>'
-  hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=cfg, output_dir='hls4mlprj_softmax_{}'.format(strategy))
-  hls_model.compile()
-  y_keras = model.predict(X)
-  y_hls4ml = hls_model.predict(X)
 
-  acc_hls4ml = accuracy_score(np.argmax(y_keras, axis=1), np.argmax(y_hls4ml, axis=1))
+@pytest.mark.parametrize('strategy,function,input_shape,io_type', [('stable', flat_distribution, (8,), 'io_parallel'),
+                                                                   ('stable', high_accuracy_distribution, (8,), 'io_parallel'),
+                                                                   ('stable', flat_distribution, (8, 8, 3), 'io_stream'),
+                                                                   ('stable', high_accuracy_distribution, (8, 8, 3), 'io_stream')])
 
-  print('Accuracy hls4ml relative to keras: {}'.format(acc_hls4ml))
+# @pytest.mark.parametrize('strategy,function,input_shape', [('stable', flat_distribution, (8, 8, 3)),
+#                                                            ('stable', high_accuracy_distribution, (8, 8, 3))])
+def test_softmax(strategy, generate_data, input_shape, io_type):
+    X = generate_data
+    model = tf.keras.models.Sequential()
+    model.add(tf.keras.layers.Activation(input_shape=input_shape, activation='softmax', name='softmax'))
+    model.compile()
+    cfg = hls4ml.utils.config_from_keras_model(model, granularity='name')
+    cfg['LayerName']['softmax']['Strategy'] = strategy
+    cfg['LayerName']['softmax']['inv_table_t'] = 'ap_fixed<18,8,AP_RND,AP_SAT>'
+    cfg['LayerName']['softmax']['exp_table_t'] = 'ap_fixed<18,8,AP_RND,AP_SAT>'
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=cfg, io_type=io_type,
+                                                           output_dir='hls4mlprj_softmax_{}'.format(strategy))
+    hls_model.compile()
+    y_keras = model.predict(X)
+    y_hls4ml = hls_model.predict(X).reshape(y_keras.shape)
 
-  assert acc_hls4ml >= 0.98
+    acc_hls4ml = accuracy_score(np.argmax(y_keras, axis=1).ravel(), np.argmax(y_hls4ml, axis=1).ravel())
+
+    print('Accuracy hls4ml relative to keras: {}'.format(acc_hls4ml))
+
+    assert acc_hls4ml >= 0.98

--- a/test/pytest/test_softmax.py
+++ b/test/pytest/test_softmax.py
@@ -23,17 +23,15 @@ def generate_data(function, input_shape):
 
 
 # TODO: include latency strategy with flat_distribution when it can be made to pass
-# @pytest.mark.parametrize('strategy,function', [('latency', flat_distribution),
-#                                               ('stable', flat_distribution),
-#                                               ('stable', high_accuracy_distribution)])
-
-@pytest.mark.parametrize('strategy,function,input_shape,io_type', [('stable', flat_distribution, (8,), 'io_parallel'),
+@pytest.mark.parametrize('strategy,function,input_shape,io_type', [#('latency', flat_distribution, (8,), 'io_parallel'),
+                                                                   #('latency', flat_distribution, (8, 8, 3), 'io_stream'),
+                                                                   ('stable', flat_distribution, (8,), 'io_parallel'),
                                                                    ('stable', high_accuracy_distribution, (8,), 'io_parallel'),
+                                                                   ('stable', flat_distribution, (8,), 'io_stream'),
+                                                                   ('stable', high_accuracy_distribution, (8,), 'io_stream'),
+                                                                   # Multi-dimensional tests, only for io_stream for now
                                                                    ('stable', flat_distribution, (8, 8, 3), 'io_stream'),
                                                                    ('stable', high_accuracy_distribution, (8, 8, 3), 'io_stream')])
-
-# @pytest.mark.parametrize('strategy,function,input_shape', [('stable', flat_distribution, (8, 8, 3)),
-#                                                            ('stable', high_accuracy_distribution, (8, 8, 3))])
 def test_softmax(strategy, generate_data, input_shape, io_type):
     X = generate_data
     model = tf.keras.models.Sequential()
@@ -49,7 +47,7 @@ def test_softmax(strategy, generate_data, input_shape, io_type):
     y_keras = model.predict(X)
     y_hls4ml = hls_model.predict(X).reshape(y_keras.shape)
 
-    acc_hls4ml = accuracy_score(np.argmax(y_keras, axis=1).ravel(), np.argmax(y_hls4ml, axis=1).ravel())
+    acc_hls4ml = accuracy_score(np.argmax(y_keras, axis=-1).ravel(), np.argmax(y_hls4ml, axis=-1).ravel())
 
     print('Accuracy hls4ml relative to keras: {}'.format(acc_hls4ml))
 


### PR DESCRIPTION
Current implementations of `softmax` are incorrect when applied to multidimensional tensors (used in e.g., ENet model). The implementations in this PR handle this properly for `axis=-1` (the default).