### PR TITLE
Quartus Synthesis Flow Improvement

### DIFF
--- a/hls4ml/backends/quartus/quartus_backend.py
+++ b/hls4ml/backends/quartus/quartus_backend.py
@@ -115,35 +115,43 @@ class QuartusBackend(FPGABackend):
         layer.weights['weight'].data_length = layer.weights['weight'].data.size
         return
 
-    def build(self, model, synth=True, fpgasynth=False):
+    def build(self, model, synth=True, fpgasynth=False, log_level=1, cont_if_large_area=False):
         """
         Builds the project using Intel HLS compiler.
 
-        Users should generally not call this function directly but instead use `ModelGraph.build()`.
-        This function assumes the model was written with a call to `ModelGraph.write()`
-
         Args:
             model (ModelGraph): The model to build
-            synth, optional: Whether to run synthesis
-            fpgasynth, optional:  Whether to run fpga synthesis
-
+            synth, optional: Whether to run HLS synthesis
+            fpgasynth, optional:  Whether to run FPGA synthesis (Quartus Compile)
+            log_level, optional: Logging level to be displayed during HLS synthesis (0, 1, 2)
+            cont_if_large_area: Instruct the HLS compiler to continue synthesis if the estimated resource usaga exceeds device resources
         Errors raise exceptions
         """
+
+        # Check software needed is present
         found = os.system('command -v i++ > /dev/null')
         if found != 0:
             raise Exception('Intel HLS installation not found. Make sure "i++" is on PATH.')
 
-        with chdir(model.config.get_output_dir()):
-            if synth:
-                os.system('make {}-fpga'.format(model.config.get_project_name()))
-                os.system('./{}-fpga'.format(model.config.get_project_name()))
-
-            if fpgasynth:
+        if fpgasynth:
+                if fpgasynth and not synth:
+                    raise Exception('HLS Synthesis needs to be run before FPGA synthesis')
                 found = os.system('command -v quartus_sh > /dev/null')
                 if found != 0:
                     raise Exception('Quartus installation not found. Make sure "quartus_sh" is on PATH.')
-                os.chdir(model.config.get_project_name() + '-fpga.prj/quartus')
-                os.system('quartus_sh --flow compile quartus_compile')
+
+        with chdir(model.config.get_output_dir()):
+            if synth:
+                quartus_compile = 'QUARTUS_COMPILE=--quartus-compile' if fpgasynth else ''
+                cont_synth = 'CONT_IF_LARGE_AREA=--dont-error-if-large-area-est' if cont_if_large_area else ''
+                log_1 = 'LOGGING_1=-v ' if log_level >= 1 else ''
+                log_2 = 'LOGGING_2=-v ' if log_level >= 2 else '' 
+                os.system(f'make {model.config.get_project_name()}-fpga {log_1} {log_2} {cont_synth} {quartus_compile}')
+                
+                # If running i++ through a container, such a singularity, this command will throw an exception, because the host OS doesn't have access to HLS simulation tools
+                # To avoid the exception, shell into the container (e.g. singularity shell ....) and then execute the following command manually
+                # This command simply tests the IP using a simulation tool and obtains the latency and initiation interval
+                os.system('./{}-fpga'.format(model.config.get_project_name()))
 
         return parse_quartus_report(model.config.get_output_dir())
 

--- a/hls4ml/report/quartus_report.py
+++ b/hls4ml/report/quartus_report.py
@@ -5,19 +5,18 @@ from calmjs.parse import asttypes
 from tabulate import tabulate
 from ast import literal_eval
 
