### PR TITLE
Extension API

### DIFF
--- a/hls4ml/backends/backend.py
+++ b/hls4ml/backends/backend.py
@@ -43,21 +43,58 @@ class Backend(object):
         return [name for name in get_backend_passes(self.name) if isinstance(get_optimizer(name), Template)]
 
     def create_initial_config(self, **kwargs):
+        """Create the minimal conversion config for the backend.
+
+        Subclasses should implement this method to provide the initial configuration for the conversion.
+        """
         raise NotImplementedError
 
     def create_layer_class(self, layer_class):
+        """Wrap the original layer class into the backend-specific layer class.
+
+        Backends should extend base layer classes with new attributes and variables as needed. These new classes are then
+        used within the model.
+
+        Args:
+            layer_class (class): Base class to extend
+        """
         raise NotImplementedError
 
     def get_available_flows(self):
+        """Returns the list of flows registered for this backend.
+
+        Returns:
+            list: The list of registered flows.
+        """
         return get_backend_flows(self.name)
 
     def get_default_flow(self):
+        """The name of the default flow of the backend.
+
+        Default flow is used as the conversion target if the target flow has not been specified.
+        """
         raise NotImplementedError
 
     def get_custom_source(self):
+        """Returns the registered custom source files.
+
+        Returns:
+            dict: Custom source files. Keys represent destination paths, values are absolute paths to registered source
+                files.
+        """
         return self.custom_source
 
     def register_source(self, source_file, destination_dir='nnet_utils'):
+        """Register custom source that is not part of the backend's templates.
+
+        Args:
+            source_file (str or Path): Absolute path to the source file.
+            destination_dir (str, optional): The sub-directory of the output project to write the source file to.
+                Defaults to 'nnet_utils'.
+
+        Raises:
+            Exception: If the source file is not a str or Path, or if the path is not absolute
+        """
         if isinstance(source_file, str):
             if not os.path.isabs(source_file):
                 raise Exception(f'Expected absolute path to custom source file, got: "{source_file}"')
@@ -66,10 +103,19 @@ class Backend(object):
             source_path = source_file
         else:
             raise Exception(f'Expected string or Path, got: "{type(source_file)}"')
-        
+
         self.custom_source[destination_dir + os.path.sep + source_path.name] = source_path
 
     def register_pass(self, name, opt_cls, flow=None):
+        """Register an optimizer path for the backend.
+
+        Note that user-provided optimizers registered without specifying any flow will not be invoked.
+
+        Args:
+            name (str): Name of the optimizer
+            opt_cls (class): Optimizer class
+            flow (str, list or tuple, optional): Existing flow(s) to add the optimizer to. Defaults to None.
+        """
         opt_name = register_pass(name, opt_cls, backend=self.name)
         if flow is not None:
             if not isinstance(flow, (list, tuple)):
@@ -79,6 +125,13 @@ class Backend(object):
                 update_flow(f, add_optimizers=[opt_name])
 
     def register_template(self, template_cls):
+        """Register a template "optimizer".
+
+        E.g., function call template or op configuration template.
+
+        Args:
+            template_cls (class): Template to register.
+        """
         template = template_cls()
         register_pass(template.get_name(), template, backend=self.name)
 
@@ -86,6 +139,15 @@ class Backend(object):
 backend_map = {}
 
 def register_backend(name, backend_cls):
+    """Create the backend instance and add it to the registry.
+
+    Args:
+        name (str): Name of the backend.
+        backend_cls (class): Backend class to instantiate. Class must implement a constructor without parameters.
+
+    Raises:
+        Exception: If the backend has already been registered.
+    """
     if name.lower() in backend_map:
         raise Exception('Backend {} already registered'.format(name))
 

--- a/hls4ml/backends/fpga/fpga_backend.py
+++ b/hls4ml/backends/fpga/fpga_backend.py
@@ -33,6 +33,17 @@ class FPGABackend(Backend):
         return type(self.name + layer_class.__name__, (layer_class,), {'_expected_attributes': new_attrubutes, '_wrapped': True})
 
     def compile(self, model):
