### PR TITLE
remove cppname

### DIFF
--- a/hls4ml/backends/fpga/fpga_types.py
+++ b/hls4ml/backends/fpga/fpga_types.py
@@ -184,11 +184,11 @@ class VariableDefinition(object):
 
 class VivadoArrayVariableDefinition(VariableDefinition):
     def definition_cpp(self, name_suffix='', as_reference=False):
-        return '{type} {name}{suffix}[{shape}]'.format(type=self.type.name, name=self.cppname, suffix=name_suffix, shape=self.size_cpp())
+        return '{type} {name}{suffix}[{shape}]'.format(type=self.type.name, name=self.name, suffix=name_suffix, shape=self.size_cpp())
 
 class QuartusArrayVariableDefinition(VariableDefinition):
     def definition_cpp(self, name_suffix='', as_reference=False):
-        return '{type} {name}{suffix}[{shape}] {pragma}'.format(type=self.type.name, name=self.cppname, suffix=name_suffix, shape=self.size_cpp(), pragma=self.pragma)
+        return '{type} {name}{suffix}[{shape}] {pragma}'.format(type=self.type.name, name=self.name, suffix=name_suffix, shape=self.size_cpp(), pragma=self.pragma)
 
 class ArrayVariableConverter(object):
     def __init__(self, type_converter, prefix, definition_cls):
@@ -254,9 +254,9 @@ class QuartusStructMemberVariableConverter(StructMemberVariableConverter):
 class VivadoStreamVariableDefinition(VariableDefinition):
     def definition_cpp(self, name_suffix='', as_reference=False):
         if as_reference: # Function parameter
-            return 'hls::stream<{type}> &{name}{suffix}'.format(type=self.type.name, name=self.cppname, suffix=name_suffix)
+            return 'hls::stream<{type}> &{name}{suffix}'.format(type=self.type.name, name=self.name, suffix=name_suffix)
         else: # Declaration
-            return 'hls::stream<{type}> {name}{suffix}("{name}")'.format(type=self.type.name, name=self.cppname, suffix=name_suffix)
+            return 'hls::stream<{type}> {name}{suffix}("{name}")'.format(type=self.type.name, name=self.name, suffix=name_suffix)
 
 class StreamVariableConverter(object):
     def __init__(self, type_converter, prefix, definition_cls):
@@ -315,7 +315,7 @@ class QuartusInplaceVariableConverter(InplaceVariableConverter):
 
 class StaticWeightVariableDefinition(VariableDefinition):
     def definition_cpp(self, name_suffix='', as_reference=False):
-        return '{type} {name}[{size}]'.format(type=self.type.name, name=self.cppname, size=self.data_length)
+        return '{type} {name}[{size}]'.format(type=self.type.name, name=self.name, size=self.data_length)
 
 class StaticWeightVariableConverter(object):
     def __init__(self, type_converter):

--- a/hls4ml/model/types.py
+++ b/hls4ml/model/types.py
@@ -186,7 +186,6 @@ class Variable(object):
     def __init__(self, var_name, atype, **kwargs):
         self.name = var_name.format(**kwargs)
         self.type = atype
-        self.cppname = re.sub(r'\W|^(?=\d)','_', self.name)
 
 class TensorVariable(Variable):
     def __init__(self, shape, dim_names, var_name='layer{index}', type_name='layer{index}_t', precision=None, **kwargs):

