### PR TITLE
Inplace variable fix

### DIFF
--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -140,7 +140,7 @@ class HLSConfig(object):
             targ_cycles = self.layer_name_targ_cycles.get(layer.__class__.__name__.lower())
         if targ_cycles is None:
             targ_cycles = self.model_targ_cycles
- 
+
         return targ_cycles
 
     def get_strategy(self, layer):
@@ -151,7 +151,7 @@ class HLSConfig(object):
             strategy = self.model_strategy
 
         return strategy
-    
+
     def get_conv_implementation(self, layer):
         conv_implementation = self.layer_name_conv_implementation.get(layer.name.lower())
         if conv_implementation is None:
@@ -175,7 +175,7 @@ class HLSConfig(object):
 
     def _parse_hls_config(self):
         hls_config = self.config['HLSConfig']
-        
+
         self.optimizers = hls_config.get('Optimizers')
         if 'SkipOptimizers' in hls_config:
             if self.optimizers is not None:
@@ -186,9 +186,9 @@ class HLSConfig(object):
                 try:
                     selected_optimizers.remove(opt)
                 except ValueError:
-                    pass                
+                    pass
             self.optimizers = selected_optimizers
-        
+
         model_cfg = hls_config.get('Model')
         if model_cfg is not None:
             precision_cfg = model_cfg.get('Precision')
@@ -219,7 +219,7 @@ class HLSConfig(object):
                 rf = layer_cfg.get('ReuseFactor')
                 if rf is not None:
                     self.layer_type_rf[layer_type.lower()] = rf
-                
+
                 targ_cycles = layer_cfg.get('TargetCycles')
                 if targ_cycles is not None:
                     self.layer_type_targ_cycles[layer_type.lower()] = targ_cycles
@@ -308,7 +308,7 @@ class HLSModel(object):
         self.graph = OrderedDict()
         self.output_vars = {}
 
-        # External BRAM 
+        # External BRAM
         self.bram_vars = {}
 
         self._top_function_lib = None
@@ -339,7 +339,7 @@ class HLSModel(object):
         """ Make a new node not connected to the model graph.
 
         The 'kind' should be a valid layer registered with `register_layer`. If no outputs
-        are specified, a default output named the same as the node will be created. The 
+        are specified, a default output named the same as the node will be created. The
         returned node should be added to the graph with `insert_node` or `replace_node`
         functions.
 
@@ -372,13 +372,13 @@ class HLSModel(object):
     def insert_node(self, node, before=None):
         """ Insert a new node into the model graph.
 
-        The node to be inserted should be created with `make_node()` function. The optional 
+        The node to be inserted should be created with `make_node()` function. The optional
         parameter `before` can be used to specify the node that follows in case of ambiguities.
 
         Args:
             node (Layer): Node to insert
             before (Layer, optional): The next node in sequence before which a
-                new node should be inserted. 
+                new node should be inserted.
         Raises:
             Exception: If an attempt to insert a node with multiple inputs is made or if
                 `before` does not specify a correct node in sequence.
@@ -440,7 +440,7 @@ class HLSModel(object):
                         raise Exception('Cannot rewire a node without child')
             else:
                 raise Exception('Cannot rewire a node without a parent')
-        
+
         del self.output_vars[node.outputs[0]]
         del self.graph[node.name]
         self._update_model_outputs()
@@ -457,6 +457,7 @@ class HLSModel(object):
         next_node = next((x for x in self.graph.values() if x.inputs[0] == old_node.outputs[0]), None)
         if next_node is not None:
             next_node.inputs[0] = new_node.outputs[0]
+            next_node.update_inplace_variables()
         if prev_node is not None:
             if new_node.inputs is None or len(new_node.inputs) == 0: # Check if already rewired
                 new_node.inputs = [prev_node.outputs[0]]
@@ -517,7 +518,7 @@ class HLSModel(object):
             from random import choice
             length = 8
             return ''.join(choice(hexdigits) for m in range(length))
-        
+
         self.config.config['Stamp'] = make_stamp()
 
         self.config.writer.write_hls(self)