+        """Compile the generated project that can be linked into Python runtime.
+
+        Args:
+            model (ModelGraph): Model to compile.
+
+        Raises:
+            Exception: If the project failed to compile
+
+        Returns:
+            string: Returns the name of the compiled library.
+        """        
         curr_dir = os.getcwd()
         os.chdir(model.config.get_output_dir())
 
@@ -52,6 +63,9 @@ class FPGABackend(Backend):
 
         This function converts the model to C++ and writes the generated files in the output
         directory specified in the `config`.
+
+        Args:
+            model (ModelGraph): Model to write.
         """
 
         model.apply_flow(self.get_writer_flow())

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -55,7 +55,7 @@ class VivadoBackend(FPGABackend):
         vivado_types_flow = register_flow('specific_types', vivado_types, requires=[init_flow], backend=self.name)
 
         templates = self._get_layer_templates()
-        template_flow = register_flow('apply_templates', templates, requires=[init_flow], backend=self.name)
+        template_flow = register_flow('apply_templates', self._get_layer_templates, requires=[init_flow], backend=self.name)
 
         writer_passes = [
             'vivado:write_hls'

--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -88,11 +88,23 @@ def get_qkeras_quantization(layer, keras_layer):
 
 layer_handlers = {}
 
-def register_keras_layer_handler(layer_name, handler_func):
-    if layer_name in layer_handlers:
-        raise Exception('Layer {} already registered'.format(layer_name))
+def register_keras_layer_handler(layer_cname, handler_func):
+    """Register a handler function for the given layer class name.
+
+    The handler function should have the following signature:
+        parse_func(keras_layer, input_names, input_shapes, data_reader, config):
+
+    Args:
+        layer_cname (str): The name of Keras layer (the 'class_name' property in the layer's config)
+        handler_func (callable): The handler function
+
+    Raises:
+        Exception: If the layer class has already been registered.
+    """    
+    if layer_cname in layer_handlers:
+        raise Exception('Layer {} already registered'.format(layer_cname))
     else:
-        layer_handlers[layer_name] = handler_func
+        layer_handlers[layer_cname] = handler_func
 
 def get_supported_keras_layers():
     return list(layer_handlers.keys())

--- a/hls4ml/model/flow/__init__.py
+++ b/hls4ml/model/flow/__init__.py
@@ -1,1 +1,1 @@
-from hls4ml.model.flow.flow import get_available_flows, get_flow, get_backend_flows, register_flow, Flow
+from hls4ml.model.flow.flow import get_available_flows, get_flow, get_backend_flows, register_flow, update_flow, Flow

--- a/hls4ml/model/flow/flow.py
+++ b/hls4ml/model/flow/flow.py
@@ -3,13 +3,47 @@ class Flow(object):
     def __init__(self, name, optimizers, requires=None):
         self.name = name
         if optimizers is None:
-            self.optimizers = []
+            self._optimizers = []
         else:
-            self.optimizers = optimizers
+            self._optimizers = optimizers
         if requires is None:
             self.requires = []
         else:
             self.requires = requires
+
+    @property
+    def optimizers(self):
+        return self._optimizers
+    
+    def _add_optimizer(self, opt_name):
+        self._optimizers.append(opt_name)
+
+    def _remove_optimizer(self, opt_name):
+        self._optimizers.remove(opt_name)
+
+class DynamicFlow(Flow):
+    def __init__(self, name, optimizer_func, requires=None):
+        self.name = name
+        self._optimizer_func = optimizer_func
+        self._added_optimizers = set()
+        self._removed_optimizers = set()
+        if requires is None:
+            self.requires = []
+        else:
+            self.requires = requires
+
+    @property
+    def optimizers(self):
+        optimizers = self._optimizer_func()
+        optimizers.extend(self._added_optimizers)
+        optimizers = [o for o in optimizers if o not in self._removed_optimizers]
+        return optimizers
+    
+    def _add_optimizer(self, opt_name):
+        self._added_optimizers.put(opt_name)
+
+    def _remove_optimizer(self, opt_name):
+        self._removed_optimizers.put(opt_name)
 
 flow_map = {}
 
@@ -25,9 +59,24 @@ def register_flow(name, optimizers, requires=None, backend=None):
     if name in flow_map:
         raise Exception('Flow {} already registered'.format(name))
 
-    flow_map[name] = Flow(name, optimizers, requires)
+    if callable(optimizers):
+        flow = DynamicFlow(name, optimizer_func=optimizers, requires=requires)
+    else:
+        flow = Flow(name, optimizers=optimizers, requires=requires)
+
+    flow_map[name] = flow
 
     return name
+
+def update_flow(flow_name, add_optimizers=None, remove_optimizers=None):
+    flow = get_flow(flow_name)
+    if add_optimizers is not None:
+        for opt in add_optimizers:
+            flow._add_optimizer(opt)
+
+    if remove_optimizers is not None:
+        for opt in remove_optimizers:
+            flow._remove_optimizer(opt)
 
 def get_flow(name):
     if name in flow_map:

--- a/hls4ml/model/flow/flow.py
+++ b/hls4ml/model/flow/flow.py
@@ -1,6 +1,14 @@
 
 class Flow(object):
+    """This class represents a collection of optimizers. The flow can optionally depend on other flows."""    
     def __init__(self, name, optimizers, requires=None):
+        """Creates a new flow.
+
+        Args:
+            name (str): Unique name of the flow.
+            optimizers (list, optional): List of optimizers.
+            requires (list, optional): List (str) of flows which have to be applied before this flow. Defaults to None.
+        """        
         self.name = name
         if optimizers is None:
             self._optimizers = []
@@ -22,7 +30,20 @@ class Flow(object):
         self._optimizers.remove(opt_name)
 
 class DynamicFlow(Flow):
+    """A dynamically updated flow.
+    
+    This flow will get the list of optimizers by calling optimizer_func. Useful to represent a view of all available
+    optimizers of a certain type.
+    """
+
     def __init__(self, name, optimizer_func, requires=None):
+        """Creates a new dynamic flow.
+
+        Args:
+            name (str): Unique name of the flow.
+            optimizer_func (callable): Function to call (without arguments) to get the list of optimizers.
+            requires (_type_, optional): List (str) of flows which have to be applied before this flow. Defaults to None.
+        """        
         self.name = name
         self._optimizer_func = optimizer_func
         self._added_optimizers = set()
@@ -54,6 +75,21 @@ def _get_backend_name_prefix(name, backend):
     return name
 
 def register_flow(name, optimizers, requires=None, backend=None):
+    """Create a flow and add it to the registry.
+
+    Args:
+        name (str): _description_
+        optimizers (list): List of optimizers.
+        requires (list, optional): List (str) of flows which have to be applied before this flow. Defaults to None.
+        backend (str, optional): Backend to which the flow will belong. If not None, the name of the backend will be
+            appended to the name of the registered flow. Defaults to None.
+
+    Raises:
+        Exception: If the flow has already been registered.
+
+    Returns:
+        str: The name of the registered flow.
+    """    
     name = _get_backend_name_prefix(name, backend)
 
     if name in flow_map:
@@ -69,6 +105,13 @@ def register_flow(name, optimizers, requires=None, backend=None):
     return name
 
 def update_flow(flow_name, add_optimizers=None, remove_optimizers=None):
+    """Add or remove optimizers to/from an existing flow.
+
+    Args:
+        flow_name (str): The name of the flow to update.
+        add_optimizers (list, optional): List (str) of optimizers to add. Defaults to None.
+        remove_optimizers (list, optional): List (str) of optimizers to remove. Defaults to None.
+    """    
     flow = get_flow(flow_name)
     if add_optimizers is not None:
         for opt in add_optimizers:

--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -9,6 +9,7 @@ import glob
 from collections import OrderedDict
 
 from hls4ml.writer.writers import Writer
+from hls4ml.backends import get_backend
 
 config_filename = 'hls4ml_config.yml'
 
@@ -458,6 +459,17 @@ class QuartusWriter(Writer):
             rmtree(dstpath)
 
         copytree(srcpath, dstpath)
+
+        ###################
+        ## custom source
+        ###################
+
+        filedir = os.path.dirname(os.path.abspath(__file__))
+
+        custom_source = get_backend('Quartus').get_custom_source()
+        for dst, srcpath in custom_source.items():
+            dstpath = '{}/firmware/{}'.format(model.config.get_output_dir(), dst)
+            copyfile(srcpath, dstpath)
 
     def write_activation_tables(self, model):
 

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -9,6 +9,7 @@ import glob
 from collections import OrderedDict
 
 from hls4ml.writer.writers import Writer
+from hls4ml.backends import get_backend
 
 config_filename = 'hls4ml_config.yml'
 
@@ -606,6 +607,17 @@ class VivadoWriter(Writer):
             rmtree(dstpath)
 
         copytree(srcpath, dstpath)
+
+        ###################
+        ## custom source
+        ###################
+
+        filedir = os.path.dirname(os.path.abspath(__file__))
+
+        custom_source = get_backend('Vivado').get_custom_source()
+        for dst, srcpath in custom_source.items():
+            dstpath = '{}/firmware/{}'.format(model.config.get_output_dir(), dst)
+            copyfile(srcpath, dstpath)
 
     def write_yml(self, model):
         ###################

--- a/test/pytest/test_extensions.py
+++ b/test/pytest/test_extensions.py
@@ -1,0 +1,162 @@
+import hls4ml
+import tensorflow as tf
+import numpy as np
+import pytest
+from pathlib import Path
+
+test_root_path = Path(__file__).parent
+
+# Keras implementation of a custom layer
+
+class KReverse(tf.keras.layers.Layer):
+    ''' Keras implementation of a hypothetical custom layer '''
+    def __init__(self):
+        super(KReverse, self).__init__()
+
+    def call(self, inputs):
+        return tf.reverse(inputs, axis=[-1])
+
+# hls4ml implementations
+
+class HReverse(hls4ml.model.layers.Layer):
+    ''' hls4ml implementation of a hypothetical custom layer '''
+
+    def initialize(self):
+        inp = self.get_input_variable()
+        shape = inp.shape
+        dims = inp.dim_names
+        self.add_output_variable(shape, dims)
+
+
+# Templates
+
+rev_config_template = """struct config{index} : nnet::reverse_config {{
+    static const unsigned n_in = {n_in};
+}};\n"""
+
+rev_function_template = 'nnet::reverse<{input_t}, {config}>({input}, {output});'
+rev_include_list = ['nnet_utils/nnet_reverse.h']
+
+class HReverseConfigTemplate(hls4ml.backends.template.LayerConfigTemplate):
+    def __init__(self):
+        super().__init__(HReverse)
+        self.template = rev_config_template
+    
+    def format(self, node):
+        params = self._default_config_params(node)        
+        return self.template.format(**params)
+
+class HReverseFunctionTemplate(hls4ml.backends.template.FunctionCallTemplate):
+    def __init__(self):
+        super().__init__(HReverse, include_header=rev_include_list)
+        self.template = rev_function_template
+    
+    def format(self, node):
+        params = self._default_function_params(node)
+        return self.template.format(**params)
+
+
+# HLS implementation
+rev_hls = \
+"""#ifndef NNET_REVERSE_H_
+#define NNET_REVERSE_H_
+
+#include "nnet_common.h"
+
+namespace nnet {
+
+struct reverse_config {
+    static const unsigned n_in = 10;
+};
+
+template<class data_T, typename CONFIG_T>
+void reverse(
+    data_T input[CONFIG_T::n_in],
+    data_T reversed[CONFIG_T::n_in]
+) {
+    #pragma HLS PIPELINE
+
+    for (int i = 0; i < CONFIG_T::n_in; i++) {
+        reversed[CONFIG_T::n_in - 1 - i] = input[i];
+    }
+}
+
+}
+
+#endif
+"""
+
+class RemoveDuplicateReverse(hls4ml.model.optimizer.OptimizerPass):
+    '''OptimizerPass to remove consecutive HReverse layers.'''
+
+    def match(self, node):
+        return isinstance(node, HReverse) and \
+               isinstance(node.get_input_node(), HReverse)
+
+    def transform(self, model, node):
+        first = node.get_input_node()
+        second = node
+
+        model.remove_node(first, rewire=True)
+        model.remove_node(second, rewire=True)
+        return True
+
+# Parser for converter
+def parse_reverse_layer(keras_layer, input_names, input_shapes, data_reader, config):
+    layer = {}
+    layer['class_name'] = 'HReverse'
+    layer['name'] = keras_layer['config']['name']
+    layer['n_in'] = input_shapes[0][1]
+    
+    if input_names is not None:
+        layer['inputs'] = input_names
+
+    return layer, [shape for shape in input_shapes[0]]
+
+def test_extensions(tmp_path):
+    # Register the converter for custom Keras layer
+    hls4ml.converters.register_keras_layer_handler('KReverse', parse_reverse_layer)
+
+    # Register the hls4ml's IR layer
+    hls4ml.model.layers.register_layer('HReverse', HReverse)
+
+    # Register the optimization passes (if any)
+    backend = hls4ml.backends.get_backend('Vivado')
+    backend.register_pass('remove_duplicate_reverse', RemoveDuplicateReverse, flow='vivado:optimize')
+
+    # Register template passes for the given backend
+    backend.register_template(HReverseConfigTemplate)
+    backend.register_template(HReverseFunctionTemplate)
+
+    # Register HLS implementation
+    p = tmp_path / 'nnet_reverse.h'
+    p.write_text(rev_hls)
+    backend.register_source(p)
+
+    # Test if it works
+    kmodel = tf.keras.models.Sequential([
+        tf.keras.layers.Input(shape=(8,)),
+        KReverse(),
+        tf.keras.layers.ReLU(),
+        # These two should be removed by the optimizer
+        KReverse(),
+        KReverse(),
+    ])
+
+    x = np.random.randint(-5, 5, (8,), dtype='int32')
+    kres = kmodel(x)
+
+    hmodel = hls4ml.converters.convert_from_keras_model(
+        kmodel,
+        output_dir=str(test_root_path / 'hls4mlprj_extensions'),
+        backend='Vivado',
+        io_type='io_parallel',
+        hls_config={ 'Model': { 'Precision': 'ap_int<4>', 'ReuseFactor': 1} })
+
+    hmodel.compile()
+    hres = hmodel.predict(x.astype('float32'))
+
+    # Check if the optimizer pass was applied
+    assert 'vivado:remove_duplicate_reverse' in hmodel._applied_flows[0]['vivado:optimize']
+
+    np.testing.assert_array_equal(kres, hres)


### PR DESCRIPTION
One of the pitfalls of using hls4ml with new applications is that there is little support for extending hls4ml with custom objects (layers, hls code, optimizers etc). This forces people to create forks and make changes there. These forks often include useful bugfixes and improvements that never go back into the main branch. As a result, we often fix bugs multiple times across different branches. If the core is extendable, there is no need for forks, and bugfixes can be applied once, on the main branch, and we wouldn't waste effort.

This PR extends the core with a few missing features and documents the extension points in depth. It is not the end of extension API, just the beginning, but it should be enough so that most of the new applications targeting existing features don't need to fork.

The included test case demonstrates a flow of extending hls4ml to support a custom Keras layer. 