### PR TITLE
Update for pyyaml 6.0

### DIFF
--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -93,7 +93,7 @@ def parse_yaml_config(config_file):
 
     print('Loading configuration from', config_file)
     with open(config_file, 'r') as file:
-        parsed_config = yaml.load(file, Loader=yaml.SafeLoader)
+        parsed_config = yaml.safe_load(file)
     return parsed_config
 
 def convert_from_config(config):

--- a/test/pytest/test_cnn_mnist.py
+++ b/test/pytest/test_cnn_mnist.py
@@ -37,7 +37,7 @@ def mnist_model():
 def hls_model(settings):
   io_type = settings[0]
   strategy = settings[1]
-  config = yaml.load(open('../../example-models/config-files/qkeras_mnist_cnn_config.yml').read())
+  config = yaml.safe_load(open('../../example-models/config-files/qkeras_mnist_cnn_config.yml').read())
   config['KerasJson'] = '../../example-models/keras/qkeras_mnist_cnn.json'
   config['KerasH5'] = '../../example-models/keras/qkeras_mnist_cnn_weights.h5'
   config['OutputDir'] = 'hls4mlprj_cnn_mnist_{}_{}'.format(io_type, strategy)


### PR DESCRIPTION
From our `setup.py` we pick up the latest `pyyaml` with `pip install hls4ml`. Since `pyyaml`'s `6.0` release a few weeks ago the `Loader` argument is required by `yaml.load`, causing a few issues in `hls4ml`. The pytests currently fail on master branch as a consequence.

This PR & #423 fix all the broken `yaml.load` occurrences in the code base. 