--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -358,10 +358,10 @@ class QuartusWriter(Writer):
             elif '//hls-fpga-machine-learning insert header' in line:
                 dtype = line.split('#', 1)[1].strip()
                 inputs_str = ', '.join(
-                    ['{type} {name}[{shape}]'.format(type=dtype, name=i.cppname, shape=i.size_cpp()) for i in
+                    ['{type} {name}[{shape}]'.format(type=dtype, name=i.member_name, shape=i.size_cpp()) for i in
                      model_inputs])
                 outputs_str = ', '.join(
-                    ['{type} {name}[{shape}]'.format(type=dtype, name=o.cppname, shape=o.size_cpp()) for o in
+                    ['{type} {name}[{shape}]'.format(type=dtype, name=o.member_name, shape=o.size_cpp()) for o in
                      model_outputs])
                 insize_str = ', '.join(
                     ['unsigned short &const_size_in_{}'.format(i) for i in range(1, len(model_inputs) + 1)])
@@ -381,8 +381,8 @@ class QuartusWriter(Writer):
                 for i in model_inputs:
                     newline += indent + 'nnet::convert_data<{}, {}, {}>({}, inputs_ap.{});\n'.format(dtype, i.type.name,
                                                                                                      i.size_cpp(),
-                                                                                                     i.cppname,
-                                                                                                     i.cppname)
+                                                                                                     i.member_name,
+                                                                                                     i.member_name)
                 newline += '\n'
 
                 newline += indent + 'output_data outputs_ap;\n'
@@ -394,8 +394,8 @@ class QuartusWriter(Writer):
                     newline += indent + 'nnet::convert_data_back<{}, {}, {}>(outputs_ap.{}, {});\n'.format(o.type.name,
                                                                                                            dtype,
                                                                                                            o.size_cpp(),
-                                                                                                           o.cppname,
-                                                                                                           o.cppname)
+                                                                                                           o.member_name,
+                                                                                                           o.member_name)
             elif '//hls-fpga-machine-learning insert trace_outputs' in line:
                 newline = ''
                 for layer in model.get_layers():

--- a/hls4ml/writer/vivado_accelerator_writer.py
+++ b/hls4ml/writer/vivado_accelerator_writer.py
@@ -251,11 +251,11 @@ class VivadoAcceleratorWriter(VivadoWriter):
             elif '{}('.format(model.config.get_project_name()) in line:
                 indent_amount = line.split(model.config.get_project_name())[0]
                 newline = indent_amount + '{}_axi(inputs,outputs);\n'.format(model.config.get_project_name())
-            elif inp.size_cpp() in line or inp.cppname in line or inp.type.name in line:
-                newline = line.replace(inp.size_cpp(), 'N_IN').replace(inp.cppname, 'inputs').replace(inp.type.name,
+            elif inp.size_cpp() in line or inp.name in line or inp.type.name in line:
+                newline = line.replace(inp.size_cpp(), 'N_IN').replace(inp.name, 'inputs').replace(inp.type.name,
                                                                                                       'input_axi_t')
-            elif out.size_cpp() in line or out.cppname in line or out.type.name in line:
-                newline = line.replace(out.size_cpp(), 'N_OUT').replace(out.cppname, 'outputs').replace(out.type.name,
+            elif out.size_cpp() in line or out.name in line or out.type.name in line:
+                newline = line.replace(out.size_cpp(), 'N_OUT').replace(out.name, 'outputs').replace(out.type.name,
                                                                                                         'output_axi_t')
             else:
                 newline = line
@@ -289,17 +289,17 @@ class VivadoAcceleratorWriter(VivadoWriter):
                                        '{}_axi.h'.format(model.config.get_project_name()))
             elif inp.definition_cpp(name_suffix='_ap') in line:
                 newline = line.replace(inp.definition_cpp(name_suffix='_ap'),
-                                       'input_axi_t {}_ap[N_IN]'.format(inp.cppname))
+                                       'input_axi_t {}_ap[N_IN]'.format(inp.name))
             elif out.definition_cpp(name_suffix='_ap') in line:
                 newline = line.replace(out.definition_cpp(name_suffix='_ap'),
-                                       'output_axi_t {}_ap[N_OUT]'.format(out.cppname))
+                                       'output_axi_t {}_ap[N_OUT]'.format(out.name))
             elif '{}('.format(model.config.get_project_name()) in line:
                 indent_amount = line.split(model.config.get_project_name())[0]
-                newline = indent_amount + '{}_axi({}_ap,{}_ap);\n'.format(model.config.get_project_name(), inp.cppname,
-                                                                          out.cppname)
-            elif inp.size_cpp() in line or inp.cppname in line or inp.type.name in line:
+                newline = indent_amount + '{}_axi({}_ap,{}_ap);\n'.format(model.config.get_project_name(), inp.name,
+                                                                          out.name)
+            elif inp.size_cpp() in line or inp.name in line or inp.type.name in line:
                 newline = line.replace(inp.size_cpp(), 'N_IN').replace(inp.type.name, 'input_axi_t')