@@ -552,7 +553,7 @@ class HLSModel(object):
             raise Exception('Model not compiled')
         if len(self.get_input_variables()) == 1:
             xlist = [x]
-        else: 
+        else:
             xlist = x
         
         for xi in xlist:

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -434,6 +434,7 @@ class HLSModel(object):
                     for i,_ in enumerate(next_node.inputs):
                         if node.outputs[0] == next_node.inputs[i]:
                             next_node.inputs[i] = prev_node.outputs[0]
+                            next_node.update_inplace_variables()
                             break
                 else:
                     if not node.outputs[0] in self.outputs:

--- a/hls4ml/model/optimizer/passes/nop.py
+++ b/hls4ml/model/optimizer/passes/nop.py
@@ -8,5 +8,5 @@ class EliminateLinearActivation(OptimizerPass):
         return node.__class__.__name__ == 'Activation' and node.get_attr('activation') == 'linear' and not cast
     
     def transform(self, model, node):
-        model.remove_node(node)
+        model.remove_node(node, rewire=True)
         return True

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -106,7 +106,7 @@ class VivadoWriter(Writer):
         If `pragma` is a tuple: (mode, type, factor) where mode is 'partition' or 'reshape', type is
         'complete', 'cyclic', or 'block', and factor is an integer only used when the type is not 'complete'.
         """
-        
+
         config = variable.pragma
         if type(config) is tuple:
             mode = config[0]
@@ -161,7 +161,7 @@ class VivadoWriter(Writer):
                 newline = ''
                 newline += indent + inputs_str + ',\n'
                 newline += indent + outputs_str + ',\n'
-                if len(model_brams) > 0: 
+                if len(model_brams) > 0:
                     newline += brams_str + ',\n'
                 newline += indent + insize_str + ',\n'
                 newline += indent + outsize_str + '\n'
@@ -182,7 +182,7 @@ class VivadoWriter(Writer):
                 newline = line
                 all_inputs = [i.cppname for i in model_inputs]
                 all_outputs = [o.cppname for o in model_outputs]
-                all_brams = [b.cppname for b in model_brams] 
+                all_brams = [b.cppname for b in model_brams]
                 io_type = model.config.get_config_value("IOType")
 
                 if io_type == 'io_parallel':
@@ -275,7 +275,7 @@ class VivadoWriter(Writer):
                 newline = ''
                 newline += indent + inputs_str + ',\n'
                 newline += indent + outputs_str + ',\n'
-                if len(model_brams) > 0: 
+                if len(model_brams) > 0:
                     newline += brams_str + ',\n'
                 newline += indent + insize_str + ',\n'
                 newline += indent + outsize_str + '\n'
@@ -351,12 +351,12 @@ class VivadoWriter(Writer):
         for layer in model.get_layers():
             for weights in layer.get_weights():
                 self.print_array_to_cpp(weights, model.config.get_output_dir())
-    
-    def __make_dat_file(self, original_path, project_path): 
+
+    def __make_dat_file(self, original_path, project_path):
         """
         Convert other input/output data types into a dat file, which is
         a text file with the falttened matrix printed out. Note that ' ' is
