### PR TITLE
Fix for QActivations passed as an argument

### DIFF
--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -316,16 +316,32 @@ def keras_to_hls(config):
         layer_list.append( layer )
         if 'activation' in layer and layer['class_name'] not in activation_layers + recurrent_layers:# + qkeras_layers:
             act_layer = {}
-            act_layer['name'] = layer['name'] + '_' + layer['activation']
-            act_layer['activation'] = layer['activation']
-            if 'activ_param' in layer:
-                act_layer['activ_param'] = layer['activ_param']
-                act_layer['class_name'] = layer['activation']
-            elif layer['activation'] == 'softmax':
-                act_layer['class_name'] = 'Softmax'
-                act_layer['axis'] = -1
+            # Workaround for QKeras activations passed as an argument
+            if isinstance(layer['activation'], dict):
+                act_details = layer['activation']
+                act_layer['class_name'] = 'QActivation'
+                act_layer['config'] = {
+                    'name': layer['name'] + '_' + act_details['class_name'],
+                    'activation': act_details['class_name']
+                }
+                act_layer, output_shape = layer_handlers['QActivation'](
+                    act_layer,
+                    None,
+                    [output_shape],
+                    reader,
+                    config
+                )
             else:
-                act_layer['class_name'] = 'Activation'
+                act_layer['name'] = layer['name'] + '_' + layer['activation']
+                act_layer['activation'] = layer['activation']
+                if 'activ_param' in layer:
+                    act_layer['activ_param'] = layer['activ_param']
+                    act_layer['class_name'] = layer['activation']
+                elif layer['activation'] == 'softmax':
+                    act_layer['class_name'] = 'Softmax'
+                    act_layer['axis'] = -1
+                else:
+                    act_layer['class_name'] = 'Activation'
             inputs_map[layer['name']] = act_layer['name']
             if output_layers is not None and layer['name'] in output_layers:
                 output_layers = [act_layer['name'] if name == layer['name'] else name for name in output_layers]

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -177,13 +177,20 @@ def config_from_keras_model(model, granularity='model', default_precision='ap_fi
 
         print('Layer name: {}, layer type: {}'.format(layer['name'], layer['class_name']))
         layer_list.append( layer )
-        if 'activation' in layer['config'] and layer['class_name'] not in activation_layers + qkeras_layers:
+        if 'activation' in layer['config'] and layer['class_name'] not in activation_layers:
             act_layer = {}
-            act_layer['name'] = layer['name'] + '_' + layer['config']['activation']
-            act_layer['class_name'] = 'Activation'
-            print('  -> Activation ({}), layer name: {}'.format(layer['config']['activation'], layer['name']))
+            act_details = layer['config']['activation']
+            if isinstance(act_details, dict):
+                precision = _get_precision_from_quantizer(act_details)
+                act_details = act_details['class_name']
+                act_layer['precision'] = {}
+                act_layer['precision']['result'] = precision
+                act_layer['class_name'] = 'QActivation'
+            else:
+                act_layer['class_name'] = 'Activation'
+            act_layer['name'] = layer['name'] + '_' + act_details
+            print('  -> Activation ({}), layer name: {}'.format(act_details, layer['name']))
             layer_list.append(act_layer)
-
 
     def make_layer_config(layer):
         layer_config = {}

--- a/test/pytest/test_qactivation.py
+++ b/test/pytest/test_qactivation.py
@@ -1,0 +1,41 @@
+import pytest
+import numpy as np
+import qkeras
+import hls4ml
+
+from tensorflow.keras.layers import Input
+from tensorflow.keras.models import Model
+from tensorflow.keras.initializers import Ones
+from qkeras.quantizers import quantized_bits, quantized_relu, ternary, binary
+
+from pathlib import Path
+
+test_root_path = Path(__file__).parent
+
+@pytest.mark.parametrize(
+    'quantizer', [
+        ('binary'),
+        ('ternary'),
+        ('quantized_bits(8, 2)'),
+        ('quantized_relu(8, 2)')
+    ]
+)
+def test_qactivation_kwarg(quantizer):
+    inputs = Input(shape=(10,))
+    outputs = qkeras.QDense(
+        10,
+        kernel_quantizer=qkeras.quantized_bits(8, 2),
+        activation=quantizer
+    )(inputs)
+
+    model = Model(inputs, outputs)
+    out_dir = str(test_root_path / 'hls4mlprj_qactivation_kwarg_{}'.format(
+        quantizer)
+    )
+    config = hls4ml.utils.config_from_keras_model(model, granularity='name')
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model,
+        hls_config=config,
+        output_dir=out_dir
+    )
+    hls_model.compile()


### PR DESCRIPTION
Fix for `QKeras` layers with `QActivations` passed as an argument.

Right now these models fail to compile with `TypeError` in the `keras_to_hls` method as the method expects the `layer['activation']` to be a string, not a dict.