### PR TITLE
Add QKeras as a package dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     docker {
-      image 'vivado-el7:1'
+      image 'vivado-el7:2'
       args  '-v /data/Xilinx:/data/Xilinx'
     }
   }
@@ -14,7 +14,7 @@ pipeline {
       steps {
         dir(path: 'test') {
           sh '''#!/bin/bash --login
-              conda activate hls4ml-py36
+              conda activate hls4ml-py37
               pip install tensorflow
               pip install -U ../ --user
               ./convert-keras-models.sh -x -f keras-models.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@ pipeline {
           sh '''#!/bin/bash --login
               conda activate hls4ml-py36
               pip install tensorflow
-              pip install git+git://github.com/google/qkeras.git@v0.8.0#egg=qkeras
               pip install -U ../ --user
               ./convert-keras-models.sh -x -f keras-models.txt
               pip uninstall hls4ml -y'''

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -18,6 +18,9 @@ http://www.h5py.org
 
 https://pypi.python.org/pypi/PyYAML 
 
+**QKeras**\ : for working with quantized models 
+
+https://github.com/google/qkeras
 
 **PyTorch**\ : for reading in Torch models
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [metadata]
 description-file = README.md
 
+[options]
+python_requires = >=3.7
+
 [options.entry_points]
 pytest_randomly.random_seeder =
     hls4ml = hls4ml:reseed

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(name='hls4ml',
           'h5py',
           'onnx>=1.4.0',
           'calmjs.parse',
-          'tabulate'
+          'tabulate',
+          'qkeras',
       ],
       extras_require={
         'profiling': [


### PR DESCRIPTION
So far we have avoided requiring QKeras installation and tried to only load it if available. The reasons for this are long gone now, and much of the advanced functionality is not available without QKeras, so we should make it a hard dependency. Since it will be installed by pip alongside hls4ml, the impact on users should be minimal. As for "why now?", well, GitHub changed the checkout policy for unauthenticated git access which broke Jenkins tests. While the fix for that particular issue is trivial it reveals that the current code-base simply doesn't work without QKeras, so instead of maintaining this feature of QKeras being optional, we should make sure it is installed in the first place. 