### PR TITLE
Rework to use Constant nodes in intermediate representation

### DIFF
--- a/hls4ml/converters/onnx/convolution.py
+++ b/hls4ml/converters/onnx/convolution.py
@@ -1,5 +1,5 @@
 import math
-from hls4ml.converters.onnx_to_hls import onnx_handler, get_onnx_attribute, get_onnx_input_name, compute_pads_1d, compute_pads_2d
+from hls4ml.converters.onnx_to_hls import onnx_handler, get_onnx_attribute, compute_pads_1d, compute_pads_2d
 from hls4ml.converters.utils import compute_padding_1d, compute_padding_2d
 
 @onnx_handler('Conv')
@@ -8,7 +8,8 @@ def parse_conv_layer(reader, node, inputs_map, input_shapes, graph, config):
     layer = {}
     layer['name'] = node.name
     layer['data_format'] = 'channels_first' #ONNX's default is channel first
-    layer['inputs'] = get_onnx_input_name(node, graph)
+    layer['inputs'] = node.input
+    layer['outputs'] = node.output
     reader.add_input(layer['name'], node.input)
 
     strides = get_onnx_attribute(node, 'strides')
@@ -37,7 +38,7 @@ def parse_conv_layer(reader, node, inputs_map, input_shapes, graph, config):
                                                       layer['stride_width'],
                                                       layer['filt_width'])
 
-        output_shape = [input_shapes[0][0], layer['n_filt'], layer['out_width']]
+        # output_shape = [input_shapes[0][0], layer['n_filt'], layer['out_width']]
         
     elif len(input_shapes[0]) == 4: # Conv2D
         
@@ -73,7 +74,7 @@ def parse_conv_layer(reader, node, inputs_map, input_shapes, graph, config):
                                                                                layer['filt_height'],
                                                                                layer['filt_width'])
 
-        output_shape = [input_shapes[0][0], layer['n_filt'], layer['out_height'], layer['out_width']]
+        # output_shape = [input_shapes[0][0], layer['n_filt'], layer['out_height'], layer['out_width']]
 
-    return layer, output_shape
+    return layer
     

--- a/hls4ml/converters/onnx/merge.py
+++ b/hls4ml/converters/onnx/merge.py
@@ -1,15 +1,16 @@
-from hls4ml.converters.onnx_to_hls import onnx_handler, get_onnx_attribute, get_onnx_input_name
+from hls4ml.converters.onnx_to_hls import onnx_handler, get_onnx_attribute
 
 merge_layers = ['Add', 'Sub', 'Mul', 'Div', 'Average', 'Max', 'Min', 'Concat', 'Sum']
 @onnx_handler(*merge_layers)
 def parse_merge_layer(reader, node, inputs_map, input_shapes, graph, config):
-    
+
     layer = {}
     layer['class_name'] = node.op_type
     layer['name'] = node.name
     layer['op'] = layer['class_name'].lower()
-    layer['inputs'] = get_onnx_input_name(node, graph)
-    output_shape = input_shapes[0]
+    layer['inputs'] = node.input
+    layer['outputs'] = node.output
+    # output_shape = input_shapes[0]
 
     if layer['class_name'] == 'Concat':
         rank = len(input_shapes[0][1:])
@@ -20,20 +21,28 @@ def parse_merge_layer(reader, node, inputs_map, input_shapes, graph, config):
         layer['op'] = layer['class_name'].lower() + '{}d'.format(rank)
         layer['axis'] = get_onnx_attribute(node, 'axis')
 
-        #Calculate output shape
-        new_dim = sum([x.type.tensor_type.shape.dim[layer['axis']].dim_value for x in graph.value_info if x.name in node.input])
-        output_shape[layer['axis']] = new_dim
-   
+        # #Calculate output shape
+        # new_dim = sum([x.type.tensor_type.shape.dim[layer['axis']].dim_value for x in graph.value_info if x.name in node.input])
+        # output_shape[layer['axis']] = new_dim
+
     elif layer['class_name'] ==  'Add':
         #Check if the layer is an AddBias
         for input in node.input:
             if "bias" in input:
                 layer['class_name'] = 'BiasAdd'
-                reader.add_input(layer['name'], node.input)
+                # # Should the line below really be replaced with the one below it?
+                # # Going to assume so
+                # reader.add_input(layer['name'], node.input)
+                reader.add_input(layer['name'], input)
+
+        if layer['class_name'] ==  'Add':
+            # If it wasn't changed, just make it a merge node
+            layer['class_name'] = 'Merge'
+
     else:
         layer['class_name'] = 'Merge'
-    
+
     if len(layer['inputs']) > 2:
         raise Exception('ERROR: Merging more than two tensors is not yet supported.')
-    
-    return layer, output_shape
+
+    return layer

--- a/hls4ml/converters/onnx/pooling.py
+++ b/hls4ml/converters/onnx/pooling.py
@@ -1,5 +1,5 @@
 import math
-from hls4ml.converters.onnx_to_hls import onnx_handler, get_onnx_attribute, compute_pads_1d, compute_pads_2d, get_onnx_input_name
+from hls4ml.converters.onnx_to_hls import onnx_handler, get_onnx_attribute, compute_pads_1d, compute_pads_2d
 from hls4ml.converters.utils import compute_padding_1d, compute_padding_2d
 
 pool_operations = ['AveragePool', 'MaxPool']
@@ -8,7 +8,8 @@ def parse_pool_layer(reader, node, inputs_map, input_shapes, graph, config):
     
     layer = {}
     layer['name'] = node.name
