### PR TITLE
Update flow dependencies

### DIFF
--- a/hls4ml/backends/quartus/quartus_backend.py
+++ b/hls4ml/backends/quartus/quartus_backend.py
@@ -51,6 +51,7 @@ class QuartusBackend(FPGABackend):
         template_flow = register_flow('apply_templates', templates, requires=[init_flow], backend=self.name)
 
         writer_passes = [
+            'make_stamp',
             'quartus:write_hls'
         ]
         writer_flow_requirements = ['optimize', quartus_types_flow, template_flow]

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -67,10 +67,10 @@ class VivadoBackend(FPGABackend):
         template_flow = register_flow('apply_templates', self._get_layer_templates, requires=[init_flow], backend=self.name)
 
         writer_passes = [
+            'make_stamp',
             'vivado:write_hls'
         ]
-        writer_flow_requirements = ['optimize', vivado_types_flow, template_flow]
-        self._writer_flow = register_flow('write', writer_passes, requires=writer_flow_requirements, backend=self.name)
+        self._writer_flow = register_flow('write', writer_passes, requires=['vivado:ip'], backend=self.name)
 
         all_passes = get_backend_passes(self.name)
 
@@ -173,6 +173,7 @@ class VivadoBackend(FPGABackend):
 
     @layer_optimizer(Conv2D)
     def init_conv2d(self, layer):
+        print('here in conv2d')
         if len(layer.weights['weight'].data.shape) == 2: # This can happen if we assign weights of Dense layer to 1x1 Conv2D
             layer.weights['weight'].data = np.expand_dims(layer.weights['weight'].data, axis=(0,1))
 

--- a/hls4ml/backends/vivado_accelerator/vivado_accelerator_backend.py
+++ b/hls4ml/backends/vivado_accelerator/vivado_accelerator_backend.py
@@ -99,7 +99,7 @@ class VivadoAcceleratorBackend(VivadoBackend):
         return config
 
     def _register_flows(self):
-        vivado_writer = ['vivado:write']
-        vivado_accel_writer = ['vivadoaccelerator:write_hls']
-        self._writer_flow = register_flow('write', vivado_accel_writer, requires=vivado_writer, backend=self.name)
-        self._default_flow = 'vivado:ip'
+        vivado_ip = 'vivado:ip'
+        writer_passes = ['make_stamp', 'vivadoaccelerator:write_hls']
+        self._writer_flow = register_flow('write', writer_passes, requires=[vivado_ip], backend=self.name)
+        self._default_flow = vivado_ip

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -333,8 +333,37 @@ class ModelGraph(object):
 
             self.graph[name] = self.make_node(kind, name, layer, inputs, outputs)
 
-    def apply_flow(self, flow):
-        applied_flows = {}
+    def apply_flow(self, flow, reapply='single'):
+        """Applies a flow (a collection of optimizers).
+        Args:
+            flow (str): The name of the flow to apply
+            reapply (str, optional): Determines the action to take if the flow and its requirements have already been
+                applied. Possible values are:
+                - 'all': Apply the flow and all its requirements.
+                - 'single': Apply only the given flow, but skip the already applied requirements.
+                - 'none': Skip applying the flow.
+                Defaults to 'single'.
+        """
+        def all_applied_flows():
+            applied_flows = {}
+
+            for flow_group in self._applied_flows:
+                applied_flows.update({flow: [] for flow in flow_group.keys()})
+
+            return applied_flows
+
+        assert reapply in ['all', 'single', 'none']
+
+        if reapply == 'all':
+            applied_flows = {}
+        elif reapply == 'single':
+            applied_flows = all_applied_flows()
+            applied_flows.pop(flow, None)
+        else:  # reapply == 'none'
+            applied_flows = all_applied_flows()
+            if flow in applied_flows:
+                return
+
         self._apply_sub_flow(flow, applied_flows)
         self._applied_flows.append(applied_flows)
 
