### PR TITLE
Embedding layer

### DIFF
--- a/hls4ml/converters/keras/core.py
+++ b/hls4ml/converters/keras/core.py
@@ -122,9 +122,8 @@ def parse_batchnorm_layer(keras_layer, input_names, input_shapes, data_reader, c
 
     return layer, [shape for shape in input_shapes[0]]
 
-embedding_layers = ['Embedding']
-@keras_handler(*embedding_layers)
-def parse_dense_layer(keras_layer, input_names, input_shapes, data_reader, config):
+@keras_handler('Embedding')
+def parse_embedding_layer(keras_layer, input_names, input_shapes, data_reader, config):
     assert('Embedding' in keras_layer['class_name'])
 
     layer = parse_default_keras_layer(keras_layer, input_names)

--- a/hls4ml/converters/keras/core.py
+++ b/hls4ml/converters/keras/core.py
@@ -121,3 +121,19 @@ def parse_batchnorm_layer(keras_layer, input_names, input_shapes, data_reader, c
         layer['n_filt']=input_shapes[0][3]
 
     return layer, [shape for shape in input_shapes[0]]
+
+embedding_layers = ['Embedding']
+@keras_handler(*embedding_layers)
+def parse_dense_layer(keras_layer, input_names, input_shapes, data_reader, config):
+    assert('Embedding' in keras_layer['class_name'])
+
+    layer = parse_default_keras_layer(keras_layer, input_names)
+    
+    weights_shape = data_reader.get_weights_shape(layer['name'], 'embeddings')
+    layer['n_in'] = input_shapes[0][1]
+    layer['vocab_size'] = weights_shape[0]
+    layer['n_out'] = weights_shape[1]
+    layer['weight_quantizer'] = None
+    output_shape = input_shapes[0]+[layer['n_out']]
+
+    return layer, output_shape

--- a/hls4ml/templates/vivado/nnet_utils/nnet_embed.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_embed.h
@@ -1,0 +1,43 @@
+#ifndef NNET_EMBED_H_
+#define NNET_EMBED_H_
+
+#include "nnet_common.h"
+#include "nnet_helpers.h"
+#include "hls_stream.h"
+#include <math.h>
+
+namespace nnet {
+
+struct embed_config
+{
+    // Internal data type definitions
+    typedef float weight_t;
+
+    // Layer Sizes
+    static const unsigned n_in = 10;
+    static const unsigned n_out = 16;
+    static const unsigned vocab_size = 50;
+
+    // Resource reuse info
+    static const unsigned io_type = io_parallel;
+    static const unsigned reuse_factor = 1;
+};
+
+ template<class data_T, class res_T, typename CONFIG_T>
+   void embedding(
+	      data_T    data[CONFIG_T::n_in],
+	      res_T     res[CONFIG_T::n_in*CONFIG_T::n_out],
+	      typename CONFIG_T::weight_t  weights[CONFIG_T::vocab_size*CONFIG_T::n_out])
+ {
+   // copy over the corresponding row in the weights lookup table
+   for (int j = 0; j < CONFIG_T::n_in; j++) {
+     for (int i = 0; i < CONFIG_T::n_out; i++) {
+       #pragma HLS UNROLL
+       res[j * CONFIG_T::n_out + i] = (res_T) weights[data[j] * CONFIG_T::n_out + i];
+     }
+   }
+ }
+
+}
+
+#endif

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -345,6 +345,15 @@ const config{index}::sublayer_t<{il}>::output_transform_biases_t (&config{index}
 garnet_stack_config_template = (garnet_stack_base_config_template, garnet_stack_sublayer_config_template)
 
 
+embed_config_template = """struct config{index} : nnet::embed_config {{
+    static const unsigned n_in = {n_in};
+    static const unsigned n_out = {n_out};
+    static const unsigned vocab_size = {vocab_size};
+    static const unsigned io_type = nnet::{iotype};
+    static const unsigned reuse_factor = {reuse};
+    typedef {weight_t} weight_t;
+}};\n"""
+
 
 dense_function_template = 'nnet::dense<{input_t}, {output_t}, {config}>({input}, {output}, {w}, {b});'
 batchnorm_function_template = 'nnet::normalize<{input_t}, {output_t}, {config}>({input}, {output}, {scale}, {bias});'
@@ -366,6 +375,7 @@ resize_function_template = 'nnet::resize_{algorithm}<{input_t}, {config}>({input
 transpose_function_template = 'nnet::transpose_{dim}<{input_t}, {config}>({input}, {output});'
 garnet_function_template = 'nnet::garnet{impl}<{input_t}, {integer_input_t}, {output_t}, {config}>({input}, {nvtx}, {output});'
 garnet_stack_function_template = 'nnet::garnet_stack<{input_t}, {integer_input_t}, {output_t}, {config}>({input}, {nvtx}, {output});'
+embed_function_template = 'nnet::embedding<{input_t}, {output_t}, {config}>({input}, {output}, {w});'
 
 dense_include_list = ['nnet_utils/nnet_dense.h', 'nnet_utils/nnet_dense_compressed.h', 'nnet_utils/nnet_dense_stream.h']
 batchnorm_include_list = ['nnet_utils/nnet_batchnorm.h', 'nnet_utils/nnet_batchnorm_stream.h']
@@ -380,6 +390,7 @@ merge_include_list = ['nnet_utils/nnet_merge.h', 'nnet_utils/nnet_merge_stream.h
 resize_include_list = ['nnet_utils/nnet_image.h', 'nnet_utils/nnet_image_stream.h']
 transpose_include_list = ['nnet_utils/nnet_array.h']
 garnet_include_list = ['nnet_utils/nnet_garnet.h']
+embed_include_list = ['nnet_utils/nnet_embed.h']
 
 class VivadoBackend(Backend):
     def __init__(self, name='Vivado'):
@@ -410,7 +421,8 @@ class VivadoBackend(Backend):
         self.register_templates('Resize'                 , resize_function_template,      resize_config_template, resize_include_list)
         self.register_templates('Transpose'              , transpose_function_template,   transpose_config_template, transpose_include_list)
         self.register_templates('GarNet'                 , garnet_function_template,      garnet_config_template, garnet_include_list)
-        self.register_templates('GarNetStack'            , garnet_stack_function_template,garnet_stack_config_template, garnet_include_list)        
+        self.register_templates('GarNetStack'            , garnet_stack_function_template,garnet_stack_config_template, garnet_include_list)
+        self.register_templates('Embedding', embed_function_template, embed_config_template, embed_include_list)
     
     def create_initial_config(self, part='xcku115-flvb2104-2-i', board=None, clock_period=5, io_type='io_parallel'):
         config = {}

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -101,7 +101,7 @@ def config_from_keras_model(model, granularity='model', default_precision='ap_fi
         model_arch = json.loads(model.to_json())
 
     #Define supported layers
-    core_layers = ['InputLayer', 'Dropout', 'Flatten', 'Reshape', 'Permute']
+    core_layers = ['InputLayer', 'Dropout', 'Flatten', 'Reshape', 'Permute', 'Embedding']
     dense_layers = ['Dense', 'BinaryDense', 'TernaryDense']
     conv_layers = ['Conv1D', 'Conv2D', 'BinaryConv2D']
     pooling_layers = ['MaxPooling1D', 'MaxPooling2D', 'GlobalMaxPooling1D', 'GlobalMaxPooling2D', 'AveragePooling1D', 'AveragePooling2D', 'GlobalAveragePooling1D', 'GlobalAveragePooling2D']

--- a/test/pytest/test_embed.py
+++ b/test/pytest/test_embed.py
@@ -1,0 +1,45 @@
+import pytest
+import hls4ml
+import numpy as np
+from tensorflow.keras.models import model_from_json, Model
+from tensorflow.keras.layers import Input, Permute, Concatenate, Activation, Embedding
+import yaml
+
+@pytest.fixture(scope='module')
+def data():
+    X = np.random.randint(10, size=(32, 100))
+    return X
+
+@pytest.fixture(scope='module')
+def keras_model():
+    inputs = Input(shape=(100,), name='embedding_input')
+    embedding = Embedding(13, 8, input_length=100, name='embedding')(inputs)
+    model = Model(inputs=inputs, outputs=embedding)
+    return model
+
+@pytest.fixture      
+@pytest.mark.parametrize('io_type', ['io_parallel',
+                                     'io_stream'])
+def hls_model(keras_model, io_type):
+    hls_config = hls4ml.utils.config_from_keras_model(keras_model, 
+                                                      default_precision='ap_fixed<16,6>',
+                                                      granularity='name')
+    hls_config['LayerName']['embedding_input']['Precision']['result'] = 'ap_uint<4>'
+    hls_model = hls4ml.converters.convert_from_keras_model(keras_model,
+                                                           hls_config=hls_config,
+                                                           io_type=io_type,
+                                                           output_dir='hls4mlprj_embed_{}'.format(io_type))
+
+    hls_model.compile()
+    return hls_model
+
+@pytest.mark.parametrize('io_type', ['io_parallel', 
+                                     'io_stream'])
+def test_accuracy(data, keras_model, hls_model):
+    X = data
+    model = keras_model
+    # model under test predictions and accuracy
+    y_keras = model.predict(X)
+    y_hls4ml   = hls_model.predict(X.astype(np.float)).reshape(y_keras.shape)
+    # "accuracy" of hls4ml predictions vs keras
+    np.testing.assert_allclose(y_keras, y_hls4ml, rtol=0, atol=1e-03, verbose=True)


### PR DESCRIPTION
Original implementation from @drewpersigehl: https://github.com/drewpersigehl/L1MET_EmbeddingLayer

Addresses #422

Simple test script: https://gist.github.com/jmduarte/302c1d629747d86b926fa13b485a1682

- [x] `io_parallel` implementation
- [x] `io_stream` implementation
- [x] add tests

A few peculiarities to note (not yet enforced):
* `weight_t` should always be equal to `res_t`
* `data_t` should always be `[u]int` or `ap_[u]int<X>`

Example HLS latency/resources for `n_in = 100`, `vocab_size = 13`, `n_out = 8`, `ap_uint<4>` for inputs, and `ap_fixed<16,6>` for outputs.
* `io_parallel`:
```
    +---------+---------+----------+----------+-----+-----+----------+
    |  Latency (cycles) |  Latency (absolute) |  Interval | Pipeline |
    |   min   |   max   |    min   |    max   | min | max |   Type   |
    +---------+---------+----------+----------+-----+-----+----------+
    |        1|        1| 5.000 ns | 5.000 ns |    1|    1| function |
    +---------+---------+----------+----------+-----+-----+----------+
+---------------------+---------+-------+---------+---------+-----+
|         Name        | BRAM_18K| DSP48E|    FF   |   LUT   | URAM|
+---------------------+---------+-------+---------+---------+-----+
|DSP                  |        -|      -|        -|        -|    -|
|Expression           |        -|      -|        0|        6|    -|
|FIFO                 |        -|      -|        -|        -|    -|
|Instance             |        0|      -|     5602|     4918|    -|
|Memory               |        -|      -|        -|        -|    -|
|Multiplexer          |        -|      -|        -|       45|    -|
|Register             |        -|      -|      403|        -|    -|
+---------------------+---------+-------+---------+---------+-----+
|Total                |        0|      0|     6005|     4969|    0|
+---------------------+---------+-------+---------+---------+-----+
|Available SLR        |     1440|   2280|   788160|   394080|  320|
+---------------------+---------+-------+---------+---------+-----+
|Utilization SLR (%)  |        0|      0|    ~0   |        1|    0|
+---------------------+---------+-------+---------+---------+-----+
|Available            |     4320|   6840|  2364480|  1182240|  960|
+---------------------+---------+-------+---------+---------+-----+
|Utilization (%)      |        0|      0|    ~0   |    ~0   |    0|
+---------------------+---------+-------+---------+---------+-----+
```
* `io_stream`: Note the long latency/II is due to the fact that the input data is put in a stream of size 100 (so we read have to wait to read in the full data)
```
    +---------+---------+----------+----------+-----+-----+----------+
    |  Latency (cycles) |  Latency (absolute) |  Interval | Pipeline |
    |   min   |   max   |    min   |    max   | min | max |   Type   |
    +---------+---------+----------+----------+-----+-----+----------+
    |      101|      101| 0.505 us | 0.505 us |  100|  100| dataflow |
    +---------+---------+----------+----------+-----+-----+----------+
+---------------------+---------+-------+---------+---------+-----+
|         Name        | BRAM_18K| DSP48E|    FF   |   LUT   | URAM|
+---------------------+---------+-------+---------+---------+-----+
|DSP                  |        -|      -|        -|        -|    -|
|Expression           |        -|      -|        0|       20|    -|
|FIFO                 |        -|      -|        -|        -|    -|
|Instance             |        0|      -|      557|    13507|    -|
|Memory               |        -|      -|        -|        -|    -|
|Multiplexer          |        -|      -|        -|       36|    -|
|Register             |        -|      -|        6|        -|    -|
+---------------------+---------+-------+---------+---------+-----+
|Total                |        0|      0|      563|    13563|    0|
+---------------------+---------+-------+---------+---------+-----+
|Available SLR        |     1440|   2280|   788160|   394080|  320|
+---------------------+---------+-------+---------+---------+-----+
|Utilization SLR (%)  |        0|      0|    ~0   |        3|    0|
+---------------------+---------+-------+---------+---------+-----+
|Available            |     4320|   6840|  2364480|  1182240|  960|
+---------------------+---------+-------+---------+---------+-----+
|Utilization (%)      |        0|      0|    ~0   |        1|    0|
+---------------------+---------+-------+---------+---------+-----+
```