### PR TITLE
Ensure 2 bits for scale in po2 quantizers

### DIFF
--- a/hls4ml/model/optimizer/passes/qkeras.py
+++ b/hls4ml/model/optimizer/passes/qkeras.py
@@ -179,7 +179,7 @@ class QKerasFactorizeAlpha(OptimizerPass):
 
         # insert a Batch Normalization layer to apply the alpha scale
         if alpha == 'auto_po2':
-            scale_bits = np.abs(np.log2(scale)).max().astype('int') + 1
+            scale_bits = np.maximum(np.abs(np.log2(scale)).max().astype('int') + 1, 2)
             scale_quantizer = QKerasPO2Quantizer({'class_name' : 'quantized_po2', 'config': {'bits': scale_bits}})
         else:
             scale_quantizer = None


### PR DESCRIPTION
In a corner-case of using `alpha=auto_po2` the computed number of bits for scale can be 1. This results in a creation of a 1-bit signed type (e.g., `ap_int<1>`). While Vivado compiler will still work with this type, on Quartus side the `ac_int<1>` will fail compilation. This change ensures that at least 2 bits are reserved for scale, avoiding the problem.