### PR TITLE
Remove io_serial

### DIFF
--- a/hls4ml/backends/vivado/passes/transform_types.py
+++ b/hls4ml/backends/vivado/passes/transform_types.py
@@ -20,8 +20,6 @@ class TransformTypes(GlobalOptimizerPass):
                 new_var = self.inplace_var_converter.convert(var, io_type)
             if io_type == 'io_stream':
                 new_var = self.stream_var_converter.convert(var)
-            elif io_type == 'io_serial':
-                new_var = self.array_var_converter.convert(var, pragma='stream')
             elif io_type == 'io_parallel':
                 if node.name in node.model.inputs:
                     new_var = self.array_var_converter.convert(var, pragma='reshape')

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -188,7 +188,7 @@ def convert_from_keras_model(model, output_dir='my-hls-test', project_name='mypr
         clock_period (int, optional): Clock period of the design.
             Defaults to 5.
         io_type (str, optional): Type of implementation used. One of
-            'io_parallel' or 'io_serial'. Defaults to 'io_parallel'.
+            'io_parallel' or 'io_stream'. Defaults to 'io_parallel'.
         hls_config (dict, optional): The HLS config.
         kwargs** (dict, optional): Additional parameters that will be used to create the config of the specified backend
     Raises:
@@ -246,7 +246,7 @@ def convert_from_pytorch_model(model, input_shape, output_dir='my-hls-test', pro
     clock_period (int, optional): Clock period of the design.
         Defaults to 5.
     io_type (str, optional): Type of implementation used. One of
-        'io_parallel' or 'io_serial'. Defaults to 'io_parallel'.
+        'io_parallel' or 'io_stream'. Defaults to 'io_parallel'.
     hls_config (dict, optional): The HLS config.
     kwargs** (dict, optional): Additional parameters that will be used to create the config of the specified backend
 
@@ -319,7 +319,7 @@ def convert_from_onnx_model(model, output_dir='my-hls-test', project_name='mypro
     clock_period (int, optional): Clock period of the design.
         Defaults to 5.
     io_type (str, optional): Type of implementation used. One of
-        'io_parallel' or 'io_serial'. Defaults to 'io_parallel'.
+        'io_parallel' or 'io_stream'. Defaults to 'io_parallel'.
     hls_config (dict, optional): The HLS config.
     kwargs** (dict, optional): Additional parameters that will be used to create the config of the specified backend
 

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_common.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_common.h
@@ -37,7 +37,7 @@ typedef ac_fixed<16,6> table_default_t;
 namespace nnet {
 
 // Common type definitions
-enum io_type {io_parallel = 0, io_serial};
+enum io_type {io_parallel = 0, io_stream};
 
 // Default data types (??) TODO: Deprecate
 typedef ac_fixed<16,4>  weight_t_def;

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -48,14 +48,9 @@ struct activ_config
 template<class data_T, class res_T, typename CONFIG_T>
 void  linear(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         res[ii] = data[ii];
     }
 }
@@ -68,15 +63,10 @@ void  linear(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 template<class data_T, class res_T, typename CONFIG_T>
 void  relu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     data_T datareg;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = data[ii];
         if (datareg > 0) res[ii] = datareg;
         else res[ii] = 0;
@@ -86,15 +76,10 @@ void  relu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 template<class data_T, class res_T, int MAX_INT, typename CONFIG_T>
 void  relu_max(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     data_T datareg;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = data[ii];
         if (datareg < 0) res[ii] = 0;
         else if (datareg > MAX_INT) res[ii] = MAX_INT;
@@ -152,17 +137,12 @@ void  sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     // Index into the lookup table based on data
     int data_round;
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         data_round = data[ii]*CONFIG_T::table_size/16;
         index = data_round + 8*CONFIG_T::table_size/16;
         if (index < 0)   index = 0;
@@ -364,10 +344,7 @@ void  softmax_legacy(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
-        // Note: This is going to be a resource hog to run with pipeline, but hey, whatever
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     // Index into the lookup table based on data for exponentials
     typename CONFIG_T::table_t exp_res[CONFIG_T::n_in];// different, independent, fixed point precision
@@ -381,9 +358,6 @@ void  softmax_legacy(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
     }
 
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial) {
-            #pragma HLS PIPELINE
-        }
         for (int jj=0; jj<CONFIG_T::n_in; jj++) {
             if (ii==jj) exp_diff_res = 1;
             else {
@@ -458,17 +432,12 @@ void  tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     // Index into the lookup table based on data
     int data_round;
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         data_round = data[ii]*CONFIG_T::table_size/8;
         index = data_round + 4*CONFIG_T::table_size/8;
         //std::cout << "Input: "  << data[ii] << " Round: " << data_round << " Index: " << index << std::endl;
@@ -484,17 +453,12 @@ void  tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 template<class data_T, class res_T, typename CONFIG_T>
 void  hard_sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     data_T datareg;
     data_T slope = (data_T) 0.2;
     data_T shift = (data_T) 0.5;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = slope * data[ii] + shift;
         if (datareg > 1) datareg = 1;
         else if (datareg < 0) datareg = 0;
@@ -508,15 +472,10 @@ void  hard_sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 template<class data_T, class res_T, typename CONFIG_T>
 void  leaky_relu(data_T data[CONFIG_T::n_in], data_T alpha, res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     data_T datareg;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = data[ii];
         if (datareg > 0) res[ii] = datareg;
         else res[ii] = alpha * datareg;
@@ -529,15 +488,10 @@ void  leaky_relu(data_T data[CONFIG_T::n_in], data_T alpha, res_T res[CONFIG_T::
 template<class data_T, class res_T, typename CONFIG_T>
 void  thresholded_relu(data_T data[CONFIG_T::n_in], data_T theta, res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     data_T datareg;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = data[ii];
         if (datareg > theta) res[ii] = datareg;
         else res[ii] = 0;
@@ -582,17 +536,12 @@ void  softplus(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     // Index into the lookup table based on data
     int data_round;
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         data_round = data[ii]*CONFIG_T::table_size/16;
         index = data_round + 8*CONFIG_T::table_size/16;
         if (index < 0)   index = 0;
@@ -639,17 +588,12 @@ void  softsign(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     // Index into the lookup table based on data
     int data_round;
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         data_round = data[ii]*CONFIG_T::table_size/16;
         index = data_round + 8*CONFIG_T::table_size/16;
         if (index < 0)   index = 0;
@@ -696,17 +640,12 @@ void  elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     data_T datareg;
     // Index into the lookup table based on data
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = data[ii];
         if (datareg >= 0) {
             res[ii] = datareg;
@@ -762,17 +701,12 @@ void  selu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         initialized = true;
     }
 
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     data_T datareg;
     // Index into the lookup table based on data
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = data[ii];
         if (datareg >= 0) {
             res[ii] = res_T(1.0507009873554804934193349852946) * datareg;
@@ -790,15 +724,10 @@ void  selu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 template<class data_T, class res_T, typename CONFIG_T>
 void  prelu(data_T data[CONFIG_T::n_in], data_T alpha[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     data_T datareg;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = data[ii];
         if (datareg > 0) res[ii] = datareg;
         else res[ii] = alpha[ii] * datareg;
@@ -811,16 +740,11 @@ void  prelu(data_T data[CONFIG_T::n_in], data_T alpha[CONFIG_T::n_in], res_T res
 template<class data_T, class res_T, typename CONFIG_T>
 void  binary_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
 
     data_T datareg;
     res_T cache;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = data[ii];
         if( datareg > 0 ) cache = 1;
         else cache = -1;
@@ -835,17 +759,11 @@ void  binary_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 template<class data_T, class res_T, typename CONFIG_T>
 void  ternary_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
-
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-    }
+    #pragma HLS PIPELINE
   
     data_T datareg;   
     res_T cache; 
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial) {
-            #pragma HLS PIPELINE
-        }
         datareg = 2*data[ii];
         if( datareg > 1 ) cache = 1;
         else if( datareg > -1 && datareg <= 1) cache=0;

--- a/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_batchnorm.h
@@ -61,32 +61,20 @@ void normalize(
     // Use a function_instantiate in case it helps to explicitly optimize unchanging weights/biases
     #pragma HLS function_instantiate variable=scale,bias
 
-    if (CONFIG_T::io_type == io_parallel) {
-        // For parallel inputs:
-        //   - completely partition arrays -- target fabric
-        //   - if we have an unroll factor, limit number of multipliers
-        #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
+    // For parallel inputs:
+    //   - completely partition arrays -- target fabric
+    //   - if we have an unroll factor, limit number of multipliers
+    #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
-        // #pragma HLS ARRAY_PARTITION variable=weights complete // remove this line for now, it breaks compression sometimes
-        #pragma HLS ARRAY_PARTITION variable=scale complete
-        #pragma HLS ARRAY_PARTITION variable=bias complete
+    // #pragma HLS ARRAY_PARTITION variable=weights complete // remove this line for now, it breaks compression sometimes
+    #pragma HLS ARRAY_PARTITION variable=scale complete
+    #pragma HLS ARRAY_PARTITION variable=bias complete
 
-        int multiplier_limit  = ceil(float(CONFIG_T::n_in) / float(CONFIG_T::reuse_factor));
-        CONFIG_T::template product<data_T, typename CONFIG_T::scale_t>::limit(multiplier_limit);
-
-    } else if (CONFIG_T::io_type == io_serial) {
-        #pragma HLS ARRAY_RESHAPE variable=scale complete dim=1
-        #pragma HLS ARRAY_RESHAPE variable=bias complete dim=1
-        #pragma HLS DATAFLOW
-    }            
+    int multiplier_limit  = ceil(float(CONFIG_T::n_in) / float(CONFIG_T::reuse_factor));
+    CONFIG_T::template product<data_T, typename CONFIG_T::scale_t>::limit(multiplier_limit);
 
     // Calcuate result
     Result: for (int ires = 0; ires < CONFIG_T::n_in; ires++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS UNROLL
-            #pragma HLS PIPELINE
-        }
-        
         if (CONFIG_T::n_filt==-1) {
             res[ires] = CONFIG_T::template product<data_T, typename CONFIG_T::scale_t>::product(data[ires], scale[ires]) + bias[ires];
 	    } else {
@@ -114,17 +102,12 @@ struct batchnorm_quantized_tanh_config
 template<class data_T, typename CONFIG_T>
 void  normalize_binary_tanh(data_T data[CONFIG_T::n_in], ap_uint<1> res[CONFIG_T::n_in], data_T threshold[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-        #pragma HLS ARRAY_PARTITION variable=res complete
-    }
+    #pragma HLS PIPELINE
+    #pragma HLS ARRAY_PARTITION variable=res complete
 
     data_T datareg;   
     ap_uint<1> cache; 
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = data[ii];	 
         int norm_index = CONFIG_T::n_filt==-1 ? ii : ii%CONFIG_T::n_filt;
         if( datareg > threshold[norm_index] ) cache = 1;
@@ -138,17 +121,12 @@ void  normalize_binary_tanh(data_T data[CONFIG_T::n_in], ap_uint<1> res[CONFIG_T
 template<class data_T, typename CONFIG_T>
 void  normalize_ternary_tanh(data_T data[CONFIG_T::n_in], ap_int<2> res[CONFIG_T::n_in], data_T threshold_hi[CONFIG_T::n_in], data_T threshold_lo[CONFIG_T::n_in])
 {
-    if (CONFIG_T::io_type == io_parallel){
-        #pragma HLS PIPELINE
-        #pragma HLS ARRAY_PARTITION variable=res complete
-    }
+    #pragma HLS PIPELINE
+    #pragma HLS ARRAY_PARTITION variable=res complete
 
     data_T datareg;   
     ap_int<2> cache; 
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         datareg = data[ii];
         int norm_index = CONFIG_T::n_filt==-1 ? ii : ii%CONFIG_T::n_filt;
         if( datareg > threshold_hi[norm_index] ) cache = 1;

--- a/hls4ml/templates/vivado/nnet_utils/nnet_common.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_common.h
@@ -30,7 +30,7 @@
 namespace nnet {
 
 // Common type definitions
-enum io_type {io_parallel = 0, io_serial, io_stream};
+enum io_type {io_parallel = 0, io_stream};
 enum strategy { latency, resource };
 
  /* ---

--- a/hls4ml/templates/vivado/nnet_utils/nnet_dense_latency.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_dense_latency.h
@@ -42,85 +42,43 @@ void dense_latency(
     // Use a function_instantiate in case it helps to explicitly optimize unchanging weights/biases
     #pragma HLS function_instantiate variable=weights,biases
 
-    if (CONFIG_T::io_type == io_parallel || CONFIG_T::io_type == io_stream){
-        // For parallel inputs:
-        //   - completely partition arrays -- target fabric
-        //   - if we have an unroll factor, limit number of multipliers
-        #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
+    // For parallel inputs:
+    //   - completely partition arrays -- target fabric
+    //   - if we have an unroll factor, limit number of multipliers
+    #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
-        // #pragma HLS ARRAY_PARTITION variable=weights complete // remove this line for now, it breaks compression sometimes
-        #pragma HLS ARRAY_PARTITION variable=biases complete
-        #pragma HLS ARRAY_PARTITION variable=mult complete
-        #pragma HLS ARRAY_PARTITION variable=acc complete
+    // #pragma HLS ARRAY_PARTITION variable=weights complete // remove this line for now, it breaks compression sometimes
+    #pragma HLS ARRAY_PARTITION variable=biases complete
+    #pragma HLS ARRAY_PARTITION variable=mult complete
+    #pragma HLS ARRAY_PARTITION variable=acc complete
 
-        int multiplier_limit  = ceil(float(CONFIG_T::n_in*CONFIG_T::n_out) / float(CONFIG_T::reuse_factor)) - floor(float(CONFIG_T::n_zeros) / float(CONFIG_T::reuse_factor));
-        CONFIG_T::template product<data_T, typename CONFIG_T::weight_t>::limit(multiplier_limit);
-
-    } else if (CONFIG_T::io_type == io_serial){
-        // Only reduce cycle_factor if n_out is evenly divisible by reuse_factor
-        // Otherwise, HLS wont be happy
-        int cycle_factor = CONFIG_T::n_out / CONFIG_T::reuse_factor;
-        int reused_cycle = DIV_ROUNDUP(CONFIG_T::n_out, CONFIG_T::reuse_factor);
-        if (cycle_factor != reused_cycle) {
-            cycle_factor = CONFIG_T::n_out;
-        }
-        /*int cycle_factor = CONFIG_T::n_out;
-        float reused_cycle = CONFIG_T::n_out / CONFIG_T::reuse_factor;
-        if (reused_cycle == ceil(reused_cycle)){
-            // Dont use "ceil" here; as of 2018.2, HLS crashes mysteriously
-            cycle_factor = cycle_factor / CONFIG_T::reuse_factor;
-        }*/
-        #pragma HLS ARRAY_PARTITION variable=weights cyclic factor=cycle_factor
-        #pragma HLS ARRAY_PARTITION variable=mult cyclic factor=cycle_factor
-        #pragma HLS ARRAY_PARTITION variable=acc complete
-        #pragma HLS DATAFLOW
-        #pragma HLS STREAM variable=mult depth=1
-        #pragma HLS STREAM variable=acc depth=1
-        if (CONFIG_T::store_weights_in_bram){
-            #pragma HLS RESOURCE variable=weights core=ROM_2P_BRAM
-        }
-    }
+    int multiplier_limit  = ceil(float(CONFIG_T::n_in*CONFIG_T::n_out) / float(CONFIG_T::reuse_factor)) - floor(float(CONFIG_T::n_zeros) / float(CONFIG_T::reuse_factor));
+    CONFIG_T::template product<data_T, typename CONFIG_T::weight_t>::limit(multiplier_limit);
 
     // Do the matrix-multiply
     Product1: for(int ii = 0; ii < CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         cache = data[ii];
         Product2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
-            if (CONFIG_T::io_type == io_serial) {
-                int multiplier_limit  = ceil(float(CONFIG_T::n_out) / float(CONFIG_T::reuse_factor));
-                CONFIG_T::template product<data_T, typename CONFIG_T::weight_t>::limit(multiplier_limit);
-            }
-        int index = ii*CONFIG_T::n_out+jj;
-        mult[index] = CONFIG_T::template product<data_T, typename CONFIG_T::weight_t>::product(cache, weights[index]);
+            int index = ii*CONFIG_T::n_out+jj;
+            mult[index] = CONFIG_T::template product<data_T, typename CONFIG_T::weight_t>::product(cache, weights[index]);
         }
     }
 
     // Initialize accumulator with input biases
     ResetAccum: for(int iacc = 0; iacc < CONFIG_T::n_out; iacc++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS UNROLL
-        }
         acc[iacc] = (typename CONFIG_T::accum_t) biases[iacc];
     }
 
     // Accumulate multiplication result
     Accum1: for(int ii = 0; ii < CONFIG_T::n_in; ii++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
         Accum2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
-        int index = ii*CONFIG_T::n_out+jj;
-        acc[jj] += mult[index];
+            int index = ii*CONFIG_T::n_out+jj;
+            acc[jj] += mult[index];
         }
     }
 
     // Cast to "res_t" type
-    Result: for(int ires = 0; ires < CONFIG_T::n_out; ires++){
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS UNROLL
-        }
+    Result: for(int ires = 0; ires < CONFIG_T::n_out; ires++) {
         //res[ires] = (res_T) (acc[ires]);
         res[ires] = cast<data_T, res_T, CONFIG_T>(acc[ires]);
     }

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -155,7 +155,7 @@ class VivadoWriter(Writer):
                         newline += indent + '#pragma HLS DATAFLOW \n'
                     else:
                         newline += indent + '#pragma HLS PIPELINE \n'
-                if io_type == 'io_serial' or io_type == 'io_stream':
+                if io_type == 'io_stream':
                     newline += indent + '#pragma HLS INTERFACE axis port={},{} \n'.format(','.join(all_inputs), ','.join(all_outputs))
                     if all_brams:
                         newline += indent + '#pragma HLS INTERFACE bram port={} \n'.format(','.join(all_brams))


### PR DESCRIPTION
# Description

Remove the old `io_serial` from the HLS templates. 

Why now? Well, I would like Vitis and Vivado implementations to be as similar as possible (ideally identical) and Vitis changed how `PIPELINE` pragma can be applied. So constructs like
```
if (CONFIG_T::io_type == io_parallel){
    #pragma HLS PIPELINE
}
```
are not allowed anymore, and the function doesn't get pipelined. Since we use this trick to switch between `io_parallel` and `io_serial`, removing `io_serial` will also get rid of the requirement for checking the `io_type`. This allows the array-based implementations to be identical in Vitis and Vivado (at least it appears so, still need more tests).

## Type of change

- [x] Other (Specify) - Cleanup

## Tests

No tests, we remove traces of non-functional code.
