### PR TITLE
QConv alpha != 1 bug fix

### DIFF
--- a/hls4ml/model/optimizer/passes/qkeras.py
+++ b/hls4ml/model/optimizer/passes/qkeras.py
@@ -189,11 +189,18 @@ class QKerasFactorizeAlpha(OptimizerPass):
         else:
             scale_quantizer = None
 
+        if 'Dense' in node.class_name:
+            n_in = node.get_attr('n_out')
+        elif 'Conv' in node.class_name:
+            n_in = node.get_attr('out_width') * node.get_attr('out_height', 1) * node.get_attr('n_filt')
+        else:
+            n_in = node.get_attr('n_out')
+
         attrs = {
             'name' : node.get_attr('name') + '_alpha',
             'class_name' : 'Alpha',
             'inputs' : node.outputs,
-            'n_in' : node.get_attr('n_out'),
+            'n_in' : n_in,
             'n_filt' : node.get_attr('n_filt', -1),
             'reuse_factor' : node.get_attr('reuse_factor'),
             'scale_data': scale,


### PR DESCRIPTION
A# Description

> :memo: Please include a summary of the change. 
>  When using `alpha='auto'` an exception is thrown because Conv1D & Conv2D have no attribute `n_in`, `n_out` which is needed for the `ApplyAlpha` layer config template

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
## Tests

> :memo: Please describe the tests that you ran to verify your changes.
To reproduce error, run most up-to-date version of hls4ml with the following QKeras model:
```
keras_model = Sequential()
keras_model.add(QConv2D(4, (3, 3), input_shape=(4, 4, 1), kernel_quantizer=quantized_bits(4, 0, alpha='auto')))
keras_model.compile()
```

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/master/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.B