### PR TITLE
Edit order of the optimizers in the flow so that BramFactor is followed

### DIFF
--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -56,8 +56,8 @@ class VivadoBackend(FPGABackend):
         optimization_flow = register_flow('optimize', optimization_passes, requires=[init_flow], backend=self.name)
 
         vivado_types = [
-            'vivado:register_bram_weights',
             'vivado:transform_types',
+            'vivado:register_bram_weights',
             'vivado:generate_conv_streaming_instructions',
             'vivado:apply_resource_strategy',
         ]

--- a/test/pytest/test_bram_factor.py
+++ b/test/pytest/test_bram_factor.py
@@ -1,0 +1,47 @@
+import pytest
+import hls4ml
+import tensorflow as tf
+import numpy as np
+from pathlib import Path
+from tensorflow.keras.layers import Input, Dense, Activation
+
+import math
+
+test_root_path = Path(__file__).parent
+
+def test_bram_factor():
+    '''A copy of the test_dense from test_keras_api.py with BramFactor set to 0'''
+    model = tf.keras.models.Sequential()
+    model.add(Dense(2,
+              input_shape=(1,),
+              name='Dense',
+              use_bias=True,
+              kernel_initializer= tf.keras.initializers.RandomUniform(minval=1, maxval=10),
+              bias_initializer='zeros',
+              kernel_regularizer=None,
+              bias_regularizer=None,
+              activity_regularizer=None,
+              kernel_constraint=None,
+              bias_constraint=None))
+    model.add(Activation(activation='elu', name='Activation'))
+    model.compile(optimizer='adam', loss='mse')
+
+    X_input = np.random.rand(100,1)
+
+    keras_prediction = model.predict(X_input)
+
+    config = hls4ml.utils.config_from_keras_model(model)
+    config["Model"]["BramFactor"] = 0
+    output_dir = str(test_root_path / 'hls4mlprj_bram_factor')
+
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir)
+
+    hls_model.compile()
+
+    hls_prediction = hls_model.predict(X_input)
+
+    np.testing.assert_allclose(hls_prediction, keras_prediction, rtol=1e-2, atol=0.01)
+
+    # Check that there weights are actually remote
+    model_brams = [var for var in hls_model.get_weight_variables() if var.storage.lower() == 'bram']
+    assert len(model_brams) == 2


### PR DESCRIPTION
# Description

The order of the optimizers made `register_bram_weights` do nothing. Moving it after `transform_types` seems to fix the problem. Also added a simple pytest to make sure that `BramFactor` is not ignored.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Added `test_bram_factor.py`, which copies `test_dense` from `test_keras_api.py` but with `BramFactor` set to 0. A check is added to make sure that some variables have `storage == 'bram'`.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/master/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.