### PR TITLE
Fixes: quantized_relu & unsigned profiling

### DIFF
--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -159,32 +159,31 @@ def types_histogram(data, fmt='longform'):
 types_plots = {'boxplot' : types_boxplot,
                'histogram' : types_histogram}
 
-def ap_fixed_WIF(dtype):
+def ap_fixed_WIFS(dtype):
     from hls4ml.templates.vivado_template import VivadoBackend
     dtype = VivadoBackend.convert_precision_string(None, dtype) 
-    W, I, F = dtype.width, dtype.integer, dtype.fractional
-    return W, I, F
+    W, I, F, S = dtype.width, dtype.integer, dtype.fractional, dtype.signed
+    return W, I, F, S
 
 def types_hlsmodel(model):
     suffix = ['w', 'b']
     data = {'layer' : [], 'low' : [], 'high' : []}
     # Plot the default precision
     default_precision = model.config.model_precision['default']
-    # assumes ap_fixed
-    W, I, F = ap_fixed_WIF(default_precision)
+    W, I, F, S = ap_fixed_WIFS(default_precision)
     data['layer'].append('model')
     data['low'].append(-F)
-    data['high'].append(I-1)
+    data['high'].append(I-1 if S else I)
 
     for layer in model.get_layers():
         for iw, weight in enumerate(layer.get_weights()):
             wname = '{}/{}'.format(layer.name, suffix[iw])
             T = weight.type
             if T.name != 'model':
-                W, I, F = ap_fixed_WIF(T.precision)
+                W, I, F, S = ap_fixed_WIFS(T.precision)
                 data['layer'].append(wname)
                 data['low'].append(-F)
-                data['high'].append(I-1)
+                data['high'].append(I-1 if S else I)
     data = pandas.DataFrame(data)
     return data
 
@@ -192,16 +191,16 @@ def activation_types_hlsmodel(model):
     data = {'layer' : [], 'low' : [], 'high' : []}
     # Get the default precision
     default_precision = model.config.model_precision['default']
-    W, I, F = ap_fixed_WIF(default_precision)
+    W, I, F, S = ap_fixed_WIFS(default_precision)
     data['layer'].append('model')
     data['low'].append(-F)
-    data['high'].append(I-1)
+    data['high'].append(I-1 if S else I)
     for layer in model.get_layers():
         T = layer.get_output_variable().type.precision
-        W, I, F = ap_fixed_WIF(T)
+        W, I, F, S = ap_fixed_WIFS(T)
         data['layer'].append(layer.name)
         data['low'].append(-F)
-        data['high'].append(I-1)
+        data['high'].append(I-1 if S else I)
     data = pandas.DataFrame(data)
     return data
 

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -37,11 +37,14 @@ def _get_precision_from_quantizer(quantizer):
             quantizer['class_name'] = quantizer_obj.__name__
 
     supported_quantizers = ['quantized_bits', 'quantized_relu', 'quantized_tanh', 'quantized_po2', 'quantized_relu_po2']
+    signed = True
     if quantizer['class_name'] in supported_quantizers:
         bits = int(quantizer['config']['bits'])
         # if integer isn't specified, it should be the same as bits
         integer = int(quantizer['config'].get('integer', bits-1)) + 1
-        
+        if quantizer['class_name'] == 'quantized_relu':
+            signed = False
+            integer -= 1
     elif quantizer['class_name'] in ['binary', 'stochastic_binary', 'binary_tanh']:
         bits = 2
         integer = 2
@@ -53,10 +56,11 @@ def _get_precision_from_quantizer(quantizer):
         raise Exception('ERROR: Unsupported quantizer: {}'.format(quantizer['class_name']))
 
     decimal = bits - integer
+    signed = '' if signed else 'u'
     if decimal > 0:
-        return 'ap_fixed<{},{}>'.format(bits, integer)
+        return 'ap_{}fixed<{},{}>'.format(signed, bits, integer)
     else:
-        return 'ap_int<{}>'.format(bits)
+        return 'ap_{}int<{}>'.format(signed, bits)
 
 def config_from_keras_model(model, granularity='model', default_precision='ap_fixed<16,6>', default_reuse_factor=1):
     """Create an HLS conversion config given the Keras model.

--- a/test/pytest/test_qkeras.py
+++ b/test/pytest/test_qkeras.py
@@ -186,9 +186,13 @@ def randX_1000_1():
                                        (quantized_bits(8,4)),
                                        (quantized_bits(4,2)),
                                        (quantized_bits(4,0)),
-                                       (quantized_bits(10,0)),])
-                                       #(quantized_relu(4)),
-                                       #(quantized_relu(10))])
+                                       (quantized_bits(10,0)),
+                                       (quantized_relu(4)),
+                                       (quantized_relu(4,2)),
+                                       (quantized_relu(8)),
+                                       (quantized_relu(8,4)),
+                                       (quantized_relu(10)),
+                                       (quantized_relu(10,5))])
 def test_quantizer(randX_1000_1, quantizer):
   '''
   Test a single quantizer as an Activation function.


### PR DESCRIPTION
Note: bugfixes targeting release branch

## `quantized_relu`

Since [this change](https://github.com/fastmachinelearning/hls4ml/commit/02624c5fc491cc221326eac631b7219e76e0eef8#diff-8ec43234900e263f95104d90f7969c22a9d314817d20ce4d1f23f1a4354fc91a), we assign the wrong data type to `quantized_relu` activations. It sets the correct type for `quantized_bits`, just not `quantized_relu`. This is what causes the tests flagged in #377 to fail. 

Using the example of the hls4ml-tutorial Part3 QKeras model which uses `quantized_relu(6)` activations, on master branch we assign `ap_fixed<6,1>`. But appropriate choices would be instead `ap_fixed<7,1>` (signed) or `ap_ufixed<6,0>` (unsigned). I've chosen to go for the `ap_ufixed` case for the fix since it uses fewer bits. 

You can see that the types we currently assign to the `relu` layers are wrong in the profiling:

![Screenshot 2021-09-29 at 16 35 10](https://user-images.githubusercontent.com/14807534/135293032-5b4ddcae-b7f3-4957-968c-10673eb07e61.png)

The model accuracy is:

- 0.743656 QKeras on CPU (reference / target)
- 0.743542 hls4ml on master branch
- 0.743855 hls4ml on this PR (identical if `ap_fixed<7,1>` was used instead)


The synthesis results slightly prefer the `ap_ufixed` variation which has one fewer bit than the necessary `ap_fixed` option.

| `quantized_relu` precision | Accuracy | Latency | II | LUT | FF | DSP | BRAM18 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `ap_ufixed<6,0>` | 0.743855 | 9 | 1 | 33706 | 3037 | 119 | 4 |
| `ap_fixed<7,1>` | 0.743855 | 9 | 1 | 37523 | 3155 | 119 | 4 |

The `quantized_relu` tests now pass, so they are included again, resolving #377. I added a few more variations as well.

## unsigned `profiling`
In fixing the above, I noticed that we don't display unsigned types correctly in the profiling, so I include the fix for that as well. (Separate commits in case they need to be taken separately).

Before (master):

![Screenshot 2021-09-29 at 16 53 33](https://user-images.githubusercontent.com/14807534/135293996-19804a5b-6756-45da-a70a-ef2f1c88d948.png)

After (this PR):

![Screenshot 2021-09-29 at 16 32 10](https://user-images.githubusercontent.com/14807534/135293054-be2bcf08-d793-4d9c-aa19-a7608df15746.png)

