### PR TITLE
Raise runtime error when a layer is named `input`

### DIFF
--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -38,6 +38,9 @@ class Layer(object):
         return all_attributes
 
     def __init__(self, model, name, attributes, inputs, outputs=None):
+        if name == 'input':
+            raise RuntimeError("No model layer should be named 'input' because that is a reserved;" + \
+                               "layer name in ModelGraph; Please rename the layer in your model")
         self.model = model
         self.name = name
         self.index = model.next_layer()


### PR DESCRIPTION
- Raise runtime error when a layer is named `input` because it is a reserved layer name in `HLSModel`

Resolves #442 and many other similar situations