### PR TITLE
Add tracing support for the quartus backend

### DIFF
--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_helpers.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_helpers.h
@@ -26,6 +26,7 @@
 #include <fstream>
 #include <algorithm>
 #include <map>
+#include <sstream>
 
 namespace nnet {
 
@@ -56,6 +57,49 @@ constexpr int floorlog2(int x){
 
 constexpr int pow2(int x){
   return x == 0 ? 1 : 2 * pow2(x - 1);
+}
+
+extern bool trace_enabled;
+extern std::map<std::string, void *> *trace_outputs;
+extern size_t trace_type_size;
+
+template<class data_T, class save_T>
+void save_output_array(data_T *data, save_T *ptr, size_t layer_size) {
+    for(int i = 0; i < layer_size; i++) {
+        ptr[i] = static_cast<save_T>(data[i].to_double());
+    }
+}
+
+// We don't want to include save_T in this function because it will be inserted into myproject.cpp
+// so a workaround with element size is used
+template<class data_T>
+void save_layer_output(data_T *data, const char *layer_name, size_t layer_size) {
+    if (!trace_enabled) return;
+
+    if (trace_outputs) {
+        if (trace_outputs->count(layer_name) > 0) {
+            if (trace_type_size == 4) {
+                save_output_array(data, (float *) (*trace_outputs)[layer_name], layer_size);
+            } else if (trace_type_size == 8) {
+                save_output_array(data, (double *) (*trace_outputs)[layer_name], layer_size);
+            } else {
+                std::cout << "Unknown trace type!" << std::endl;
+            }
+        } else {
+            std::cout << "Layer name: " << layer_name << " not found in debug storage!" << std::endl;
+        }
+    } else {
+        std::ostringstream filename;
+        filename << "./tb_data/" << layer_name << "_output.log"; //TODO if run as a shared lib, path should be ../tb_data
+        std::fstream out;
+        out.open(filename.str(), std::ios::app);
+        assert(out.is_open());
+        for(int i = 0; i < layer_size; i++) {
+            out << data[i] << " "; // We don't care about precision in text files
+        }
+        out << std::endl;
+        out.close();
+    }
 }
 
 }

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_helpers.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_helpers.h
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <map>
 #include <sstream>
+#include <iostream>
 
 namespace nnet {
 

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_helpers.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_helpers.h
@@ -60,10 +60,6 @@ constexpr int pow2(int x){
   return x == 0 ? 1 : 2 * pow2(x - 1);
 }
 
-extern bool trace_enabled;
-extern std::map<std::string, void *> *trace_outputs;
-extern size_t trace_type_size;
-
 template<class data_T, class save_T>
 void save_output_array(data_T *data, save_T *ptr, size_t layer_size) {
     for(int i = 0; i < layer_size; i++) {

--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -129,6 +129,12 @@ class QuartusWriter(Writer):
                     if func:
                         newline += '    ' + func + '\n'
                         newline += '\n'
+                    if model.config.trace_output and layer.get_attr('Trace', False):
+                        newline += '#ifndef HLS_SYNTHESIS\n'
+                        for var in vars:
+                            newline += '    nnet::save_layer_output<{}>({}, "{}", {});\n'.format(var.type.name, var.name, layer.name, var.size_cpp())
+                        newline += '#endif\n'
+                    newline += '\n'
 
             # Just copy line
             else:

--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -128,13 +128,12 @@ class QuartusWriter(Writer):
                     func = layer.get_attr('function_cpp', None)
                     if func:
                         newline += '    ' + func + '\n'
+                        if model.config.trace_output and layer.get_attr('Trace', False):
+                            newline += '#ifndef HLS_SYNTHESIS\n'
+                            for var in vars:
+                                newline += '    nnet::save_layer_output<{}>({}, "{}", {});\n'.format(var.type.name, var.name, layer.name, var.size_cpp())
+                            newline += '#endif\n'
                         newline += '\n'
-                    if model.config.trace_output and layer.get_attr('Trace', False):
-                        newline += '#ifndef HLS_SYNTHESIS\n'
-                        for var in vars:
-                            newline += '    nnet::save_layer_output<{}>({}, "{}", {});\n'.format(var.type.name, var.name, layer.name, var.size_cpp())
-                        newline += '#endif\n'
-                    newline += '\n'
 
             # Just copy line
             else:

--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -406,8 +406,7 @@ class QuartusWriter(Writer):
                 newline = ''
                 for layer in model.get_layers():
                     func = layer.get_attr('function_cpp')
-                    if func and model.config.trace_output and model.config.get_layer_config_value(layer, 'Trace',
-                                                                                                  False):
+                    if func and model.config.trace_output and layer.get_attr('Trace', False):
                         vars = layer.get_variables()
                         for var in vars:
                             newline += indent + 'nnet::trace_outputs->insert(std::pair<std::string, void *>("{}", (void *) malloc({} * element_size)));\n'.format(

--- a/test/pytest/test_trace.py
+++ b/test/pytest/test_trace.py
@@ -1,0 +1,45 @@
+import pytest
+import hls4ml
+import tensorflow as tf
+import numpy as np
+from pathlib import Path
+from tensorflow.keras.layers import Dense, Activation
+
+test_root_path = Path(__file__).parent
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Quartus'])
+def test_trace(backend):
+    model = tf.keras.models.Sequential()
+    model.add(Dense(2,
+              input_shape=(1,),
+              name='Dense',
+              use_bias=True,
+              kernel_initializer= tf.keras.initializers.RandomUniform(minval=1, maxval=10),
+              bias_initializer='zeros',
+              kernel_regularizer=None,
+              bias_regularizer=None,
+              activity_regularizer=None,
+              kernel_constraint=None,
+              bias_constraint=None))
+    model.add(Activation(activation='elu', name='Activation'))
+    model.compile(optimizer='adam', loss='mse')
+
+    X_input = np.random.rand(100,1)
+
+    keras_prediction = model.predict(X_input)
+
+    config = hls4ml.utils.config_from_keras_model(model, granularity='name')
+    for layer in config['LayerName'].keys():
+        config['LayerName'][layer]['Trace'] = True
+
+    output_dir = str(test_root_path / f'hls4mlprj_trace_{backend}')
+
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir, backend=backend)
+
+    hls_model.compile()
+    hls4ml_pred, hls4ml_trace = hls_model.trace(X_input)
+    keras_trace = hls4ml.model.profiling.get_ymodel_keras(model, X_input)
+
+    np.testing.assert_allclose(hls4ml_trace['Dense'], keras_trace['Dense'], rtol=1e-2, atol=0.01)
+    np.testing.assert_allclose(hls4ml_pred, keras_prediction, rtol=1e-2, atol=0.01)
+

--- a/test/pytest/test_trace.py
+++ b/test/pytest/test_trace.py
@@ -9,6 +9,7 @@ test_root_path = Path(__file__).parent
 
 @pytest.mark.parametrize('backend', ['Vivado', 'Quartus'])
 def test_trace(backend):
+    '''Test the tracing feature with a simple Keras model.'''
     model = tf.keras.models.Sequential()
     model.add(Dense(2,
               input_shape=(1,),
@@ -42,4 +43,3 @@ def test_trace(backend):
 
     np.testing.assert_allclose(hls4ml_trace['Dense'], keras_trace['Dense'], rtol=1e-2, atol=0.01)
     np.testing.assert_allclose(hls4ml_pred, keras_prediction, rtol=1e-2, atol=0.01)
-

--- a/test/pytest/test_trace.py
+++ b/test/pytest/test_trace.py
@@ -1,5 +1,6 @@
 import pytest
 import hls4ml
+import hls4ml.model.profiling
 import tensorflow as tf
 import numpy as np
 from pathlib import Path


### PR DESCRIPTION
# Description

Tracing was only partially supported in the Quartus backend. This adds the missing features to enable support in the currently supported `io_parallel` style. (This will need to be expanded when streaming is added.)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Tests

`test_trace.py` is added in pytest:  it is a simple copy of the `test_dense` with tracing enabled.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/master/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation -- not needed; should be identical as Vivado,
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.B# Description