@@ -551,16 +580,6 @@ class ModelGraph(object):
         This function converts the model to C++ and writes the generated files in the output
         directory specified in the `config`.
         """
-
-        def _make_stamp():
-            """ Create a unique identifier for the generated code. This identifier is used to
-            compile a unique library and link it with python. """
-            from string import hexdigits
-            from random import choice
-            length = 8
-            return ''.join(choice(hexdigits) for m in range(length))
-        
-        self.config.config['Stamp'] = _make_stamp()
 
         self.config.backend.write(self)
 

--- a/hls4ml/model/optimizer/__init__.py
+++ b/hls4ml/model/optimizer/__init__.py
@@ -1,7 +1,7 @@
 from hls4ml.model.flow.flow import register_flow
 import os
 
-from hls4ml.model.optimizer.optimizer import OptimizerPass, GlobalOptimizerPass, LayerOptimizerPass, ConfigurableOptimizerPass, register_pass, get_optimizer, optimize_model, get_available_passes, get_backend_passes, optimizer_pass, layer_optimizer, model_optimizer, extract_optimizers_from_path, extract_optimizers_from_object
+from hls4ml.model.optimizer.optimizer import OptimizerPass, GlobalOptimizerPass, LayerOptimizerPass, ModelOptimizerPass, ConfigurableOptimizerPass, register_pass, get_optimizer, optimize_model, get_available_passes, get_backend_passes, optimizer_pass, layer_optimizer, model_optimizer, extract_optimizers_from_path, extract_optimizers_from_object
 
 
 opt_path = os.path.dirname(__file__) + '/passes'

--- a/hls4ml/model/optimizer/passes/stamp.py
+++ b/hls4ml/model/optimizer/passes/stamp.py
@@ -1,0 +1,19 @@
+from hls4ml.model.optimizer import ModelOptimizerPass
+
+
+class MakeStamp(ModelOptimizerPass):
+    def __init__(self):
+        self.name = 'make_stamp'
+
+    def transform(self, model):
+        def _make_stamp():
+            """ Create a unique identifier for the generated code. This identifier is used to
+            compile a unique library and link it with python. """
+            from string import hexdigits
+            from random import choice
+            length = 8
+            return ''.join(choice(hexdigits) for m in range(length))
+
+        model.config.config['Stamp'] = _make_stamp()
+
+        return False  # No model graph changes made

--- a/test/pytest/test_graph.py
+++ b/test/pytest/test_graph.py
@@ -17,7 +17,7 @@ def base_model(output_dir='hls4mlprj_graph_base_model', iotype = 'io_parallel'):
   layers = [{'class_name' : 'Input', 'name' : 'layer0_input', 'input_shape' : [1]},
             {'class_name' : 'Dense', 'name' : 'layer0', 'n_in' : 1, 'n_out' : 1},
             {'class_name' : 'Dense', 'name' : 'layer1', 'n_in' : 1, 'n_out' : 1}]
-  config = {'HLSConfig':{'Model':{'Precision':'ap_fixed<32,16>','ReuseFactor' : 1}}}
+  config = {'HLSConfig':{'Model':{'Precision':'ap_fixed<32,16>','ReuseFactor' : 1}, 'Flows': []}}
   config['OutputDir'] = output_dir
   config['ProjectName'] = 'myprj'
   config['IOType'] = iotype


### PR DESCRIPTION
## Description

This PR shuffles the order of flows a bit to help resolve the issues observed in #509 and elsewhere. Essentially it makes writer flows depend on the ip flows and expands functionality of `apply_flows()` to control how the flows are reapplied if they were already applied before. Another effect of the change is that the flows aren't applied multiple times, an issue that many people have observed.

## Type of change
- [x] Kind of a bug fix since it fixes multiple flows problem
- [x] New feature

## Tests
No extra tests are needed. To reproduce the old behavior, just convert any model and call `compile()` and `build()` and see how many times the same optimizers will be applied (in `model._applied_flows`).

## Checklist
- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/master/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings. Yeah, right, as if I could prove this.