-def parse_quartus_report(hls_dir):
-    """
+def parse_quartus_report(hls_dir, write_to_file=True):
+    '''
     Parse a report from a given Quartus project as a dictionary.
 
     Args:
-        hls_dir (string):  The directory where the project is found
+        hls_dir (string): The directory where the project is found
+        write_to_file (bool): A flag indicating whether to write the results to a separate file 
 
     Returns:
-        dict: the report dictionary
+        results (dict): The report dictionary, containing latency, resource usage etc.
 
-    Raises exceptions on errors
-
-    """
+    '''
     if not os.path.exists(hls_dir):
         print('Path {} does not exist. Exiting.'.format(hls_dir))
         return
@@ -29,16 +28,29 @@ def parse_quartus_report(hls_dir):
         print('Project {} does not exist. Rerun "hls4ml build -p {}".'.format(prj_dir, hls_dir))
         return
 
-    return _find_reports(rpt_dir)
+    results = _find_reports(rpt_dir)
+    print(results)
+    if write_to_file:
+        print("Here")
+        f = open(hls_dir + '/' 'synthesis-report.txt', 'w')
+        f.write('HLS Synthesis Latency & Resource Usage Report')
+        for key in results:
+            f.write(str(key) + ':' + str(results[key]) + '\n')
+        print("There")
+        print(f'Saved latency & resource usage summary to {hls_dir}/synthesis-report.txt')
+    return results
 
 def read_quartus_report(hls_dir, open_browser=False):
-    """
+    '''
     Parse and print the Quartus report to print the report. Optionally open a browser.
 
     Args:
         hls_dir (string):  The directory where the project is found
         open_browser, optional:  whether to open a browser