-            elif out.size_cpp() in line or out.cppname in line or out.type.name in line:
+            elif out.size_cpp() in line or out.name in line or out.type.name in line:
                 newline = line.replace(out.size_cpp(), 'N_OUT').replace(out.type.name, 'output_axi_t')
             else:
                 newline = line

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -143,9 +143,9 @@ class VivadoWriter(Writer):
             #Add input/output type
             elif '//hls-fpga-machine-learning insert IO' in line:
                 newline = line
-                all_inputs = [i.cppname for i in model_inputs]
-                all_outputs = [o.cppname for o in model_outputs]
-                all_brams = [b.cppname for b in model_brams]
+                all_inputs = [i.name for i in model_inputs]
+                all_outputs = [o.name for o in model_outputs]
+                all_brams = [b.name for b in model_brams]
                 io_type = model.config.get_config_value("IOType")
 
                 if io_type == 'io_parallel':
@@ -384,13 +384,13 @@ class VivadoWriter(Writer):
             elif '//hls-fpga-machine-learning insert bram' in line:
                 newline = line
                 for bram in model_brams:
-                    newline += '#include \"firmware/weights/{}.h\"\n'.format(bram.cppname)
+                    newline += '#include \"firmware/weights/{}.h\"\n'.format(bram.name)
             elif '//hls-fpga-machine-learning insert data' in line:
                 newline = line
                 offset = 0
                 for inp in model_inputs:
                     newline += '      ' + inp.definition_cpp() + ';\n'
-                    newline += '      nnet::copy_data<float, {}, {}, {}>(in, {});\n'.format(inp.type.name, offset, inp.size_cpp(), inp.cppname)
+                    newline += '      nnet::copy_data<float, {}, {}, {}>(in, {});\n'.format(inp.type.name, offset, inp.size_cpp(), inp.name)
                     offset += inp.size()
                 for out in model_outputs:
                     newline += '      ' + out.definition_cpp() + ';\n'
@@ -398,7 +398,7 @@ class VivadoWriter(Writer):
                 newline = line
                 for inp in model_inputs:
                     newline += '    ' + inp.definition_cpp() + ';\n'
-                    newline += '    nnet::fill_zero<{}, {}>({});\n'.format(inp.type.name, inp.size_cpp(), inp.cppname)
+                    newline += '    nnet::fill_zero<{}, {}>({});\n'.format(inp.type.name, inp.size_cpp(), inp.name)
                 for out in model_outputs:
                     newline += '    ' + out.definition_cpp() + ';\n'
             elif '//hls-fpga-machine-learning insert top-level-function' in line:
@@ -409,9 +409,9 @@ class VivadoWriter(Writer):
                 output_size_vars = ','.join(['size_out{}'.format(o) for o in range(1, len(model_outputs) + 1)])
                 newline += size_str.format(input_size_vars, output_size_vars)
 
-                input_vars = ','.join([i.cppname for i in model_inputs])
-                output_vars = ','.join([o.cppname for o in model_outputs])
-                bram_vars   =','.join([b.cppname for b in model_brams])
+                input_vars = ','.join([i.name for i in model_inputs])
+                output_vars = ','.join([o.name for o in model_outputs])
+                bram_vars   =','.join([b.name for b in model_brams])
 
                 # Concatenate the input, output, and bram variables. Filter out empty/null values
                 all_vars = ','.join(filter(None, [input_vars, output_vars, bram_vars]))
@@ -429,11 +429,11 @@ class VivadoWriter(Writer):
             elif '//hls-fpga-machine-learning insert tb-output' in line:
                 newline = line
                 for out in model_outputs:
-                    newline += indent + 'nnet::print_result<{}, {}>({}, fout);\n'.format(out.type.name, out.size_cpp(), out.cppname) #TODO enable this
+                    newline += indent + 'nnet::print_result<{}, {}>({}, fout);\n'.format(out.type.name, out.size_cpp(), out.name) #TODO enable this
             elif '//hls-fpga-machine-learning insert output' in line or '//hls-fpga-machine-learning insert quantized' in line:
                 newline = line
                 for out in model_outputs:
-                    newline += indent + 'nnet::print_result<{}, {}>({}, std::cout, true);\n'.format(out.type.name, out.size_cpp(), out.cppname)
+                    newline += indent + 'nnet::print_result<{}, {}>({}, std::cout, true);\n'.format(out.type.name, out.size_cpp(), out.name)
             else:
                 newline = line
             fout.write(newline)
