### PR TITLE
Fix Conv2D with `io_type = io_parallel` & `Strategy: Resource`

### DIFF
--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv2d_resource.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv2d_resource.h
@@ -154,20 +154,18 @@ void im2col_2d_cl(
     const int col)
 {
     int index = 0;
-    for (int channel = CONFIG_T::n_chan; channel--; data++) {
+    for (int kernel_row = 0; kernel_row < CONFIG_T::filt_height; kernel_row++) {
         #pragma HLS UNROLL
-        for (int kernel_row = 0; kernel_row < CONFIG_T::filt_height; kernel_row++) {
-            int input_row = -CONFIG_T::pad_top + kernel_row * CONFIG_T::dilation_height + row * CONFIG_T::stride_height;
-            for (int kernel_col = 0; kernel_col < CONFIG_T::filt_width; kernel_col++) {
+        int input_row = -CONFIG_T::pad_top + kernel_row * CONFIG_T::dilation_height + row * CONFIG_T::stride_height;
+        for (int kernel_col = 0; kernel_col < CONFIG_T::filt_width; kernel_col++) {
+            for (int channel = 0; channel < CONFIG_T::n_chan; channel++) {
                 if (input_row < 0 || input_row >= CONFIG_T::in_height) {
                     data_col[index++] = 0;
                 } else {
                     int input_col = -CONFIG_T::pad_left + kernel_col * CONFIG_T::dilation_width + col * CONFIG_T::stride_width;
                     if (input_col >= 0 && input_col < CONFIG_T::in_width) {
-                        //*(data_col++) = data[input_row * CONFIG_T::in_width * CONFIG_T::n_chan + input_col * CONFIG_T::n_chan];
-                        data_col[index++] = data[input_row * CONFIG_T::in_width * CONFIG_T::n_chan + input_col * CONFIG_T::n_chan];
+                        data_col[index++] = data[input_row * CONFIG_T::in_width * CONFIG_T::n_chan + input_col * CONFIG_T::n_chan + channel];
                     } else {
-                        //*(data_col++) = 0;
                         data_col[index++] = 0;
                     }
                 }
@@ -209,7 +207,6 @@ void conv_2d_resource_cl(
             FiltLoop:
             for (int k = 0; k < CONFIG_T::n_filt; k++) {
                 res[i * CONFIG_T::out_width * CONFIG_T::n_filt + j * CONFIG_T::n_filt + k] = res_col[k];
-                //res[k * CONFIG_T::out_height * CONFIG_T::out_width + i * CONFIG_T::out_width + j] = res_col[k]; // Transposed order
             }
         }
     }

--- a/test/pytest/test_cnn_mnist.py
+++ b/test/pytest/test_cnn_mnist.py
@@ -28,10 +28,9 @@ def mnist_model():
   model.load_weights('../../example-models/keras/qkeras_mnist_cnn_weights.h5')
   return model
 
-# TODO: add ('io_parallel', 'resource') when it can pass
-# https://github.com/fastmachinelearning/hls4ml/issues/375
 @pytest.fixture      
 @pytest.mark.parametrize('settings', [('io_parallel', 'latency'),
+                                      ('io_parallel', 'resource'),
                                       ('io_stream', 'latency'),
                                       ('io_stream', 'resource')])
 def hls_model(settings):
@@ -49,10 +48,12 @@ def hls_model(settings):
   return hls_model
 
 @pytest.mark.parametrize('settings', [('io_parallel', 'latency'),
+                                      ('io_parallel', 'resource'),
                                       ('io_stream', 'latency'),
                                       ('io_stream', 'resource')])
 def test_accuracy(mnist_data, mnist_model, hls_model):
   x_train, y_train, x_test, y_test = mnist_data
+  x_test, y_test = x_test[:5000], y_test[:5000]
   model = mnist_model
   # model under test predictions and accuracy
   y_keras = model.predict(x_test)


### PR DESCRIPTION
Currently a `Conv2D` layer with `io_type = io_parallel` & `Strategy: Resource` gives wrong results. The loops of `im2col_2d_cl` needed reordering.

`test_cnn_mnist.py` probes the issue. On master branch the problematic combination is excluded, but if we run it we see:

```
Accuracy keras:      0.9838
Accuracy hls4ml:     0.112
Relative difference: 0.8861557227078675

>     assert acc_keras > 0.95 and rel_diff < 0.01
E     assert (0.9838 > 0.95 and 0.8861557227078675 < 0.01)

test_cnn_mnist.py:72: AssertionError
```

Now it can be included, passing with:

```
Accuracy keras:      0.9838
Accuracy hls4ml:     0.9834
Relative difference: 0.0004065867046147143
```

I've also reduced the number of MNIST images used in the test from 10000 to 5000, since that test was already the slowest and this PR adds another iteration of it.

Solves issue #375 , and also seen in issue #437.

For completeness: this doesn't touch `io_stream` implementations, they're all fine.
I haven't touched `im2col_2d_cf`, but is that even accessible?