### PR TITLE
fix insertion before a node with multiple inputs + support additional broadcasting

### DIFF
--- a/hls4ml/backends/vivado/passes/repack_stream.py
+++ b/hls4ml/backends/vivado/passes/repack_stream.py
@@ -44,8 +44,10 @@ broadcast_function_template = 'nnet::broadcast_stream<{input_t}, {output_t}, {co
 broadcast_config_template = """struct config{index} : nnet::broadcast_config {{
     static const unsigned in_width = {in_width};
     static const unsigned in_height = {in_height};
-    static const unsigned n_chan = {n_chan};
-    static const unsigned n_dupl = {n_dupl};
+    static const unsigned in_chan = {in_chan};
+    static const unsigned out_width = {out_width};
+    static const unsigned out_height = {out_height};
+    static const unsigned out_chan = {out_chan};
 }};\n"""
 broadcast_include_list = ['nnet_utils/nnet_stream.h']
 
@@ -58,8 +60,10 @@ class BroadcastConfigTemplate(LayerConfigTemplate):
         params = self._default_config_params(node)
         params['in_height'] = node.get_input_variable().shape[0]
         params['in_width'] = node.get_input_variable().shape[1]
-        params['n_chan'] = node.get_input_variable().shape[2]
-        params['n_dupl'] = int(np.prod(node.get_output_variable().shape) / np.prod(node.get_input_variable().shape))
+        params['in_chan'] = node.get_input_variable().shape[2]
+        params['out_height'] = node.get_output_variable().shape[0]
+        params['out_width'] = node.get_output_variable().shape[1]
+        params['out_chan'] = node.get_output_variable().shape[2]
 
         return self.template.format(**params)
 
@@ -120,20 +124,38 @@ class BroadcastStream(OptimizerPass):
         if model.config.backend.name not in ['Vivado'] or \
             model.config.get_config_value('IOType') != 'io_stream':
             return False
-            
-        inp1 = node.get_input_variable(node.inputs[0])
-        inp2 = node.get_input_variable(node.inputs[1])
-        if np.prod(inp1.shape) > np.prod(inp2.shape):
+
+        inp = [node.get_input_variable(inp_name) for inp_name in node.inputs]
+
+        if np.prod(inp[0].shape) > np.prod(inp[1].shape):
             idx = 1
             attrs = {
-                'target_shape': inp1.shape
+                'target_shape': inp[0].shape
             }
         else:
             idx = 0
             attrs = {
-                'target_shape': inp2.shape
+                'target_shape': inp[1].shape
             }
+
+        def supported_broadcast(inp_shape, target_shape):
+            # Must be (H, W, C)
+            if not len(inp_shape) == 3:
+                return False
+            # Supported: (1, 1, C) -> (H, W, C)
+            if inp_shape[0] == inp_shape[1] == 1 and inp_shape[2] == target_shape[2]:
+                return True
+            # Supported: (H, W, 1) -> (H, W, C)
+            if inp_shape[2] == 1 and inp_shape[0] == target_shape[0] and inp_shape[1] == target_shape[1]:
+                return True
+            return False
+
         brdcst_inp = node.inputs[idx]
+        inp_shape = node.get_input_variable(brdcst_inp).shape
+        target_shape = attrs['target_shape']
+        if not supported_broadcast(inp_shape, target_shape):
+            raise RuntimeError('Unsupported broadcast type for stream: {} -> {};'.format(inp_shape, target_shape) + \
+                               'Only (1, 1, C) -> (H, W, C) and (H, W, 1) -> (H, W, C) currently supported')
         brdcst_out = 'broadcast_' + brdcst_inp
         brdcst_layer = model.make_node('Broadcast', brdcst_out, attrs, [brdcst_inp].copy())
         model.insert_node(brdcst_layer, before=node, input_idx=idx)

--- a/hls4ml/backends/vivado/passes/repack_stream.py
+++ b/hls4ml/backends/vivado/passes/repack_stream.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from hls4ml.model.optimizer import OptimizerPass
-from hls4ml.model.layers import Layer, Merge, Reshape, register_layer
+from hls4ml.model.layers import Layer, Merge, Reshape, Concatenate, register_layer
 from hls4ml.backends import get_backend
 from hls4ml.backends.template import FunctionCallTemplate, LayerConfigTemplate
 
@@ -109,7 +109,7 @@ class ReshapeStream(OptimizerPass):
 
 class BroadcastStream(OptimizerPass):
     def match(self, node):
-        if isinstance(node, Merge):
+        if isinstance(node, Merge) and not isinstance(node, Concatenate):
             inp1 = node.get_input_variable(node.inputs[0])
             inp2 = node.get_input_variable(node.inputs[1])
             return inp1.shape != inp2.shape

--- a/hls4ml/backends/vivado/passes/repack_stream.py
+++ b/hls4ml/backends/vivado/passes/repack_stream.py
@@ -136,7 +136,7 @@ class BroadcastStream(OptimizerPass):
         brdcst_inp = node.inputs[idx]
         brdcst_out = 'broadcast_' + brdcst_inp
         brdcst_layer = model.make_node('Broadcast', brdcst_out, attrs, [brdcst_inp].copy())
-        model.insert_node(brdcst_layer)
+        model.insert_node(brdcst_layer, before=node, input_idx=idx)
         node.inputs[idx] = brdcst_out
 
         return True

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -395,7 +395,7 @@ class ModelGraph(object):
             self.output_vars[o] = out_var
         return node
 
