### PR TITLE
Don't override precision directly in the QKeras optimizer

### DIFF
--- a/hls4ml/model/optimizer/passes/qkeras.py
+++ b/hls4ml/model/optimizer/passes/qkeras.py
@@ -59,7 +59,12 @@ class OutputRoundingSaturationMode(ConfigurableOptimizerPass):
             new_precision = FixedPrecisionType(old_precision.width, old_precision.integer, old_precision.signed, self.rounding_mode, self.saturation_mode, self.saturation_bits)
         else: # in case the precision is a string
             new_precision = self.precision_string_modify(old_precision)
-        node.get_output_variable().type.precision = new_precision
+
+        out_var = node.get_output_variable()
+        out_t = NamedType(out_var.type.name, new_precision)
+        out_var.type = out_t
+        node.attributes['result_t'] = out_t
+
         if node.get_attr('accum_t') is not None:
             accum_t = NamedType('layer{}_accum_t'.format(node.index), new_precision)
             node.set_attr('accum_t', new_precision)


### PR DESCRIPTION
`output_rounding_saturation_mode` optimizer directly manipulates precision object of the output variable of the node, which can trip up the later optimizers and make them skip the type conversion. It was observed in testing of accelerator backend with fifo depth optimization (by @thesps) as well as some GNN models (by @sznajder) This change ensures the update of precision also updates the entire type. Eventually we will make the `precision` a read-only property to ensure this type of error doesn't affect future optimizers, but this kind of change requires a bit more work. 