### PR TITLE
Use correct number of args for multiple outputs

### DIFF
--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -658,16 +658,20 @@ class ModelGraph(object):
                 argtuple += predictions
                 argtuple = tuple(argtuple)
                 top_function(*argtuple)
-                output.extend(predictions)
+                output.append(predictions)
 
 
-            #Convert to numpy array
-            output = [np.asarray(output_i) for output_i in output]
+            # Convert to list of numpy arrays (one for each output)
+            output = [np.asarray([output[i_sample][i_output] for i_sample in range(n_samples)]) for i_output in range(n_outputs)]
         finally:
             os.chdir(curr_dir)
-
-        if n_samples == 1:
+            
+        if n_samples == 1 and n_outputs == 1:
+            return output[0][0]
+        elif n_outputs == 1:
             return output[0]
+        elif n_samples == 1:
+            return [output_i[0] for output_i in output]
         else:
             return output
 

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -658,11 +658,11 @@ class ModelGraph(object):
                 argtuple += predictions
                 argtuple = tuple(argtuple)
                 top_function(*argtuple)
-                output.append(predictions)
+                output.extend(predictions)
 
 
             #Convert to numpy array
-            output = np.asarray(output, dtype=object)
+            output = [np.asarray(output_i) for output_i in output]
         finally:
             os.chdir(curr_dir)
 

--- a/test/pytest/test_graph.py
+++ b/test/pytest/test_graph.py
@@ -175,3 +175,31 @@ def test_broadcast_stream(shapes, layer):
   y = model.predict([X1, X2])
   y_hls = hls_model.predict([X1, X2]).reshape(y.shape)
   np.testing.assert_allclose(y, y_hls, rtol=0)
+
+@pytest.mark.parametrize('batch', [1, 32])
+def test_multiple_outputs(batch):
+  ''' Test case for multple outputs '''
+  input1 = tf.keras.layers.Input(shape=(10,))
+  inputs = [input1]
+  output1 = tf.keras.layers.Dense(5, kernel_initializer='ones', use_bias=False)(input1)
+  output2 = tf.keras.layers.Dense(2, kernel_initializer='ones', use_bias=False)(input1)
+  outputs = [output1, output2]
+  model = tf.keras.models.Model(inputs=inputs, outputs=outputs)
+
+  # create the ModelGraph
+  config = hls4ml.utils.config_from_keras_model(model, granularity='model', default_precision='ap_fixed<32,16>')
+  odir = str(test_root_path / 'hls4mlprj_graph_multiple_outputs')
+  hls_model = hls4ml.converters.convert_from_keras_model(model,
+                                                         output_dir=odir,
+                                                         backend='Vivado',
+                                                         io_type='io_serial',
+                                                         hls_config=config)
+  hls_model.compile()
+
+  # Test with integers (for exact agreement)
+  X1 = np.random.randint(0, 100, size=(batch, 10)).astype(float)
+  y = model.predict(X1)
+  y_hls = hls_model.predict(X1)
+  for y_i, y_hls_i in zip(y, y_hls):
+    y_hls_i = y_hls_i.reshape(y_i.shape)
+    np.testing.assert_allclose(y_i, y_hls_i, rtol=0)


### PR DESCRIPTION
The arguments set for `top_function` assumed there could be multiple inputs but *only one* output. If there were multiple outputs, the `argtuple` did not match the parameters in the generated HLS function, and caused a seg fault when calling `predict()`.