### PR TITLE
Fix parsing of ZeroPadding layers

### DIFF
--- a/hls4ml/converters/keras/reshaping.py
+++ b/hls4ml/converters/keras/reshaping.py
@@ -26,6 +26,8 @@ def parse_zeropadding1d_layer(keras_layer, input_names, input_shapes, data_reade
         ]
         layer['out_width'] = output_shape[2]
         layer['n_chan'] = output_shape[1]
+
+        layer['in_width'] = input_shapes[0][2]
     else:
         output_shape = [
             input_shapes[0][0], # Batch
@@ -34,6 +36,8 @@ def parse_zeropadding1d_layer(keras_layer, input_names, input_shapes, data_reade
         ]
         layer['out_width'] = output_shape[1]
         layer['n_chan'] = output_shape[2]
+
+        layer['in_width'] = input_shapes[0][1]
 
     return layer, output_shape
 
@@ -74,6 +78,9 @@ def parse_zeropadding2d_layer(keras_layer, input_names, input_shapes, data_reade
         layer['out_height'] = output_shape[2]
         layer['out_width'] = output_shape[3]
         layer['n_chan'] = output_shape[1]
+
+        layer['in_height'] = input_shapes[0][2]
+        layer['in_width'] = input_shapes[0][3]
     else:
         output_shape = [
             input_shapes[0][0], # Batch
@@ -84,5 +91,8 @@ def parse_zeropadding2d_layer(keras_layer, input_names, input_shapes, data_reade
         layer['out_height'] = output_shape[1]
         layer['out_width'] = output_shape[2]
         layer['n_chan'] = output_shape[3]
+
+        layer['in_height'] = input_shapes[0][1]
+        layer['in_width'] = input_shapes[0][2]
 
     return layer, output_shape

--- a/test/pytest/test_zeropadding.py
+++ b/test/pytest/test_zeropadding.py
@@ -1,0 +1,71 @@
+import pytest
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import ZeroPadding1D, ZeroPadding2D
+import numpy as np
+import hls4ml
+from pathlib import Path
+
+test_root_path = Path(__file__).parent
+
+in_height = 6
+in_width = 8
+in_feat = 4
+
+pad_t = 1
+pad_b = 2
+pad_l = 3
+pad_r = 4
+
+atol = 5e-3
+
+@pytest.fixture(scope='module')
+def data_1d():
+    X = np.random.rand(100, in_width, in_feat)
+    return X
+
+@pytest.fixture(scope='module')
+def data_2d():
+    X = np.random.rand(100, in_height, in_width, in_feat)
+    return X
+
+
+@pytest.fixture(scope='module')
+def keras_model_1d():
+    model = Sequential()
+    model.add(ZeroPadding1D(input_shape=(in_width, in_feat), padding=(pad_l, pad_r)))
+    model.compile()
+    return model
+
+@pytest.fixture(scope='module')
+def keras_model_2d():
+    model = Sequential()
+    model.add(ZeroPadding2D(input_shape=(in_height, in_width, in_feat), padding=((pad_t, pad_b), (pad_l, pad_r))))
+    model.compile()
+    return model
+
+
+@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
+@pytest.mark.parametrize('model_type', ['1d', '2d'])
+def test_zeropadding(keras_model_1d, keras_model_2d, data_1d, data_2d, model_type, io_type):
+    if model_type == '1d':
+        model = keras_model_1d
+        data = data_1d
+    else:
+        model = keras_model_2d
+        data = data_2d
+
+    config = hls4ml.utils.config_from_keras_model(model,
+                                                  default_precision='ap_fixed<32,1>',
+                                                  granularity='name')
+    odir = str(test_root_path / f'hls4mlprj_zeropadding_{model_type}_{io_type}')
+    hls_model = hls4ml.converters.convert_from_keras_model(model,
+                                                           hls_config=config,
+                                                           io_type=io_type,
+                                                           output_dir=odir,
+                                                           part='xcvu9p-flgb2104-2-i')
+    hls_model.compile()
+
+    # Predict
+    y_keras = model.predict(data).flatten()
+    y_hls = hls_model.predict(data).flatten()
+    np.testing.assert_allclose(y_keras, y_hls, rtol=0, atol=atol, verbose=True)


### PR DESCRIPTION
# Description

Fixes parsing of ZeroPadding1D/2D layers. These layers expect the input height/width to be specified. When we insert these layers to support the "same" padding of Conv1D/2D layers we properly set these values, but when parsing a Keras model that has these layers we didn't do that

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
## Tests

A test of ZeroPadding1D/2D layer functionality is included.