### PR TITLE
Make layer names case sensitive in config.

### DIFF
--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -58,7 +58,7 @@ class HLSConfig(object):
     def get_layer_config_value(self, layer, key, default=None):
         hls_config = self.config['HLSConfig']
 
-        name_config = hls_config.get('LayerName', {}).get(layer.name.lower(), None)
+        name_config = hls_config.get('LayerName', {}).get(layer.name, None)
         if name_config is not None:
             return name_config.get(key, default)
 
@@ -80,7 +80,7 @@ class HLSConfig(object):
         if type_config is not None:
             layer_config.update(type_config)
 
-        name_config = hls_config.get('LayerName', {}).get(layer.name.lower(), None)
+        name_config = hls_config.get('LayerName', {}).get(layer.name, None)
         if name_config is not None:
             layer_config.update(name_config)
 


### PR DESCRIPTION
This implements option 1 of #573:  all keys in the HLSConfig are made case sensitive. I think it is logically simpler to make the config case sensitive or insensitive everywhere, not just in some places, and the first option is easier. This PR fixes being able to turn on tracing if layer names have capitalizations, where part assumed case sensitive, and another part assumed case insensitive.