### PR TITLE
Update CI template syntax

### DIFF
--- a/test/pytest/ci-template.yml
+++ b/test/pytest/ci-template.yml
@@ -16,7 +16,8 @@
     reports:
       junit: 
         - test/pytest/report.xml
-      cobertura:
-        - test/pytest/coverage.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: test/pytest/coverage.xml
     paths:
       - test/pytest/hls4mlprj*.tar.gz


### PR DESCRIPTION
One of the Gitlab CI features we're using [had a syntax change](https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportscobertura-removed), causing some tests to fail recently on PRs. 
This PR brings the syntax up to date.