### PR TITLE
Remove email helpline from the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A package for machine learning inference in FPGAs. We create firmware implementations of machine learning algorithms using high level synthesis language (HLS). We translate traditional open-source machine learning package models into HLS that can be configured for your use-case!
 
-**Contact:** hls4ml.help@gmail.com
+If you have any questions, comments, or ideas regarding hls4ml or just want to show us how you use hls4ml, don't hesitate to reach us through the [discussions](https://github.com/fastmachinelearning/hls4ml/discussions) tab.
 
 # Documentation & Tutorial
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,9 +35,7 @@ Welcome to hls4ml's documentation!
 
 ``hls4ml`` is a Python package for machine learning inference in FPGAs. We create firmware implementations of machine learning algorithms using high level synthesis language (HLS). We translate traditional open-source machine learning package models into HLS that can be configured for your use-case!
 
-The project is currently in development, so please let us know if you are interested, your experiences with the package, and if you would like new features to be added.
-
-Contact: hls4ml.help@gmail.com
+The project is currently in development, so please let us know if you are interested, your experiences with the package, and if you would like new features to be added. You can reach us through our GitHub page.
 
 
 Project Status


### PR DESCRIPTION
We should retire the email helpline. GitHub discussions are a nicer way to reach the developers of hls4ml for any questions and it is all in the open. This PR updates the readme and the docs to remove the helpline.

We should still have an email (perhaps the same) as a contact point for the python package. This is required by the `setuptools`.
