### PR TITLE
Rewire model output

### DIFF
--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -435,9 +435,7 @@ class HLSModel(object):
                             next_node.inputs[i] = prev_node.outputs[0]
                             break
                 else:
-                    if node.outputs[0] in self.outputs:
-                        self.outputs = [prev_node.outputs[0] if x == node.outputs[0] else x for x in self.outputs]
-                    else:
+                    if not node.outputs[0] in self.outputs:
                         raise Exception('Cannot rewire a node without child')
             else:
                 raise Exception('Cannot rewire a node without a parent')

--- a/test/pytest/test_graph.py
+++ b/test/pytest/test_graph.py
@@ -1,0 +1,81 @@
+import hls4ml
+import numpy as np
+import pytest
+
+class Reader:
+    def get_weights_data(self, name, var):
+        w = 2 if var =='kernel' else 1
+        return np.array([w])
+reader = Reader()
+
+def base_model(output_dir='hls4mlprj_graph_base_model', iotype = 'io_parallel'):
+  layers = [{'class_name' : 'Input', 'name' : 'layer0_input', 'input_shape' : [1]},
+            {'class_name' : 'Dense', 'name' : 'layer0', 'n_in' : 1, 'n_out' : 1},
+            {'class_name' : 'Dense', 'name' : 'layer1', 'n_in' : 1, 'n_out' : 1}]
+  config = {'HLSConfig':{'Model':{'Precision':'ap_fixed<32,16>','ReuseFactor' : 1}}}
+  config['OutputDir'] = output_dir
+  config['ProjectName'] = 'myprj'
+  config['IOType'] = iotype
+  model = hls4ml.model.HLSModel(config, reader, layers)
+  return model
+
+def do_nop(model, node, layers):
+  return model, layers
+
+def do_insert(model, node, layers):
+  after, before = node[0], node[1]
+  new_node = model.make_node('Dense', 'layer2', {'n_in' : 1, 'n_out' : 1}, [after])
+  if not before is None:
+    before = [x for x in model.graph.values() if x.name == before][0]
+  model.insert_node(new_node, before=before)
+  iInsert = np.argwhere(layers == after)[0][0] + 1
+  layers = np.insert(layers, iInsert, 'layer2')
+  return model, layers
+
+def do_remove(model, node, layers):
+  node_obj = [n for n in list(model.get_layers()) if n.name == node][0]
+  model.remove_node(node_obj)
+  iRemove = np.argwhere(layers == node)[0][0]
+  layers = np.delete(layers, iRemove)
+  return model, layers
+
+def do_replace(model, node, layers):
+  old_node = model.graph.get(node)
+  new_node = model.make_node('Dense', 'layer2', {'n_in' : 1, 'n_out' : 1}, old_node.inputs)
+  model.replace_node(old_node, new_node)
+  iInsert = np.argwhere(layers == node)[0][0]
+  layers = np.delete(layers, iInsert)
+  layers = np.insert(layers, iInsert, 'layer2')
+  return model, layers
+
+graph_ops = {'insert'  : do_insert,
+             'remove'  : do_remove,
+             'replace' : do_replace,
+             'nop'     : do_nop}
+
+@pytest.mark.parametrize('parameters', [(base_model, 'nop', None, [3], False),                           # 0
+                                        (base_model, 'insert', ('layer0_input', None), [7], False),      # 1
+                                        (base_model, 'insert', ('layer0', None), [7], False),            # 2
+                                        (base_model, 'insert', ('layer1', None), [7], False),            # 3
+                                        (base_model, 'remove', 'layer0', [1], False),                    # 4   
+                                        (base_model, 'remove', 'layer1', [1], False),                    # 5
+                                        (base_model, 'replace', 'layer0', [3], False),                   # 6
+                                        (base_model, 'replace', 'layer1', [3], False)])                  # 7
+@pytest.mark.parametrize('iotype', ['io_parallel', 'io_stream'])
+def test_graph_manipulation(parameters, iotype):
+  model, op, node, expected, skip_layers_check = parameters[0], parameters[1], parameters[2], parameters[3], parameters[4]
+  odir = 'hls4mlprj_graph_{}_{}_{}'.format(model.__name__, op, node)
+  model = model(odir, iotype)
+  original_layers = np.array([layer.name for layer in list(model.get_layers())])
+  model, expected_layers = graph_ops[op](model, node, original_layers)
+  model.compile()
+  hls4ml.utils.plot_model(model, show_shapes=True, show_precision=True, to_file='{}/model.png'.format(odir))
+  X = np.zeros((1,1))
+  y = model.predict(X)
+  # check the output
+  expected = np.array(expected)
+  np.testing.assert_array_equal(y, expected)
+  # check the order
+  actual_layers = np.array([layer.name for layer in list(model.get_layers())])
+  if not skip_layers_check: # skip check for this model since order changes
+    np.testing.assert_array_equal(expected_layers, actual_layers)


### PR DESCRIPTION
The follow up PR after closing #367. 

Node insertions & replacements that touch the model output are not properly handled. I've added a method that's called at the end of each graph manipulation that finds the node outputs that are not consumed by other nodes, and sets the model outputs to those. Those model outputs are therefore properly updated after a manipulation that changes the output node.

I've added a simple test for this behavior that starts with an initial model like this:
![model](https://user-images.githubusercontent.com/14807534/130944938-03b28e6b-df5a-4587-9acf-b9cb1914597b.png)
The tests then variously insert/remove/replace nodes at each possible position and verify the output. Without the changes this PR makes to `hls_model.py`, 2 of the 8 operations fail (3 & 7: the ones that insert & replace at the end). They pass with the changes.

This is also needed for the tests added by #328.
