### PR TITLE
Remove InplaceVariables and the problems they cause

### DIFF
--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -194,23 +194,6 @@ class StreamVariable(Variable):
     def size_cpp(self):
         return '*'.join([str(k) for k in self.dim_names])
 
-class InplaceVariable():
-    def __init__(self, shape, dim_names, proxy, **kwargs):
-        self.shape = shape
-        self.dim_names = dim_names
-        self.type = proxy.type
-        self.name = proxy.name
-        self.size = proxy.size
-
-    def get_shape(self):
-        return zip(self.dim_names, self.shape)
-
-    def definition_cpp(self):
-        return None
-
-    def size_cpp(self):
-        return '*'.join([str(k) for k in self.dim_names])
-
 class WeightVariable(Variable):
     def __init__(self, var_name, type_name, precision, data, quantizer=None, **kwargs):
         super(WeightVariable, self).__init__(var_name, HLSType(type_name, precision, **kwargs), **kwargs)
@@ -586,18 +569,14 @@ class Reshape(Layer):
             shape = shape[1:]
         dims = ['N_SIZE_{}_{}'.format(i, self.index) for i in range(1, len(shape) + 1)]
 
-        out_name = self.outputs[0]
-        proxy = self.get_input_variable()
-        out = InplaceVariable(shape, dims, proxy, index=self.get_input_node().index)
-
-        self.variables[out_name] = out
-        self.model.register_output_variable(out_name, out)
+        self.add_output_variable(shape, dims)
 
     def function_cpp(self):
-        return None
+        raise Exception('Layer {} should not be exported to HLS'.format(self.__class__.__name__))
 
     def config_cpp(self):
-        return None
+        raise Exception('Layer {} should not be exported to HLS'.format(self.__class__.__name__))
+
 
 class Dense(Layer):
     def initialize(self):

--- a/test/pytest/test_reshape.py
+++ b/test/pytest/test_reshape.py
@@ -1,0 +1,36 @@
+""" Test that reshape is properly handled by optimizers.
+"""
+
+import pytest
+import hls4ml
+import tensorflow as tf
+import numpy as np
+from tensorflow.keras import optimizers
+from tensorflow.keras.layers import Input, Dense, Reshape, Softmax
+
+
+def test_reshape_parallel():
+    model = tf.keras.models.Sequential([
+        tf.keras.layers.Input((10)),
+        tf.keras.layers.Dense(10*3),
+        tf.keras.layers.Reshape((10,3)),
+        tf.keras.layers.ReLU()
+    ])
+    model.compile(optimizer='adam', loss='mse')
+    config = hls4ml.utils.config_from_keras_model(model)
+    output_dir = 'hls4mlprj_reshape_parallel'
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir)
+    hls_model.compile()
+
+def test_reshape_stream():
+    model = tf.keras.models.Sequential([
+        tf.keras.layers.Input((10)),
+        tf.keras.layers.Dense(10*3),
+        tf.keras.layers.Reshape((10,3)),
+        tf.keras.layers.ReLU()
+    ])
+    model.compile(optimizer='adam', loss='mse')
+    config = hls4ml.utils.config_from_keras_model(model)
+    output_dir = 'hls4mlprj_reshape_stream'
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir, io_type='io_stream')
+    hls_model.compile()


### PR DESCRIPTION
This attempts to fix the problem that removing nodes can cause to `InplaceVariable`s by removing `InplaceVariable`s altogether. These variables are only used for the `Reshape` layar. In `io_stream` we already replace `Reshape` nodes with `Repack` nodes; this pull request additionally removes those nodes in `io_parallel` (and flatten), changing the shape of the preceding variable. (We may want to rename the `ReshapeStream` optimizer pass to reflect on the additional duties it performs.)

I added a basic test, though it does not test the flatten case.

@vloncar, is this the direction we should go?