### PR TITLE
Speed up CI tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,22 +1,27 @@
-pytest:
-  image: gitlab-registry.cern.ch/fastmachinelearning/hls4ml-testing:0.2.base
+stages:
+  - generate
+  - trigger
+  - test
+
+generator:
+  stage: generate
+  image: python:3.7-alpine
   tags: 
     - docker
   before_script:
-    - source ~/.bashrc
-    - git submodule init
-    - git submodule update
-    - conda activate hls4ml-testing
-    - pip install .[profiling]
-  script:
+    - pip install pyyaml
+  script: 
     - cd test/pytest
-    - pytest -rA --cov-report xml --cov-report term --cov=hls4ml --junitxml=report.xml --randomly-seed=42 --randomly-dont-reorganize --randomly-dont-reset-seed
+    - python generate_ci_yaml.py
   artifacts:
-    when: always
-    reports:
-      junit: 
-        - test/pytest/report.xml
-      cobertura:
-        - test/pytest/coverage.xml
     paths:
-      - test/pytest/hls4mlprj*.tar.gz
+      - test/pytest/pytests.yml
+
+pytests:
+  stage: trigger
+  trigger:
+    include:
+      - local: test/pytest/ci-template.yml
+      - artifact: test/pytest/pytests.yml
+        job: generator
+    strategy: depend

--- a/test/pytest/ci-template.yml
+++ b/test/pytest/ci-template.yml
@@ -1,0 +1,22 @@
+.pytest:
+  stage: test
+  image: gitlab-registry.cern.ch/fastmachinelearning/hls4ml-testing:0.2.base
+  tags: 
+    - docker
+  before_script:
+    - source ~/.bashrc
+    - if [ $EXAMPLEMODEL == 1 ]; then git submodule init; git submodule update; fi
+    - conda activate hls4ml-testing
+    - pip install .[profiling]
+  script:
+    - cd test/pytest
+    - pytest $PYTESTFILE -rA --cov-report xml --cov-report term --cov=hls4ml --junitxml=report.xml --randomly-seed=42 --randomly-dont-reorganize --randomly-dont-reset-seed
+  artifacts:
+    when: always
+    reports:
+      junit: 
+        - test/pytest/report.xml
+      cobertura:
+        - test/pytest/coverage.xml
+    paths:
+      - test/pytest/hls4mlprj*.tar.gz

--- a/test/pytest/generate_ci_yaml.py
+++ b/test/pytest/generate_ci_yaml.py
@@ -1,0 +1,33 @@
+import yaml
+import glob
+
+'''
+Create a Gitlab CI yml file with a separate entry for each test_* file
+in the pytests directory to parallelise the CI jobs.
+'''
+
+template = """
+pytest.{}:
+  extends: .pytest
+  variables:
+    PYTESTFILE: {}
+    EXAMPLEMODEL: {}
+"""
+
+def uses_example_model(test_filename):
+    with open(test_filename, 'r') as f:
+        content = f.read()
+        return 'example-models/' in content
+
+yml = None
+tests = glob.glob('test_*.py')
+for test in tests:
+    name = test.replace('test_','').replace('.py','')
+    new_yml = yaml.safe_load(template.format(name, 'test_{}.py'.format(name), int(uses_example_model(test))))
+    if yml is None:
+        yml = new_yml
+    else:
+        yml.update(new_yml)
+
+yamlfile = open('pytests.yml', 'w')
+yaml.safe_dump(yml, yamlfile)


### PR DESCRIPTION
As we've been adding more tests, the CI testing takes longer to run. The timing varies a lot, but to begin with it would take ~15-20 minutes, while recently with more tests it's taking ~20-30 minutes. This PR speeds things up a bit by submitting each `test_*.py` file as a separate CI job, which can be assigned to different workers. Previously we just ran all pytests in one job, so each test would run sequentially. As we continue to develop more tests this should help avoid the CI really dragging.

Here the pipeline is [generated dynamically](https://www.objectif-libre.com/en/blog/2021/02/23/a-new-era-for-gitlab-ci-dynamic-child-pipelines/): the main `.gitlab-ci.yml` job runs the `generate_ci_yaml.py` script, which creates a `.yml` file defining all the jobs from the available test files. That's uploaded as an artifact and used to trigger the next stage. So to add a new test file you can still just add the `test_something.py` file to the pytests directory and it will be picked up by the CI.

Here's a view of it running, with some jobs finished and some still going:

![Screenshot 2021-09-30 at 17 03 43](https://user-images.githubusercontent.com/14807534/135480992-764eedd5-eb9b-40fa-a2ea-c801ec492088.png)

The timing seems to now be in the 10-15 minute range, pretty much limited to the time it takes to run the slowest test file - usually the MNIST CNN one.