@@ -464,11 +464,11 @@ class VivadoWriter(Writer):
             elif '//hls-fpga-machine-learning insert bram' in line:
                 newline = line
                 for bram in model_brams:
-                    newline += '#include \"firmware/weights/{}.h\"\n'.format(bram.cppname)
+                    newline += '#include \"firmware/weights/{}.h\"\n'.format(bram.name)
             elif '//hls-fpga-machine-learning insert header' in line:
                 dtype = line.split('#', 1)[1].strip()
-                inputs_str = ', '.join(['{type} {name}[{shape}]'.format(type=dtype, name=i.cppname, shape=i.size_cpp()) for i in model_inputs])
-                outputs_str = ', '.join(['{type} {name}[{shape}]'.format(type=dtype, name=o.cppname, shape=o.size_cpp()) for o in model_outputs])
+                inputs_str = ', '.join(['{type} {name}[{shape}]'.format(type=dtype, name=i.name, shape=i.size_cpp()) for i in model_inputs])
+                outputs_str = ', '.join(['{type} {name}[{shape}]'.format(type=dtype, name=o.name, shape=o.size_cpp()) for o in model_outputs])
                 insize_str = ', '.join(['unsigned short &const_size_in_{}'.format(i) for i in range(1, len(model_inputs) + 1)])
                 outsize_str = ', '.join(['unsigned short &const_size_out_{}'.format(o) for o in range(1, len(model_outputs) + 1)])
 
@@ -482,7 +482,7 @@ class VivadoWriter(Writer):
                 newline = ''
                 for i in model_inputs:
                     newline += indent + '{var};\n'.format(var=i.definition_cpp(name_suffix='_ap'))
-                    newline += indent + 'nnet::convert_data<{}, {}, {}>({}, {}_ap);\n'.format(dtype, i.type.name, i.size_cpp(), i.cppname, i.cppname)
+                    newline += indent + 'nnet::convert_data<{}, {}, {}>({}, {}_ap);\n'.format(dtype, i.type.name, i.size_cpp(), i.name, i.name)
                 newline += '\n'
 
                 for o in model_outputs:
@@ -492,9 +492,9 @@ class VivadoWriter(Writer):
 
                 input_size_vars = ','.join(['const_size_in_{}'.format(i) for i in range(1, len(model_inputs) + 1)])
                 output_size_vars = ','.join(['const_size_out_{}'.format(o) for o in range(1, len(model_outputs) + 1)])
-                input_vars = ','.join([i.cppname + '_ap' for i in model_inputs])
-                bram_vars   =','.join([b.cppname for b in model_brams])
-                output_vars = ','.join([o.cppname + '_ap' for o in model_outputs])
+                input_vars = ','.join([i.name + '_ap' for i in model_inputs])
+                bram_vars   =','.join([b.name for b in model_brams])
+                output_vars = ','.join([o.name + '_ap' for o in model_outputs])
 
                 # Concatenate the input, output, and bram variables. Filter out empty/null values
                 all_vars = ','.join(filter(None, [input_vars, output_vars, bram_vars]))
@@ -505,7 +505,7 @@ class VivadoWriter(Writer):
                 newline += '\n'
 
                 for o in model_outputs:
-                    newline += indent + 'nnet::convert_data<{}, {}, {}>({}_ap, {});\n'.format(o.type.name, dtype, o.size_cpp(), o.cppname, o.cppname)
+                    newline += indent + 'nnet::convert_data<{}, {}, {}>({}_ap, {});\n'.format(o.type.name, dtype, o.size_cpp(), o.name, o.name)
             elif '//hls-fpga-machine-learning insert trace_outputs' in line:
                 newline = ''
                 for layer in model.get_layers():


### PR DESCRIPTION
Variable `name` and `cppname` are often used interchangeably in the code, not consistently. My understanding is that `cppname` was meant to be a cleaned up C-legal version of name. Instead of looking at each case where `name` is used and trying to see if it should be `cppname` and vice versa, it probably makes sense to just get rid of `cppname` altogether, and just use `name` everywhere.

One question is whether we want to include this name cleaning in the `Variable.__init__` function:
```python
self.name = re.sub(r'\W|^(?=\d)','_', self.name)
```
I have not included it. The standard pytests all pass without it.