-    def insert_node(self, node, before=None):
+    def insert_node(self, node, before=None, input_idx=0):
         """ Insert a new node into the model graph.
 
         The node to be inserted should be created with `make_node()` function. The optional 
@@ -405,6 +405,7 @@ class ModelGraph(object):
             node (Layer): Node to insert
             before (Layer, optional): The next node in sequence before which a
                 new node should be inserted. 
+           input_idx (int, optional): If the next node takes multiple inputs, the input index
         Raises:
             Exception: If an attempt to insert a node with multiple inputs is made or if
                 `before` does not specify a correct node in sequence.
@@ -414,7 +415,12 @@ class ModelGraph(object):
             raise Exception('Cannot insert a node with more than one input (for now).')
 
         prev_node = node.get_input_node(node.inputs[0])
-        next_nodes = [x for x in self.graph.values() if x.inputs[0] in prev_node.outputs]
+        next_nodes = []
+        for x in self.graph.values():
+            overlap = [value for value in x.inputs if value in prev_node.outputs]
+            if overlap: 
+                next_nodes.append(x)
+
         if before is None:
             next_node = next((x for x in self.graph.values() if x.inputs[0] in prev_node.outputs), None)
         else:
@@ -423,7 +429,7 @@ class ModelGraph(object):
             next_node = before
 
         if next_node is not None:
-            next_node.inputs[0] = node.outputs[0]
+            next_node.inputs[input_idx] = node.outputs[0]
 
         new_graph = OrderedDict()
         for k, v in self.graph.items():
@@ -496,10 +502,9 @@ class ModelGraph(object):
         All node outputs and inputs are found. The model outputs are set to all node outputs
         that are not also node inputs.
         '''
-        node_outputs = np.array([out for node in self.graph.values() for out in node.outputs])
-        node_inputs = np.array([inp for node in self.graph.values() for inp in node.inputs])
-        model_outputs = node_outputs[np.isin(node_outputs, node_inputs, invert=True)]
-        self.outputs = model_outputs.tolist()
+        node_outputs = [out for node in self.graph.values() for out in node.outputs]
+        node_inputs = [inp for node in self.graph.values() for inp in node.inputs]
+        self.outputs = [out for out in node_outputs if out not in node_inputs]
 
     def get_weights_data(self, layer_name, var_name):
         return self.reader.get_weights_data(layer_name, var_name)

--- a/hls4ml/templates/vivado/nnet_utils/nnet_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_stream.h
@@ -101,16 +101,6 @@ void repack_stream(hls::stream<data_T> &data, hls::stream<res_T> &res) {
 }
 
 template<class data_T, class res_T, typename CONFIG_T>
-void broadcast_stream(hls::stream<data_T> &data, hls::stream<res_T> &res) {
-    if(CONFIG_T::in_height == 1 && CONFIG_T::in_width == 1 && CONFIG_T::in_chan == CONFIG_T::out_chan) {
-	broadcast_stream_1x1xC<data_T, res_T, CONFIG_T>(data, res);
-    }
-    else if(CONFIG_T::in_chan == 1 && CONFIG_T::in_height == CONFIG_T::out_height && CONFIG_T::in_width == CONFIG_T::out_width) {
-        broadcast_stream_HxWx1<data_T, res_T, CONFIG_T>(data, res);
-    }
-}
-
-template<class data_T, class res_T, typename CONFIG_T>
 void broadcast_stream_1x1xC(hls::stream<data_T> &data, hls::stream<res_T> &res) {
     assert(CONFIG_T::in_height == 1 && CONFIG_T::in_width == 1 && CONFIG_T::in_chan == CONFIG_T::out_chan);
     int n_dupl = (CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::out_chan) / (CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::in_chan);
@@ -143,6 +133,16 @@ void broadcast_stream_HxWx1(hls::stream<data_T> &data, hls::stream<res_T> &res) 
 	    out_data[k] = in_data[0];
 	}
 	res.write(out_data);
+    }
+}
+
+template<class data_T, class res_T, typename CONFIG_T>
+void broadcast_stream(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+    if(CONFIG_T::in_height == 1 && CONFIG_T::in_width == 1 && CONFIG_T::in_chan == CONFIG_T::out_chan) {
+	broadcast_stream_1x1xC<data_T, res_T, CONFIG_T>(data, res);
+    }
+    else if(CONFIG_T::in_chan == 1 && CONFIG_T::in_height == CONFIG_T::out_height && CONFIG_T::in_width == CONFIG_T::out_width) {
+        broadcast_stream_HxWx1<data_T, res_T, CONFIG_T>(data, res);
     }
 }
 }


### PR DESCRIPTION
This PR has a few related fixes
- fix insertion before a node with multiple inputs
- correctly insert broadcast stream before a node with multiple inputs (e.g. Add or Concatenate), e.g. see figure below. The current code would behave incorrectly and replace the wrong input (always the first input) for the following layer... this would result in an additional output incorrectly being inferred
- don't insert broadcast before concatenate (figure below incorrectly does this)

<img width="782" alt="Screen Shot 2022-05-16 at 6 59 26 PM" src="https://user-images.githubusercontent.com/4932543/168712933-502f31c8-7a2c-4b69-883c-74e10f4d534f.png">

To do
- [x] Add a pytest

@nickshey