-    layer['inputs'] = get_onnx_input_name(node, graph)
+    layer['inputs'] = node.input
+    layer['outputs'] = node.output
     layer['class_name'] = node.op_type
     layer['data_format'] = 'channels_first' #Default ONNX
 
@@ -40,7 +41,7 @@ def parse_pool_layer(reader, node, inputs_map, input_shapes, graph, config):
                                                       layer['stride_width'],
                                                       layer['pool_width'])
 
-        output_shape = [input_shapes[0][0], layer['n_filt'], layer['n_out']]
+        # output_shape = [input_shapes[0][0], layer['n_filt'], layer['n_out']]
     
     elif len(input_shapes[0]) == 4: # 2D
         layer['class_name'] = info + 'Pooling2D'
@@ -73,9 +74,9 @@ def parse_pool_layer(reader, node, inputs_map, input_shapes, graph, config):
                                                                                layer['filt_height'],
                                                                                layer['filt_width'])
         
-        output_shape = [input_shapes[0][0], layer['n_filt'], layer['out_height'], layer['out_width']]
+        # output_shape = [input_shapes[0][0], layer['n_filt'], layer['out_height'], layer['out_width']]
     
-    return layer, output_shape
+    return layer
 
 global_pooling_layers = ['GlobalMaxPool', 'GlobalAveragePool']
 @onnx_handler(*global_pooling_layers)
@@ -83,7 +84,8 @@ def parse_global_pooling_layer(reader, node, inputs_map, input_shapes, graph, co
 
     layer = {}
     layer['name'] = node.name
-    layer['inputs'] = get_onnx_input_name(node, graph)
+    layer['inputs'] = node.input
+    layer['outputs'] = node.output
     layer['class_name'] = node.op_type
     layer['data_format'] = 'channels_first'
 
@@ -107,6 +109,6 @@ def parse_global_pooling_layer(reader, node, inputs_map, input_shapes, graph, co
         layer['in_height'] = input_shapes[0][2]
         layer['in_width'] = input_shapes[0][3]
     
-    output_shape = [input_shapes[0][0], layer['n_filt']] + [1]*(len(input_shapes[0]) - 2)
+    # output_shape = [input_shapes[0][0], layer['n_filt']] + [1]*(len(input_shapes[0]) - 2)
 
-    return layer, output_shape
+    return layer

--- a/hls4ml/converters/onnx/reshape.py
+++ b/hls4ml/converters/onnx/reshape.py
@@ -1,4 +1,4 @@
-from hls4ml.converters.onnx_to_hls import onnx_handler, get_onnx_input_name, get_input_initial_value
+from hls4ml.converters.onnx_to_hls import onnx_handler
 import numpy as np
 
 @onnx_handler('Transpose')
@@ -7,14 +7,13 @@ def parse_transpose_layer(reader, node, inputs_map, input_shapes, graph, config)
     layer = {}
     layer['name'] = node.name
     layer['class_name'] = 'Transpose'
-    layer['inputs'] = get_onnx_input_name(node, graph)
+    layer['inputs'] = node.input
+    layer['outputs'] = node.output
 
     perm = [list(i.ints) for i in node.attribute][0] #This will get something like [[a,b,c]][0] = [a,b,c]
     layer['perm'] = [x - 1 for x in perm[1:]] #Ignore the batch dimension in ONNX, and adjust the perm indexing
 
-    output_shape = [input_shapes[0][i] for i in perm]
-
-    return layer, output_shape
+    return layer
 
 @onnx_handler('Reshape')
 def parse_reshape_layer(reader, node, inputs_map, input_shapes, graph, config):
@@ -22,17 +21,7 @@ def parse_reshape_layer(reader, node, inputs_map, input_shapes, graph, config):
     layer = {}
     layer['name'] = node.name
     layer['class_name'] = 'Reshape'
-    layer['inputs'] = get_onnx_input_name(node, graph)
+    layer['inputs'] = node.input
+    layer['outputs'] = node.output
 
-    target_shape = get_input_initial_value(graph, node.input[1])
-
-    if -1 in target_shape: #Need to infer shape for -1
-        print("WARNING: Inferring -1 shape ... ")
-        dummy_x = np.ones(input_shapes[0][1:])
-        dummy_y = np.reshape(dummy_x, target_shape)
-        target_shape = list(dummy_y.shape)
-
-    layer['target_shape'] = target_shape
-    output_shape = input_shapes[0][:1] + layer['target_shape']
-
-    return layer, output_shape
+    return layer

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -325,7 +325,7 @@ class HLSModel(object):
             outputs = layer.get('outputs', [])
             if kind in ['InputLayer', 'Input']:
                 inputs = ['input']
-            elif len(inputs) == 0:
+            elif len(inputs) == 0 and kind != 'Constant':
                 inputs = [next(reversed(self.graph), 'input')]
             if len(outputs) == 0:
                 outputs = [name]


### PR DESCRIPTION
Based on discussion with @vloncar, I introduced a Constant node. The idea is as follows. The initial conversion from onnx to the hls4ml model should be as simple as possible, and then we build things up with optimizers. Constants, including weights, come in through Constant nodes, and the Quantizers then more easily apply their quantization on the weight inputs, producing weight outputs, which with the MatMul node, can be combined to a Dense layer with weights. The scalings and biases also come in via Merge nodes with a constant. I think it simplifies things.

The merge request is not complete. The optimization steps are not implemented, and I haven't looked at convolution yet. It seems to be able to ingenst TFC_2W2A_clean.onnx (though of course the compilation step fails.)

Any thoughts on this implementation? Note it's a PR to the ingest-qonnx development branch, not the main branch.