-    """
+    
+    Returns:
+        None
+    '''
     report = parse_quartus_report(hls_dir)
 
     print('HLS Resource Summary\n')
@@ -56,6 +68,15 @@ def read_quartus_report(hls_dir, open_browser=False):
         webbrowser.open(url)
 
 def _find_project_dir(hls_dir):
+    '''
+    Finds the synthesis folder from the HLS project directory
+    
+    Args: 
+        hls_dir (string): HLS project location
+    
+    Returns:
+        project_dir (string): Synthesis folder within HLS project directory
+    '''
     top_func_name = None
 
     with open(hls_dir + '/build_lib.sh', 'r') as f:
@@ -65,103 +86,148 @@ def _find_project_dir(hls_dir):
 
     return top_func_name + '-fpga.prj'
 
-def _find_reports(rpt_dir):
-    def read_js_object(js_script):
-        """
-        Reads the JS input (js_script, a string), and return a dictionary of
-        variables definded in the JS.
-        """
-        def visit(node):
-            if isinstance(node, asttypes.Program):
-                d = {}
-                for child in node:
-                    if not isinstance(child, asttypes.VarStatement):
-                        raise ValueError("All statements should be var statements")
-                    key, val = visit(child)
-                    d[key] = val
-                return d
-            elif isinstance(node, asttypes.VarStatement):
-                return visit(node.children()[0])
-            elif isinstance(node, asttypes.VarDecl):
-                return (visit(node.identifier), visit(node.initializer))
-            elif isinstance(node, asttypes.Object):
-                d = {}
-                for property in node:
-                    key = visit(property.left)
-                    value = visit(property.right)
-                    d[key] = value
-                return d
-            elif isinstance(node, asttypes.BinOp):
-                # simple constant folding
-                if node.op == '+':
-                    if isinstance(node.left, asttypes.String) and isinstance(node.right, asttypes.String):
-                        return visit(node.left) + visit(node.right)
-                    elif isinstance(node.left, asttypes.Number) and isinstance(node.right, asttypes.Number):
-                        return visit(node.left) + visit(node.right)
-                    else:
-                        raise ValueError("Cannot + on anything other than two literals")
+def read_js_object(js_script):
+    '''
+    Reads the JavaScript file and return a dictionary of variables definded in the script.
+    
+    Args: 
+        js_script (string) - path to JavaScript File
+    
+    Returns:
+        Dictionary of variables defines in script
+    '''
+    def visit(node):
+        if isinstance(node, asttypes.Program):
+            d = {}
+            for child in node:
+                if not isinstance(child, asttypes.VarStatement):
+                    raise ValueError("All statements should be var statements")
+                key, val = visit(child)
+                d[key] = val
+            return d
+        elif isinstance(node, asttypes.VarStatement):
+            return visit(node.children()[0])
+        elif isinstance(node, asttypes.VarDecl):
+            return (visit(node.identifier), visit(node.initializer))
+        elif isinstance(node, asttypes.Object):
+            d = {}
+            for property in node:
+                key = visit(property.left)
+                value = visit(property.right)
+                d[key] = value
+            return d
+        elif isinstance(node, asttypes.BinOp):
+            # simple constant folding
+            if node.op == '+':
+                if isinstance(node.left, asttypes.String) and isinstance(node.right, asttypes.String):
+                    return visit(node.left) + visit(node.right)
+                elif isinstance(node.left, asttypes.Number) and isinstance(node.right, asttypes.Number):
+                    return visit(node.left) + visit(node.right)
                 else:
-                    raise ValueError("Cannot do operator '%s'" % node.op)
-
-            elif isinstance(node, asttypes.String) or isinstance(node, asttypes.Number):
-                return literal_eval(node.value)
-            elif isinstance(node, asttypes.Array):
-                return [visit(x) for x in node]
-            elif isinstance(node, asttypes.Null):
-                return None
-            elif isinstance(node, asttypes.Boolean):
-                if str(node) == "false":
-                    return False
-                else:
-                    return True
-            elif isinstance(node, asttypes.Identifier):
-                return node.value
+                    raise ValueError("Cannot + on anything other than two literals")
             else:
-                raise Exception("Unhandled node: %r" % node)
-        return visit(es5(js_script))
+                raise ValueError("Cannot do operator '%s'" % node.op)
 
-    def _read_quartus_file(filename, results):
-        with open(filename) as dataFile:
-            quartus_data = dataFile.read()
-            quartus_data = read_js_object(quartus_data)
-
-        if(quartus_data['quartusJSON']['quartusFitClockSummary']['nodes'][0]['clock'] != "TBD"):
-            results['Clock'] = quartus_data['quartusJSON']['quartusFitClockSummary']['nodes'][0]['clock']
-            results['Quartus ALM'] = quartus_data['quartusJSON']['quartusFitResourceUsageSummary']['nodes'][-1]['alm']
-            results['Quartus REG'] = quartus_data['quartusJSON']['quartusFitResourceUsageSummary']['nodes'][-1]['reg']
-            results['Quartus DSP'] = quartus_data['quartusJSON']['quartusFitResourceUsageSummary']['nodes'][-1]['dsp']
-            results['Quartus RAM'] = quartus_data['quartusJSON']['quartusFitResourceUsageSummary']['nodes'][-1]['ram']
-            results['Quartus MLAB'] = quartus_data['quartusJSON']['quartusFitResourceUsageSummary']['nodes'][-1]['mlab']
-
-
-    def _read_report_file(filename, results):
-        with open(filename) as dataFile:
-            report_data = dataFile.read()
-            report_data = report_data[: report_data.rfind('var fileJSON')]
-            report_data = read_js_object(report_data)
-            results['HLS ALUT'], results['HLS FF'], results['HLS RAM'], results['HLS DSP'], results['HLS MLAB'] = report_data['areaJSON']['total']
-            results['HLS ALUT percent'], results['HLS FF percent'], results['HLS RAM percent'], results['HLS DSP percent'], results['HLS MLAB percent'] = report_data['areaJSON']['total_percent']
-
-
-
-    def _read_verification_file(filename, results):
-        if os.path.isfile(filename):
-            with open(filename) as dataFile:
-                verification_data = dataFile.read()
-                verification_data = read_js_object(verification_data)
-            results['num_invocation'] = verification_data['verifJSON']['functions'][0]['data'][0]
-            results['Latency'] = verification_data['verifJSON']['functions'][0]['data'][1].split(",")
-            results['ii'] = verification_data['verifJSON']['functions'][0]['data'][2].split(",")
+        elif isinstance(node, asttypes.String) or isinstance(node, asttypes.Number):
+            return literal_eval(node.value)
+        elif isinstance(node, asttypes.Array):
+            return [visit(x) for x in node]
+        elif isinstance(node, asttypes.Null):
+            return None
+        elif isinstance(node, asttypes.Boolean):
+            if str(node) == "false":
+                return False
+            else:
+                return True
+        elif isinstance(node, asttypes.Identifier):
+            return node.value
         else:
-            print('Verification file not found. Run ./[projectname]-fpga to generate.')
+            raise Exception("Unhandled node: %r" % node)
+    return visit(es5(js_script))
 
+def _read_quartus_file(filename):
+    '''
+    Reads results (clock frequency, resource usage) obtained through FPGA synthesis (full Quartus compilation)
+
+    Args:
+        filename (string): Location of Quartus report
+    
+    Returns:
+        results (dict): Resource usage obtained through Quartus Compile
+    '''
+
+    with open(filename) as dataFile:
+        quartus_data = dataFile.read()
+        quartus_data = read_js_object(quartus_data)
 
     results = {}
-    quartus_file = rpt_dir + '/lib/quartus_data.js'
-    report_file = rpt_dir + '/lib/report_data.js'
-    verification_file = rpt_dir + '/lib/verification_data.js'
-    _read_report_file(report_file, results)
-    _read_verification_file(verification_file, results)
-    _read_quartus_file(quartus_file, results)
+    if(quartus_data['quartusJSON']['quartusFitClockSummary']['nodes'][0]['clock'] != "TBD"):
+        results['Clock'] = quartus_data['quartusJSON']['quartusFitClockSummary']['nodes'][0]['clock']
+        results['Quartus ALM'] = quartus_data['quartusJSON']['quartusFitResourceUsageSummary']['nodes'][-1]['alm']
+        results['Quartus REG'] = quartus_data['quartusJSON']['quartusFitResourceUsageSummary']['nodes'][-1]['reg']
+        results['Quartus DSP'] = quartus_data['quartusJSON']['quartusFitResourceUsageSummary']['nodes'][-1]['dsp']
+        results['Quartus RAM'] = quartus_data['quartusJSON']['quartusFitResourceUsageSummary']['nodes'][-1]['ram']
+        results['Quartus MLAB'] = quartus_data['quartusJSON']['quartusFitResourceUsageSummary']['nodes'][-1]['mlab']
+    else:
+        print('Quartus report not found. Run Quartus Compilation using Quartus Shell or Full Compilation from Intel Quartus Prime')
+    return results
 
+def _read_hls_file(filename):
+    '''
+    Reads HLS resource estimate obtained through HLS synthesis
+
+    Args:
+        filename (string):  Location of HLS report
+
+    Returns:
+        results (dict): Resource usage obtained through HLS Estimation
+    '''
+    with open(filename) as dataFile:
+        report_data = dataFile.read()
+        report_data = report_data[: report_data.rfind('var fileJSON')]
+        report_data = read_js_object(report_data)
+        results = {}
+        results['HLS Estimate ALUT'], results['HLS Estimate FF'], results['HLS Estimate RAM'], results['HLS Estimate DSP'], results['HLS Estimate MLAB'] = report_data['areaJSON']['total']
+        results['HLS Estimate ALUT (%)'], results['HLS Estimate FF(%)'], results['HLS Estimate RAM (%)'], results['HLS Estimate DSP (%)'], results['HLS Estimate MLAB (%)'] = report_data['areaJSON']['total_percent']
+        return results
+
+def _read_verification_file(filename):
+    '''
+    Reads verification data (latency, initiation interval) obtained through simulation
+
+    Args:
+        filename (string):  Location of verification file
+    
+    Returns:
+        results (dict): Verification data obtained from simulation
+    '''
+    results = {}
+    if os.path.isfile(filename):
+        with open(filename) as dataFile:
+            verification_data = dataFile.read()
+            verification_data = read_js_object(verification_data)
+        
+        try:
+            results['Number of Invoations'] = verification_data['verifJSON']['functions'][0]['data'][0]
+            
+            latency = verification_data['verifJSON']['functions'][0]['data'][1].split(",") 
+            results['Latency (MIN)'] = latency[0]
+            results['Latency (MAX)'] = latency[1]
+            results['Latency (AVG)'] = latency[2]
+            
+            ii = verification_data['verifJSON']['functions'][0]['data'][2].split(",")
+            results['ii (MIN)'] = ii[0]
+            results['ii (MAX)'] = ii[1]
+            results['ii (AVG)'] = ii[2]
+        except:
+            print('Verification data not found. Run ./[projectname]-fpga to generate.')
+    else:
+        print('Verification file not found. Run ./[projectname]-fpga to generate.')
+    return results
+
+def _find_reports(rpt_dir):
+    results = {}
+    results.update(_read_hls_file(rpt_dir + '/lib/report_data.js'))
+    results.update(_read_verification_file(rpt_dir + '/lib/verification_data.js'))
+    results.update(_read_quartus_file(rpt_dir + '/lib/quartus_data.js'))
     return results

--- a/hls4ml/templates/quartus/Makefile
+++ b/hls4ml/templates/quartus/Makefile
@@ -1,12 +1,16 @@
 DEVICE   := Arria10
 TARGETS  := myproject-fpga
 
-CXX          := i++
-CXXFLAGS     := $(USERCXXFLAGS) -Ifirmware/ap_types/ -march=$(DEVICE)#--quartus-compile
-RM           := rm -rf
-DEBUG_FLAGS  = --time $@_time.log -v
-SOURCE_FILES := myproject_test.cpp firmware/myproject.cpp
-HEADER_FILES := firmware/myproject.h
+CXX          		:= i++
+CXXFLAGS     		:= -march=$(DEVICE)
+RM           		:= rm -rf
+DEBUG_FLAGS  		:= --time quartus-hlssynt.log
+SOURCE_FILES 		:= myproject_test.cpp firmware/myproject.cpp
+HEADER_FILES 		:= firmware/myproject.h
+LOGGING_1			:= 
+LOGGING_2			:= 
+QUARTUS_COMPILE 	:= 
+CONT_IF_LARGE_AREA 	:=
 
 .PHONY: test
 test: $(TARGETS)
@@ -23,4 +27,4 @@ clean:
 myproject-fpga: CXXFLAGS := $(CXXFLAGS)
 
 $(TARGETS) : $(SOURCE_FILES) $(HEADER_FILES)
-	$(CXX) $(CXXFLAGS) $(DEBUG_FLAGS) $(SOURCE_FILES) -o $@
+	$(CXX) $(LOGGING_1) $(LOGGING_2) $(CXXFLAGS) $(DEBUG_FLAGS) $(SOURCE_FILES) $(CONT_IF_LARGE_AREA) $(QUARTUS_COMPILE) -o $@


### PR DESCRIPTION
# Description

> :memo: Improves the Quartus synthesis flow with more logging, storing resource usage and latency results to files and more robust compilation flags

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests

> :memo: A few models were synthesized, in order to verify more logging and the presence of files containing synthesis results.

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/master/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

This PR attempts to do three things in the Quartus synthesis flow:

1. Add a variable level of logging during HLS synthesis, which allows the user to see the exact stage of HLS synthesis, alongside any warnings, intermediate fails, reasons of failure etc.
2. Write HLS synthesis results (resource usage and timing analysis) to a text file, so these can be reused later. Also, a common issue with Quartus synthesis is an exception encountered when reading verification results (latency and ii), which are obtained by running the binary produced by HLS synthesis. If i++ is not available on the host system natively (such as when it is installed in a container, e.g. singularity), running the binary from hls4ml will throw an exception after which the execution of the entire program halts, because verification results are not obtained. This PR addresses this problem by placing the verification inside a try-catch clause as well as providing clear instructions why an exception is encountered.
3. Adds a flag to HLS synthesis to continue compiling if a large area is estimated. Sometimes, the HLS compiler overestimate the resources needed, and fails compilation. Therefore, we allow the compilation to continue (even if it can't fit on the desired FPGA) to perform some analysis. This is a configurable flag and not used by default.