-        assumed to be the delimiter. 
+        assumed to be the delimiter.
         """
 
         #Take in data from current supported data files
@@ -387,16 +387,16 @@ class VivadoWriter(Writer):
 
         if not os.path.exists('{}/tb_data/'.format(model.config.get_output_dir())):
             os.mkdir('{}/tb_data/'.format(model.config.get_output_dir()))
-        
+
         input_data = model.config.get_config_value('InputData')
         output_predictions = model.config.get_config_value('OutputPredictions')
-        
+
         if input_data:
             if input_data[-3:] == "dat":
                 copyfile(input_data, '{}/tb_data/tb_input_features.dat'.format(model.config.get_output_dir()))
             else:
                 self.__make_dat_file(input_data,'{}/tb_data/tb_input_features.dat'.format(model.config.get_output_dir()))
-        
+
         if output_predictions:
             if output_predictions[-3:] == "dat":
                 copyfile(output_predictions, '{}/tb_data/tb_output_predictions.dat'.format(model.config.get_output_dir()))
@@ -444,13 +444,13 @@ class VivadoWriter(Writer):
 
                 input_vars = ','.join([i.cppname for i in model.get_input_variables()])
                 output_vars = ','.join([o.cppname for o in model.get_output_variables()])
-                bram_vars   =','.join([b.cppname for b in model.get_bram_variables()]) 
+                bram_vars   =','.join([b.cppname for b in model.get_bram_variables()])
 
                 # Concatenate the input, output, and bram variables. Filter out empty/null values
                 all_vars = ','.join(filter(None, [input_vars, output_vars, bram_vars]))
 
                 top_level = indent + '{}({},{},{});\n'.format(model.config.get_project_name(), all_vars, input_size_vars, output_size_vars)
-                
+
                 newline += top_level
             elif '//hls-fpga-machine-learning insert predictions' in line:
                 newline = line
@@ -517,18 +517,18 @@ class VivadoWriter(Writer):
                     newline += indent + '{var};\n'.format(var=self.variable_definition_cpp(model, i, name_suffix='_ap'))
                     newline += indent + 'nnet::convert_data<{}, {}, {}>({}, {}_ap);\n'.format(dtype, i.type.name, i.size_cpp(), i.cppname, i.cppname)
                 newline += '\n'
-                
+
                 for o in model_outputs:
                     newline += indent + '{var};\n'.format(var=self.variable_definition_cpp(model, o, name_suffix='_ap'))
-                
+
                 newline += '\n'
 
                 input_size_vars = ','.join(['const_size_in_{}'.format(i) for i in range(1, len(model.get_input_variables()) + 1)])
                 output_size_vars = ','.join(['const_size_out_{}'.format(o) for o in range(1, len(model.get_output_variables()) + 1)])
                 input_vars = ','.join([i.cppname + '_ap' for i in model.get_input_variables()])
-                bram_vars   =','.join([b.cppname for b in model.get_bram_variables()]) 
+                bram_vars   =','.join([b.cppname for b in model.get_bram_variables()])
                 output_vars = ','.join([o.cppname + '_ap' for o in model.get_output_variables()])
-                
+
                 # Concatenate the input, output, and bram variables. Filter out empty/null values
                 all_vars = ','.join(filter(None, [input_vars, output_vars, bram_vars]))
 
@@ -546,7 +546,7 @@ class VivadoWriter(Writer):
                             vars = layer.get_variables()
                             for var in vars:
                                 newline += indent + 'nnet::trace_outputs->insert(std::pair<std::string, void *>("{}", (void *) malloc({} * element_size)));\n'.format(layer.name, var.size_cpp())
-                    
+
             else:
                 newline = line
             fout.write(newline)

--- a/test/pytest/test_inplace_variable.py
+++ b/test/pytest/test_inplace_variable.py
@@ -1,0 +1,23 @@
+""" Test that InplaceVariable is properly handled by optimizers.
+""" 
+
+import pytest
+import hls4ml
+import tensorflow as tf
+import numpy as np
+from tensorflow.keras import optimizers
+from tensorflow.keras.layers import Input, Dense, Reshape, Softmax
+
+
+def test_implicit():
+    model = tf.keras.models.Sequential([
+        tf.keras.layers.Input((10)),
+        tf.keras.layers.Dense(10*3),
+        tf.keras.layers.Reshape((10,3)),
+        tf.keras.layers.ReLU()
+    ])
+    model.compile(optimizer='adam', loss='mse')
+    config = hls4ml.utils.config_from_keras_model(model)
+    output_dir = 'hls4mlprj_inplace_variable'
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir)
+    hls_model.compile()


### PR DESCRIPTION
This pull request fixes the reference of an `InplaceVariable` when optimizers remove the reference. It was reported in Issue #263.

The solution adds an `update_inplace_variables` member function to Layers, with the default implementation being just `pass`. If a layer does have an `InplaceVariable`, however, it must update the reference. Such a function is implemented for the `Reshape` layer.

The added pytest fails in the current main branch, but succeeds with this fix.