### PR TITLE
Remove the in/out size from top function

### DIFF
--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -611,7 +611,6 @@ class ModelGraph(object):
 
         top_function.restype = None
         top_function.argtypes = [npc.ndpointer(ctype, flags="C_CONTIGUOUS") for i in range(len(xlist)+1)]
-        top_function.argtypes += [ctypes.POINTER(ctypes.c_ushort) for i in range(len(xlist)+1)]
 
         return top_function, ctype
 
@@ -650,12 +649,11 @@ class ModelGraph(object):
             for i in range(n_samples):
                 predictions = np.zeros(self.get_output_variables()[0].size(), dtype=ctype)
                 if n_inputs == 1:
-                    top_function(x[i], predictions, ctypes.byref(ctypes.c_ushort()), ctypes.byref(ctypes.c_ushort()))
+                    top_function(x[i], predictions)
                 else:
                     inp = [xj[i] for xj in x]
                     argtuple = inp
                     argtuple += [predictions]
-                    argtuple += [ctypes.byref(ctypes.c_ushort()) for k in range(len(inp)+1)]
                     argtuple = tuple(argtuple)
                     top_function(*argtuple)
                 output.append(predictions)

--- a/hls4ml/templates/vivado_accelerator/myproject_axi.cpp
+++ b/hls4ml/templates/vivado_accelerator/myproject_axi.cpp
@@ -7,9 +7,6 @@ void myproject(
 
     //hls-fpga-machine-learning insert interface
 
-    unsigned short in_size = 0;
-    unsigned short out_size = 0;
-
     //hls-fpga-machine-learning insert local vars
 
     //hls-fpga-machine-learning insert enqueue

--- a/hls4ml/writer/vivado_accelerator_writer.py
+++ b/hls4ml/writer/vivado_accelerator_writer.py
@@ -100,7 +100,7 @@ class VivadoAcceleratorWriter(VivadoWriter):
                     newline += indent + '#pragma HLS STREAM variable=in_local depth=N_IN\n'
                     newline += indent + '#pragma HLS STREAM variable=out_local depth=N_OUT\n'
             elif '//hls-fpga-machine-learning insert call' in line:
-                newline = indent + '{}(in_local, out_local, in_size, out_size);\n'.format(
+                newline = indent + '{}(in_local, out_local);\n'.format(
                     model.config.get_project_name())
             elif '//hls-fpga-machine-learning insert interface' in line:
                 if self.vivado_accelerator_config.get_interface() == 'axi_lite':

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -118,16 +118,13 @@ class VivadoWriter(Writer):
                 inputs_str = ', '.join([i.definition_cpp(as_reference=True) for i in model_inputs])
                 outputs_str = ', '.join([o.definition_cpp(as_reference=True) for o in model_outputs])
                 brams_str  = ', \n'.join([indent + b.definition_cpp(as_reference=False) for b in model_brams])
-                insize_str = ', '.join(['unsigned short &const_size_in_{}'.format(i) for i in range(1, len(model_inputs) + 1)])
-                outsize_str = ', '.join(['unsigned short &const_size_out_{}'.format(i) for i in range(1, len(model_outputs) + 1)])
 
                 newline = ''
                 newline += indent + inputs_str + ',\n'
-                newline += indent + outputs_str + ',\n'
+                newline += indent + outputs_str
                 if len(model_brams) > 0:
-                    newline += brams_str + ',\n'
-                newline += indent + insize_str + ',\n'
-                newline += indent + outsize_str + '\n'
+                    newline += ',\n' + brams_str
+                newline += '\n'
 
             elif '//hls-fpga-machine-learning insert load weights' in line:
                 newline = line
@@ -163,12 +160,6 @@ class VivadoWriter(Writer):
                     if all_brams:
                         newline += indent + '#pragma HLS INTERFACE bram port={} \n'.format(','.join(all_brams))
                     newline += indent + '#pragma HLS DATAFLOW \n'
-
-                inval_str = '\n    '.join(['const_size_in_{} = {};'.format(i, inp.size_cpp()) for i, inp in enumerate(model_inputs, 1)])
-                outval_str = '\n    '.join(['const_size_out_{} = {};'.format(i, out.size_cpp()) for i, out in enumerate(model_outputs, 1)])
-                newline += '\n' + indent + inval_str
-                newline += '\n' + indent + outval_str
-                newline += '\n'
 
             elif '//hls-fpga-machine-learning insert layers' in line:
                 newline = line + '\n'
@@ -231,16 +222,13 @@ class VivadoWriter(Writer):
                 inputs_str = ', '.join([i.definition_cpp(as_reference=True) for i in model_inputs])
                 outputs_str = ', '.join([o.definition_cpp(as_reference=True) for o in model_outputs])
                 brams_str  = ', \n'.join([indent + b.definition_cpp(as_reference=False) for b in model_brams])
-                insize_str = ', '.join(['unsigned short &const_size_in_{}'.format(i) for i in range(1, len(model_inputs) + 1)])
-                outsize_str = ', '.join(['unsigned short &const_size_out_{}'.format(o) for o in range(1, len(model_outputs) + 1)])
 
                 newline = ''
                 newline += indent + inputs_str + ',\n'
-                newline += indent + outputs_str + ',\n'
+                newline += indent + outputs_str
                 if len(model_brams) > 0:
-                    newline += brams_str + ',\n'
-                newline += indent + insize_str + ',\n'
-                newline += indent + outsize_str + '\n'
+                    newline += ',\n' + brams_str
+                newline += '\n'
             else:
                 newline = line
             fout.write(newline)
@@ -404,11 +392,6 @@ class VivadoWriter(Writer):
             elif '//hls-fpga-machine-learning insert top-level-function' in line:
                 newline = line
 
-                size_str = indent + 'unsigned short {},{};\n'
-                input_size_vars = ','.join(['size_in{}'.format(i) for i in range(1, len(model_inputs) + 1)])
-                output_size_vars = ','.join(['size_out{}'.format(o) for o in range(1, len(model_outputs) + 1)])
-                newline += size_str.format(input_size_vars, output_size_vars)
-
                 input_vars = ','.join([i.cppname for i in model_inputs])
                 output_vars = ','.join([o.cppname for o in model_outputs])
                 bram_vars   =','.join([b.cppname for b in model_brams])
@@ -416,7 +399,7 @@ class VivadoWriter(Writer):
                 # Concatenate the input, output, and bram variables. Filter out empty/null values
                 all_vars = ','.join(filter(None, [input_vars, output_vars, bram_vars]))
 
-                top_level = indent + '{}({},{},{});\n'.format(model.config.get_project_name(), all_vars, input_size_vars, output_size_vars)
+                top_level = indent + '{}({});\n'.format(model.config.get_project_name(), all_vars)
 
                 newline += top_level
             elif '//hls-fpga-machine-learning insert predictions' in line:
@@ -469,14 +452,10 @@ class VivadoWriter(Writer):
                 dtype = line.split('#', 1)[1].strip()
                 inputs_str = ', '.join(['{type} {name}[{shape}]'.format(type=dtype, name=i.cppname, shape=i.size_cpp()) for i in model_inputs])
                 outputs_str = ', '.join(['{type} {name}[{shape}]'.format(type=dtype, name=o.cppname, shape=o.size_cpp()) for o in model_outputs])
-                insize_str = ', '.join(['unsigned short &const_size_in_{}'.format(i) for i in range(1, len(model_inputs) + 1)])
-                outsize_str = ', '.join(['unsigned short &const_size_out_{}'.format(o) for o in range(1, len(model_outputs) + 1)])
 
                 newline = ''
                 newline += indent + inputs_str + ',\n'
-                newline += indent + outputs_str + ',\n'
-                newline += indent + insize_str + ',\n'
-                newline += indent + outsize_str + '\n'
+                newline += indent + outputs_str + '\n'
             elif '//hls-fpga-machine-learning insert wrapper' in line:
                 dtype = line.split('#', 1)[1].strip()
                 newline = ''
@@ -490,8 +469,6 @@ class VivadoWriter(Writer):
 
                 newline += '\n'
 
-                input_size_vars = ','.join(['const_size_in_{}'.format(i) for i in range(1, len(model_inputs) + 1)])
-                output_size_vars = ','.join(['const_size_out_{}'.format(o) for o in range(1, len(model_outputs) + 1)])
                 input_vars = ','.join([i.cppname + '_ap' for i in model_inputs])
                 bram_vars   =','.join([b.cppname for b in model_brams])
                 output_vars = ','.join([o.cppname + '_ap' for o in model_outputs])
@@ -499,7 +476,7 @@ class VivadoWriter(Writer):
                 # Concatenate the input, output, and bram variables. Filter out empty/null values
                 all_vars = ','.join(filter(None, [input_vars, output_vars, bram_vars]))
 
-                top_level = indent + '{}({},{},{});\n'.format(model.config.get_project_name(), all_vars, input_size_vars, output_size_vars)
+                top_level = indent + '{}({});\n'.format(model.config.get_project_name(), all_vars)
                 newline += top_level
 
                 newline += '\n'


### PR DESCRIPTION
The size of input and output that is part of the top function is never used and can be removed. Since the data type used is `short` large models emit warnings. #543 suggested a fix, but after some thought, we should get rid of this feature altogether.

Basically, from  `myproject(input_t input_1, result_t result, unsigned short &const_size_in_1, unsigned short &const_size_out_1)` we do `myproject(input_t input_1, result_t result)`.