### PR TITLE
Make the size of bn scale and bias what they really are

### DIFF
--- a/hls4ml/backends/vivado/passes/core_templates.py
+++ b/hls4ml/backends/vivado/passes/core_templates.py
@@ -57,7 +57,7 @@ class DenseFunctionTemplate(FunctionCallTemplate):
 batchnorm_config_template = """struct config{index} : nnet::batchnorm_config {{
     static const unsigned n_in = {n_in};
     static const unsigned n_filt = {n_filt};
-    static const unsigned n_scale_bias = {n_scale_bias};
+    static const unsigned n_scale_bias = (n_filt == -1) ? n_in : n_filt;
     static const unsigned io_type = nnet::{iotype};
     static const unsigned reuse_factor = {reuse};
     static const bool store_weights_in_bram = false;
@@ -79,7 +79,6 @@ class BatchNormalizationConfigTemplate(LayerConfigTemplate):
     def format(self, node):
         params = self._default_config_params(node)
         params['n_in'] = node.get_input_variable().size_cpp()
-        params['n_scale_bias'] = params['n_in'] if params['n_filt'] == -1 else params['n_filt']
         params['product_type'] = get_backend('vivado').product_type(node.get_input_variable().type.precision, node.get_weights('scale').type.precision)
 
         return self.template.format(**params)

--- a/hls4ml/backends/vivado/passes/core_templates.py
+++ b/hls4ml/backends/vivado/passes/core_templates.py
@@ -57,6 +57,7 @@ class DenseFunctionTemplate(FunctionCallTemplate):
 batchnorm_config_template = """struct config{index} : nnet::batchnorm_config {{
     static const unsigned n_in = {n_in};
     static const unsigned n_filt = {n_filt};
+    static const unsigned n_scale_bias = {n_scale_bias};
     static const unsigned io_type = nnet::{iotype};
     static const unsigned reuse_factor = {reuse};
     static const bool store_weights_in_bram = false;
@@ -78,6 +79,7 @@ class BatchNormalizationConfigTemplate(LayerConfigTemplate):
     def format(self, node):
         params = self._default_config_params(node)
         params['n_in'] = node.get_input_variable().size_cpp()
+        params['n_scale_bias'] = params['n_in'] if params['n_filt'] == -1 else params['n_filt']
         params['product_type'] = get_backend('vivado').product_type(node.get_input_variable().type.precision, node.get_weights('scale').type.precision)
 
         return self.template.format(**params)

--- a/hls4ml/backends/vivado/passes/quantization_templates.py
+++ b/hls4ml/backends/vivado/passes/quantization_templates.py
@@ -11,7 +11,6 @@ class ApplyAlphaConfigTemplate(LayerConfigTemplate):
     def format(self, node):
         params = self._default_config_params(node)
         params['n_in'] = node.get_input_variable().size_cpp()
-        params['n_scale_bias'] = params['n_in'] if params['n_filt'] == -1 else params['n_filt']
         params['product_type'] = get_backend('vivado').product_type(node.get_input_variable().type.precision, node.get_weights('scale').type.precision)
 
         return self.template.format(**params)

--- a/hls4ml/backends/vivado/passes/quantization_templates.py
+++ b/hls4ml/backends/vivado/passes/quantization_templates.py
@@ -11,6 +11,7 @@ class ApplyAlphaConfigTemplate(LayerConfigTemplate):
     def format(self, node):
         params = self._default_config_params(node)
         params['n_in'] = node.get_input_variable().size_cpp()
+        params['n_scale_bias'] = params['n_in'] if params['n_filt'] == -1 else params['n_filt']
         params['product_type'] = get_backend('vivado').product_type(node.get_input_variable().type.precision, node.get_weights('scale').type.precision)
 
         return self.template.format(**params)

--- a/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm.h
@@ -36,6 +36,7 @@ struct batchnorm_config
     // Layer Sizes
     static const unsigned n_in = 10;
     static const unsigned n_filt = -1;
+    static const unsigned n_scale_bias = 10;
     
     // Resource reuse info
     static const unsigned io_type = io_parallel;
@@ -51,8 +52,8 @@ template<class data_T, class res_T, typename CONFIG_T>
 void normalize(
     data_T    data[CONFIG_T::n_in],
     res_T     res[CONFIG_T::n_in],
-    typename CONFIG_T::scale_t  scale[CONFIG_T::n_in],
-    typename CONFIG_T::bias_t   bias[CONFIG_T::n_in]
+    typename CONFIG_T::scale_t  scale[CONFIG_T::n_scale_bias],
+    typename CONFIG_T::bias_t   bias[CONFIG_T::n_scale_bias]
 )
 {
     data_T cache;

--- a/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm_stream.h
@@ -35,8 +35,8 @@ template<class data_T, class res_T, typename CONFIG_T>
 void normalize(
     hls::stream<data_T> &data,
     hls::stream<res_T>  &res,
-    typename CONFIG_T::scale_t scale[CONFIG_T::n_in],
-    typename CONFIG_T::bias_t  bias[CONFIG_T::n_in]
+    typename CONFIG_T::scale_t scale[CONFIG_T::n_scale_bias],
+    typename CONFIG_T::bias_t  bias[CONFIG_T::n_scale_bias]
 ) {
     #pragma HLS ARRAY_PARTITION variable=scale complete
     #pragma HLS ARRAY_PARTITION variable=bias complete


### PR DESCRIPTION
As discussed in issue #497, the normalize scale and bias are declared too large in the case when `n_filt != -1`, which sometimes affects syntesizability.  This PR declares them to be the needed size.