### PR TITLE
Copy flows from config

### DIFF
--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -143,6 +143,9 @@ def _check_hls_config(config, hls_config):
     if 'LayerType' in hls_config:
         config['HLSConfig']['LayerType'] = hls_config['LayerType']
 
+    if 'Flows' in hls_config:
+        config['HLSConfig']['Flows'] = hls_config['Flows']
+
     if 'Optimizers' in hls_config:
         config['HLSConfig']['Optimizers'] = hls_config['Optimizers']
 


### PR DESCRIPTION
The `convert_from_{keras,pytorch,onnx}_model` methods call `_check_hls_config` which copy the expected fields from the user config to the one propagated to `{keras,pytorch,onnx}_to_hls`. At the moment `Flows` is not copied across, so the user configurability is lost. This PR restores that.