### PR TITLE
fix nondefault project name handling

### DIFF
--- a/hls4ml/report/vivado_report.py
+++ b/hls4ml/report/vivado_report.py
@@ -39,7 +39,7 @@ def _parse_project_script(path):
 
     with open(project_path, 'r') as f:
         for line in f.readlines():
-            if 'set myproject' in line:
+            if 'set project_name' in line:
                 top_func_name = line.split('"')[-2]
                 prj_dir = top_func_name + '_prj'
 

--- a/hls4ml/report/vivado_report.py
+++ b/hls4ml/report/vivado_report.py
@@ -12,8 +12,8 @@ def read_vivado_report(hls_dir, full_report=False):
     prj_dir = None
     top_func_name = None
 
-    if os.path.isfile(hls_dir + '/build_prj.tcl'):
-        prj_dir, top_func_name = _parse_build_script(hls_dir + '/build_prj.tcl')
+    if os.path.isfile(hls_dir + '/project.tcl'):
+        prj_dir, top_func_name = _parse_build_script(hls_dir)
 
     if prj_dir is None or top_func_name is None:
         print('Unable to read project data. Exiting.')
@@ -35,17 +35,13 @@ def _parse_build_script(path):
     prj_dir = None
     top_func_name = None
 
-    build_path = path + '/build_prj.tcl'
     project_path = path + '/project.tcl'
-    with open(build_path, 'r') as f:
-        for line in f.readlines():
-            if 'set_top' in line:
-                top_func_name = line.split()[-1]
 
     with open(project_path, 'r') as f:
         for line in f.readlines():
             if 'set myproject' in line:
-                prj_dir = line.split('"')[-2] + '_prj'
+                top_func_name = line.split('"')[-2]
+                prj_dir = top_func_name + '_prj'
 
     return prj_dir, top_func_name
 

--- a/hls4ml/report/vivado_report.py
+++ b/hls4ml/report/vivado_report.py
@@ -13,7 +13,7 @@ def read_vivado_report(hls_dir, full_report=False):
     top_func_name = None
 
     if os.path.isfile(hls_dir + '/project.tcl'):
-        prj_dir, top_func_name = _parse_build_script(hls_dir)
+        prj_dir, top_func_name = _parse_project_script(hls_dir)
 
     if prj_dir is None or top_func_name is None:
         print('Unable to read project data. Exiting.')
@@ -31,7 +31,7 @@ def read_vivado_report(hls_dir, full_report=False):
         print('Reports for solution "{}":\n'.format(sln))
         _find_reports(sln_dir + '/' + sln, top_func_name, full_report)
 
-def _parse_build_script(path):
+def _parse_project_script(path):
     prj_dir = None
     top_func_name = None
 
@@ -109,8 +109,8 @@ def parse_vivado_report(hls_dir):
     prj_dir = None
     top_func_name = None
 
-    if os.path.isfile(hls_dir + '/build_prj.tcl'):
-        prj_dir, top_func_name = _parse_build_script(hls_dir)
+    if os.path.isfile(hls_dir + '/project.tcl'):
+        prj_dir, top_func_name = _parse_project_script(hls_dir)
 
     if prj_dir is None or top_func_name is None:
         print('Unable to read project data. Exiting.')

--- a/hls4ml/templates/vivado/build_prj.tcl
+++ b/hls4ml/templates/vivado/build_prj.tcl
@@ -60,15 +60,15 @@ proc add_vcd_instructions_tcl {} {
         if {[string equal "$line" "log_wave -r /"]} {
             set line {source "../../../../project.tcl"
                 if {[string equal "$backend" "vivadoaccelerator"]} {
-                    current_scope [get_scopes -regex /apatb_${project_name}_axi_top/AESL_inst_${project_name}_axi/${project_name}_U0.*]
+                    current_scope [get_scopes -regex "/apatb_${project_name}_axi_top/AESL_inst_${project_name}_axi/${project_name}_U0.*"]
                     set scopes [get_scopes -regexp {layer(\d*)_.*data_0_V_U.*}]
                     append scopes { }
-                    current_scope /apatb_${project_name}_axi_top/AESL_inst_${project_name}_axi
+                    current_scope "/apatb_${project_name}_axi_top/AESL_inst_${project_name}_axi"
                     append scopes [get_scopes -regexp {(in_local_V_data.*_0_.*)}]
                     append scopes { }
                     append scopes [get_scopes -regexp {(out_local_V_data.*_0_.*)}]
                 } else {
-                    current_scope [get_scopes -regex /apatb_${project_name}_top/AESL_inst_${project_name}]
+                    current_scope [get_scopes -regex "/apatb_${project_name}_top/AESL_inst_${project_name}"]
                     set scopes [get_scopes -regexp {layer(\d*)_.*data_0_V_U.*}]
                 }
                 open_vcd fifo_opt.vcd
@@ -88,8 +88,6 @@ proc add_vcd_instructions_tcl {} {
                     log_wave $depth
                 }
             }
-
-            set line [string map [list "project_name" $project_name] $line]
         }
 
         if {[string equal "$line" "quit"]} {

--- a/hls4ml/templates/vivado/build_prj.tcl
+++ b/hls4ml/templates/vivado/build_prj.tcl
@@ -2,14 +2,14 @@
 #    HLS4ML
 #################
 array set opt {
-  reset      0
-  csim       1
-  synth      1
-  cosim      1
-  validation 1
-  export     0
-  vsynth     0
-  fifo_opt   0
+    reset      0
+    csim       1
+    synth      1
+    cosim      1
+    validation 1
+    export     0
+    vsynth     0
+    fifo_opt   0
 }
 
 set tcldir [file dirname [info script]]
@@ -35,12 +35,12 @@ proc remove_recursive_log_wave {} {
         puts $out $line
     }
 
-     close $in
-     close $out
+    close $in
+    close $out
 
-     # move the new data to the proper filename
-     file delete -force $filename
-     file rename -force $temp $filename
+    # move the new data to the proper filename
+    file delete -force $filename
+    file rename -force $temp $filename
 }
 
 proc add_vcd_instructions_tcl {} {
@@ -58,45 +58,45 @@ proc add_vcd_instructions_tcl {} {
     # line-by-line, read the original file
     while {[gets $in line] != -1} {
         if {[string equal "$line" "log_wave -r /"]} {
-        set line {source "../../../../project.tcl"
-if {[string equal "$backend" "vivadoaccelerator"]} {
-    current_scope [get_scopes -regex /apatb_${myproject}_axi_top/AESL_inst_${myproject}_axi/${myproject}_U0.*]
-    set scopes [get_scopes -regexp {layer(\d*)_.*data_0_V_U.*}]
-    append scopes { }
-    current_scope /apatb_${myproject}_axi_top/AESL_inst_${myproject}_axi
-    append scopes [get_scopes -regexp {(in_local_V_data.*_0_.*)}]
-    append scopes { }
-    append scopes [get_scopes -regexp {(out_local_V_data.*_0_.*)}]
-} else {
-    current_scope [get_scopes -regex /apatb_${myproject}_top/AESL_inst_${myproject}]
-    set scopes [get_scopes -regexp {layer(\d*)_.*data_0_V_U.*}]
-}
-open_vcd fifo_opt.vcd
-foreach scope $scopes {
-    current_scope $scope
-    if {[catch [get_objects usedw]] == 0} {
-      puts "$scope skipped"
-      continue
-    }
-    set usedw [get_objects usedw]
-    set depth [get_objects DEPTH]
-    add_wave $usedw
-    log_vcd $usedw
-    log_wave $usedw
-    add_wave $depth
-    log_vcd $depth
-    log_wave $depth
-    }
-    }
+            set line {source "../../../../project.tcl"
+                if {[string equal "$backend" "vivadoaccelerator"]} {
+                    current_scope [get_scopes -regex /apatb_${myproject}_axi_top/AESL_inst_${myproject}_axi/${myproject}_U0.*]
+                    set scopes [get_scopes -regexp {layer(\d*)_.*data_0_V_U.*}]
+                    append scopes { }
+                    current_scope /apatb_${myproject}_axi_top/AESL_inst_${myproject}_axi
+                    append scopes [get_scopes -regexp {(in_local_V_data.*_0_.*)}]
+                    append scopes { }
+                    append scopes [get_scopes -regexp {(out_local_V_data.*_0_.*)}]
+                } else {
+                    current_scope [get_scopes -regex /apatb_${myproject}_top/AESL_inst_${myproject}]
+                    set scopes [get_scopes -regexp {layer(\d*)_.*data_0_V_U.*}]
+                }
+                open_vcd fifo_opt.vcd
+                foreach scope $scopes {
+                    current_scope $scope
+                    if {[catch [get_objects usedw]] == 0} {
+                        puts "$scope skipped"
+                        continue
+                    }
+                    set usedw [get_objects usedw]
+                    set depth [get_objects DEPTH]
+                    add_wave $usedw
+                    log_vcd $usedw
+                    log_wave $usedw
+                    add_wave $depth
+                    log_vcd $depth
+                    log_wave $depth
+                }
+            }
 
-    set line [string map [list "myproject" $myproject] $line]
+            set line [string map [list "myproject" $myproject] $line]
         }
 
         if {[string equal "$line" "quit"]} {
             set line {flush_vcd
-close_vcd
-quit
-}
+                close_vcd
+                quit
+            }
         }
         # then write the transformed line
         puts $out $line
@@ -111,17 +111,17 @@ quit
 }
 
 foreach arg $::argv {
-  foreach o [lsort [array names opt]] {
-    regexp "$o=+(\\w+)" $arg unused opt($o)
-  }
+    foreach o [lsort [array names opt]] {
+        regexp "$o=+(\\w+)" $arg unused opt($o)
+    }
 }
 
 proc report_time { op_name time_start time_end } {
-  set time_taken [expr $time_end - $time_start]
-  set time_s [expr ($time_taken / 1000) % 60]
-  set time_m [expr ($time_taken / (1000*60)) % 60]
-  set time_h [expr ($time_taken / (1000*60*60)) % 24]
-  puts "***** ${op_name} COMPLETED IN ${time_h}h${time_m}m${time_s}s *****"
+    set time_taken [expr $time_end - $time_start]
+    set time_s [expr ($time_taken / 1000) % 60]
+    set time_m [expr ($time_taken / (1000*60)) % 60]
+    set time_h [expr ($time_taken / (1000*60*60)) % 24]
+    puts "***** ${op_name} COMPLETED IN ${time_h}h${time_m}m${time_s}s *****"
 }
 
 # Compare file content: 1 = same, 0 = different
@@ -149,19 +149,19 @@ set CSIM_RESULTS "./tb_data/csim_results.log"
 set RTL_COSIM_RESULTS "./tb_data/rtl_cosim_results.log"
 
 if {$opt(reset)} {
-  open_project -reset ${myproject}_prj
+    open_project -reset ${myproject}_prj
 } else {
-  open_project ${myproject}_prj
+    open_project ${myproject}_prj
 }
-set_top myproject
-add_files firmware/myproject.cpp -cflags "-std=c++0x"
-add_files -tb myproject_test.cpp -cflags "-std=c++0x"
+set_top ${myproject}
+add_files firmware/${myproject}.cpp -cflags "-std=c++0x"
+add_files -tb ${myproject}_test.cpp -cflags "-std=c++0x"
 add_files -tb firmware/weights
 add_files -tb tb_data
 if {$opt(reset)} {
-  open_solution -reset "solution1"
+    open_solution -reset "solution1"
 } else {
-  open_solution "solution1"
+    open_solution "solution1"
 }
 catch {config_array_partition -maximum_size 4096}
 config_compile -name_max_length 60
@@ -170,81 +170,81 @@ create_clock -period 5 -name default
 
 
 if {$opt(csim)} {
-  puts "***** C SIMULATION *****"
-  set time_start [clock clicks -milliseconds]
-  csim_design
-  set time_end [clock clicks -milliseconds]
-  report_time "C SIMULATION" $time_start $time_end
+    puts "***** C SIMULATION *****"
+    set time_start [clock clicks -milliseconds]
+    csim_design
+    set time_end [clock clicks -milliseconds]
+    report_time "C SIMULATION" $time_start $time_end
 }
 
 if {$opt(synth)} {
-  puts "***** C/RTL SYNTHESIS *****"
-  set time_start [clock clicks -milliseconds]
-  csynth_design
-  set time_end [clock clicks -milliseconds]
-  report_time "C/RTL SYNTHESIS" $time_start $time_end
+    puts "***** C/RTL SYNTHESIS *****"
+    set time_start [clock clicks -milliseconds]
+    csynth_design
+    set time_end [clock clicks -milliseconds]
+    report_time "C/RTL SYNTHESIS" $time_start $time_end
 }
 
 if {$opt(cosim)} {
-  puts "***** C/RTL SIMULATION *****"
-  # TODO: This is a workaround (Xilinx defines __RTL_SIMULATION__ only for SystemC testbenches).
-  add_files -tb myproject_test.cpp -cflags "-std=c++0x -DRTL_SIM"
-  set time_start [clock clicks -milliseconds]
+    puts "***** C/RTL SIMULATION *****"
+    # TODO: This is a workaround (Xilinx defines __RTL_SIMULATION__ only for SystemC testbenches).
+    add_files -tb ${myproject}_test.cpp -cflags "-std=c++0x -DRTL_SIM"
+    set time_start [clock clicks -milliseconds]
 
-  cosim_design -trace_level all -setup
+    cosim_design -trace_level all -setup
 
-  if {$opt(fifo_opt)} {
-    puts "\[hls4ml\] - FIFO optimization started"
-    add_vcd_instructions_tcl
-  }
+    if {$opt(fifo_opt)} {
+        puts "\[hls4ml\] - FIFO optimization started"
+        add_vcd_instructions_tcl
+    }
 
-  remove_recursive_log_wave
-  set old_pwd [pwd]
-  cd ${myproject}_prj/solution1/sim/verilog/
-  source run_sim.tcl
-  cd $old_pwd
+    remove_recursive_log_wave
+    set old_pwd [pwd]
+    cd ${myproject}_prj/solution1/sim/verilog/
+    source run_sim.tcl
+    cd $old_pwd
 
-  set time_end [clock clicks -milliseconds]
-  puts "INFO:"
-  if {[string equal "$backend" "vivadoaccelerator"]} {
-    puts [read [open ${myproject}_prj/solution1/sim/report/${myproject}_axi_cosim.rpt r]]
-  } else {
-    puts [read [open ${myproject}_prj/solution1/sim/report/${myproject}_cosim.rpt r]]
-  }
-  report_time "C/RTL SIMULATION" $time_start $time_end
+    set time_end [clock clicks -milliseconds]
+    puts "INFO:"
+    if {[string equal "$backend" "vivadoaccelerator"]} {
+        puts [read [open ${myproject}_prj/solution1/sim/report/${myproject}_axi_cosim.rpt r]]
+    } else {
+        puts [read [open ${myproject}_prj/solution1/sim/report/${myproject}_cosim.rpt r]]
+    }
+    report_time "C/RTL SIMULATION" $time_start $time_end
 }
 
 if {$opt(validation)} {
-  puts "***** C/RTL VALIDATION *****"
-  if {[compare_files $CSIM_RESULTS $RTL_COSIM_RESULTS]} {
-      puts "INFO: Test PASSED"
-  } else {
-      puts "ERROR: Test failed"
-      puts "ERROR: - csim log:      $CSIM_RESULTS"
-      puts "ERROR: - RTL-cosim log: $RTL_COSIM_RESULTS"
-      exit 1
-  }
+    puts "***** C/RTL VALIDATION *****"
+    if {[compare_files $CSIM_RESULTS $RTL_COSIM_RESULTS]} {
+        puts "INFO: Test PASSED"
+    } else {
+        puts "ERROR: Test failed"
+        puts "ERROR: - csim log:      $CSIM_RESULTS"
+        puts "ERROR: - RTL-cosim log: $RTL_COSIM_RESULTS"
+        exit 1
+    }
 }
 
 if {$opt(export)} {
-  puts "***** EXPORT IP *****"
-  set time_start [clock clicks -milliseconds]
-  export_design -format ip_catalog
-  set time_end [clock clicks -milliseconds]
-  report_time "EXPORT IP" $time_start $time_end
+    puts "***** EXPORT IP *****"
+    set time_start [clock clicks -milliseconds]
+    export_design -format ip_catalog
+    set time_end [clock clicks -milliseconds]
+    report_time "EXPORT IP" $time_start $time_end
 }
 
 if {$opt(vsynth)} {
-  puts "***** VIVADO SYNTHESIS *****"
-  if {[file exist ${myproject}_prj/solution1/syn/vhdl]} {
-    set time_start [clock clicks -milliseconds]
-    exec vivado -mode batch -source vivado_synth.tcl >@ stdout
-    set time_end [clock clicks -milliseconds]
-    report_time "VIVADO SYNTHESIS" $time_start $time_end
-  } else {
-    puts "ERROR: Cannot find generated VHDL files. Did you run C synthesis?"
-    exit 1
-  }
+    puts "***** VIVADO SYNTHESIS *****"
+    if {[file exist ${myproject}_prj/solution1/syn/vhdl]} {
+        set time_start [clock clicks -milliseconds]
+        exec vivado -mode batch -source vivado_synth.tcl >@ stdout
+        set time_end [clock clicks -milliseconds]
+        report_time "VIVADO SYNTHESIS" $time_start $time_end
+    } else {
+        puts "ERROR: Cannot find generated VHDL files. Did you run C synthesis?"
+        exit 1
+    }
 }
 
 exit

--- a/hls4ml/templates/vivado/build_prj.tcl
+++ b/hls4ml/templates/vivado/build_prj.tcl
@@ -19,7 +19,7 @@ proc remove_recursive_log_wave {} {
     set tcldir [file dirname [info script]]
     source [file join $tcldir project.tcl]
 
-    set filename ${myproject}_prj/solution1/sim/verilog/${myproject}.tcl
+    set filename ${project_name}_prj/solution1/sim/verilog/${project_name}.tcl
     set timestamp [clock format [clock seconds] -format {%Y%m%d%H%M%S}]
     set temp     $filename.new.$timestamp
     # set backup   $filename.bak.$timestamp
@@ -47,7 +47,7 @@ proc add_vcd_instructions_tcl {} {
     set tcldir [file dirname [info script]]
     source [file join $tcldir project.tcl]
 
-    set filename ${myproject}_prj/solution1/sim/verilog/${myproject}.tcl
+    set filename ${project_name}_prj/solution1/sim/verilog/${project_name}.tcl
     set timestamp [clock format [clock seconds] -format {%Y%m%d%H%M%S}]
     set temp     $filename.new.$timestamp
     # set backup   $filename.bak.$timestamp
@@ -60,15 +60,15 @@ proc add_vcd_instructions_tcl {} {
         if {[string equal "$line" "log_wave -r /"]} {
             set line {source "../../../../project.tcl"
                 if {[string equal "$backend" "vivadoaccelerator"]} {
-                    current_scope [get_scopes -regex /apatb_${myproject}_axi_top/AESL_inst_${myproject}_axi/${myproject}_U0.*]
+                    current_scope [get_scopes -regex /apatb_${project_name}_axi_top/AESL_inst_${project_name}_axi/${project_name}_U0.*]
                     set scopes [get_scopes -regexp {layer(\d*)_.*data_0_V_U.*}]
                     append scopes { }
-                    current_scope /apatb_${myproject}_axi_top/AESL_inst_${myproject}_axi
+                    current_scope /apatb_${project_name}_axi_top/AESL_inst_${project_name}_axi
                     append scopes [get_scopes -regexp {(in_local_V_data.*_0_.*)}]
                     append scopes { }
                     append scopes [get_scopes -regexp {(out_local_V_data.*_0_.*)}]
                 } else {
-                    current_scope [get_scopes -regex /apatb_${myproject}_top/AESL_inst_${myproject}]
+                    current_scope [get_scopes -regex /apatb_${project_name}_top/AESL_inst_${project_name}]
                     set scopes [get_scopes -regexp {layer(\d*)_.*data_0_V_U.*}]
                 }
                 open_vcd fifo_opt.vcd
@@ -89,7 +89,7 @@ proc add_vcd_instructions_tcl {} {
                 }
             }
 
-            set line [string map [list "myproject" $myproject] $line]
+            set line [string map [list "project_name" $project_name] $line]
         }
 
         if {[string equal "$line" "quit"]} {
@@ -149,13 +149,13 @@ set CSIM_RESULTS "./tb_data/csim_results.log"
 set RTL_COSIM_RESULTS "./tb_data/rtl_cosim_results.log"
 
 if {$opt(reset)} {
-    open_project -reset ${myproject}_prj
+    open_project -reset ${project_name}_prj
 } else {
-    open_project ${myproject}_prj
+    open_project ${project_name}_prj
 }
-set_top ${myproject}
-add_files firmware/${myproject}.cpp -cflags "-std=c++0x"
-add_files -tb ${myproject}_test.cpp -cflags "-std=c++0x"
+set_top ${project_name}
+add_files firmware/${project_name}.cpp -cflags "-std=c++0x"
+add_files -tb ${project_name}_test.cpp -cflags "-std=c++0x"
 add_files -tb firmware/weights
 add_files -tb tb_data
 if {$opt(reset)} {
@@ -188,7 +188,7 @@ if {$opt(synth)} {
 if {$opt(cosim)} {
     puts "***** C/RTL SIMULATION *****"
     # TODO: This is a workaround (Xilinx defines __RTL_SIMULATION__ only for SystemC testbenches).
-    add_files -tb ${myproject}_test.cpp -cflags "-std=c++0x -DRTL_SIM"
+    add_files -tb ${project_name}_test.cpp -cflags "-std=c++0x -DRTL_SIM"
     set time_start [clock clicks -milliseconds]
 
     cosim_design -trace_level all -setup
@@ -200,16 +200,16 @@ if {$opt(cosim)} {
 
     remove_recursive_log_wave
     set old_pwd [pwd]
-    cd ${myproject}_prj/solution1/sim/verilog/
+    cd ${project_name}_prj/solution1/sim/verilog/
     source run_sim.tcl
     cd $old_pwd
 
     set time_end [clock clicks -milliseconds]
     puts "INFO:"
     if {[string equal "$backend" "vivadoaccelerator"]} {
-        puts [read [open ${myproject}_prj/solution1/sim/report/${myproject}_axi_cosim.rpt r]]
+        puts [read [open ${project_name}_prj/solution1/sim/report/${project_name}_axi_cosim.rpt r]]
     } else {
-        puts [read [open ${myproject}_prj/solution1/sim/report/${myproject}_cosim.rpt r]]
+        puts [read [open ${project_name}_prj/solution1/sim/report/${project_name}_cosim.rpt r]]
     }
     report_time "C/RTL SIMULATION" $time_start $time_end
 }
@@ -236,7 +236,7 @@ if {$opt(export)} {
 
 if {$opt(vsynth)} {
     puts "***** VIVADO SYNTHESIS *****"
-    if {[file exist ${myproject}_prj/solution1/syn/vhdl]} {
+    if {[file exist ${project_name}_prj/solution1/syn/vhdl]} {
         set time_start [clock clicks -milliseconds]
         exec vivado -mode batch -source vivado_synth.tcl >@ stdout
         set time_end [clock clicks -milliseconds]

--- a/hls4ml/templates/vivado/build_prj.tcl
+++ b/hls4ml/templates/vivado/build_prj.tcl
@@ -165,8 +165,8 @@ if {$opt(reset)} {
 }
 catch {config_array_partition -maximum_size 4096}
 config_compile -name_max_length 60
-set_part {xcku115-flvb2104-2-i}
-create_clock -period 5 -name default
+set_part $part
+create_clock -period $clock_period -name default
 
 
 if {$opt(csim)} {

--- a/hls4ml/templates/vivado/vivado_synth.tcl
+++ b/hls4ml/templates/vivado/vivado_synth.tcl
@@ -1,3 +1,6 @@
-add_files myproject_prj/solution1/syn/vhdl
-synth_design -top myproject -part xcku115-flvb2104-2-i
+set tcldir [file dirname [info script]]
+source [file join $tcldir project.tcl]
+
+add_files ${myproject}_prj/solution1/syn/vhdl
+synth_design -top ${project_name} -part $part
 report_utilization -file vivado_synth.rpt

--- a/hls4ml/templates/vivado/vivado_synth.tcl
+++ b/hls4ml/templates/vivado/vivado_synth.tcl
@@ -1,6 +1,6 @@
 set tcldir [file dirname [info script]]
 source [file join $tcldir project.tcl]
 
-add_files ${myproject}_prj/solution1/syn/vhdl
+add_files ${project_name}_prj/solution1/syn/vhdl
 synth_design -top ${project_name} -part $part
 report_utilization -file vivado_synth.rpt

--- a/hls4ml/templates/vivado_accelerator/alveo/tcl_scripts/axi_stream_design.tcl
+++ b/hls4ml/templates/vivado_accelerator/alveo/tcl_scripts/axi_stream_design.tcl
@@ -1,18 +1,18 @@
 set tcldir [file dirname [info script]]
 source [file join $tcldir project.tcl]
 
-create_project project_1 ${myproject}_vivado_accelerator -part ${part} -force
+create_project project_1 ${project_name}_vivado_accelerator -part ${part} -force
 
-set_property  ip_repo_paths  ${myproject}_prj [current_project]
+set_property  ip_repo_paths  ${project_name}_prj [current_project]
 update_ip_catalog
 
 
-add_files -scan_for_includes {src/krnl_rtl_int.sv src/krnl_rtl_axi_read_master.sv src/krnl_rtl_counter.sv src/myproject_kernel.v src/krnl_rtl_axi_write_master.sv src/krnl_rtl_control_s_axi.v}
-import_files {src/krnl_rtl_int.sv src/krnl_rtl_axi_read_master.sv src/krnl_rtl_counter.sv src/myproject_kernel.v src/krnl_rtl_axi_write_master.sv src/krnl_rtl_control_s_axi.v}
+add_files -scan_for_includes {src/krnl_rtl_int.sv src/krnl_rtl_axi_read_master.sv src/krnl_rtl_counter.sv src/${project_name}_kernel.v src/krnl_rtl_axi_write_master.sv src/krnl_rtl_control_s_axi.v}
+import_files {src/krnl_rtl_int.sv src/krnl_rtl_axi_read_master.sv src/krnl_rtl_counter.sv src/${project_name}_kernel.v src/krnl_rtl_axi_write_master.sv src/krnl_rtl_control_s_axi.v}
 
 
 
-create_ip -vlnv xilinx.com:hls:${myproject}_axi:1.0 -module_name myproject_axi_0
+create_ip -vlnv xilinx.com:hls:${project_name}_axi:1.0 -module_name ${project_name}_axi_0
 
 
 ipx::package_project -root_dir hls4ml_IP -vendor fastmachinelearning.org -library hls4ml -taxonomy /UserIP -import_files -set_current false
@@ -106,4 +106,4 @@ ipx::archive_core hls4ml_IP/fastmachinelearning.org_hls4ml_krnl_rtl_1.0.zip [ipx
 current_project project_1
 
 
-package_xo  -force -xo_path xo_files/${myproject}_kernel.xo -kernel_name krnl_rtl -ip_directory hls4ml_IP
+package_xo  -force -xo_path xo_files/${project_name}_kernel.xo -kernel_name krnl_rtl -ip_directory hls4ml_IP

--- a/hls4ml/templates/vivado_accelerator/pynq-z2/tcl_scripts/axi_lite_design.tcl
+++ b/hls4ml/templates/vivado_accelerator/pynq-z2/tcl_scripts/axi_lite_design.tcl
@@ -1,21 +1,21 @@
 set tcldir [file dirname [info script]]
 source [file join $tcldir project.tcl]
 
-create_project project_1 ${myproject}_vivado_accelerator -part xc7z020clg400-1 -force
+create_project project_1 ${project_name}_vivado_accelerator -part xc7z020clg400-1 -force
 
 set_property board_part tul.com.tw:pynq-z2:part0:1.0 [current_project]
-set_property  ip_repo_paths  ${myproject}_prj [current_project]
+set_property  ip_repo_paths  ${project_name}_prj [current_project]
 update_ip_catalog
 
 # Create Block Designer design
 create_bd_design "design_1"
 create_bd_cell -type ip -vlnv xilinx.com:ip:processing_system7:5.5 processing_system7_0
 apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {make_external "FIXED_IO, DDR" apply_board_preset "1" Master "Disable" Slave "Disable" }  [get_bd_cells processing_system7_0]
-create_bd_cell -type ip -vlnv xilinx.com:hls:${myproject}_axi:1.0 ${myproject}_axi_0
-apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {Auto} Clk_slave {Auto} Clk_xbar {Auto} Master {/processing_system7_0/M_AXI_GP0} Slave {/${myproject}_axi_0/s_axi_AXILiteS} ddr_seg {Auto} intc_ip {New AXI Interconnect} master_apm {0}}  [get_bd_intf_pins ${myproject}_axi_0/s_axi_AXILiteS]
+create_bd_cell -type ip -vlnv xilinx.com:hls:${project_name}_axi:1.0 ${project_name}_axi_0
+apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {Auto} Clk_slave {Auto} Clk_xbar {Auto} Master {/processing_system7_0/M_AXI_GP0} Slave {/${project_name}_axi_0/s_axi_AXILiteS} ddr_seg {Auto} intc_ip {New AXI Interconnect} master_apm {0}}  [get_bd_intf_pins ${project_name}_axi_0/s_axi_AXILiteS]
 
-make_wrapper -files [get_files ./${myproject}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/design_1.bd] -top
-add_files -norecurse ./${myproject}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/hdl/design_1_wrapper.v
+make_wrapper -files [get_files ./${project_name}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/design_1.bd] -top
+add_files -norecurse ./${project_name}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/hdl/design_1_wrapper.v
 
 reset_run impl_1
 reset_run synth_1

--- a/hls4ml/templates/vivado_accelerator/pynq-z2/tcl_scripts/axi_stream_design.tcl
+++ b/hls4ml/templates/vivado_accelerator/pynq-z2/tcl_scripts/axi_stream_design.tcl
@@ -2,10 +2,10 @@
 set tcldir [file dirname [info script]]
 source [file join $tcldir project.tcl]
 
-create_project project_1 ${myproject}_vivado_accelerator -part xc7z020clg400-1 -force
+create_project project_1 ${project_name}_vivado_accelerator -part xc7z020clg400-1 -force
 
 set_property board_part tul.com.tw:pynq-z2:part0:1.0 [current_project]
-set_property  ip_repo_paths  ${myproject}_prj [current_project]
+set_property  ip_repo_paths  ${project_name}_prj [current_project]
 update_ip_catalog
 
 create_bd_design "design_1"
@@ -36,19 +36,19 @@ endgroup
 apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {Auto} Clk_slave {/processing_system7_0/FCLK_CLK0 (100 MHz)} Clk_xbar {/processing_system7_0/FCLK_CLK0 (100 MHz)} Master {/axi_dma_0/M_AXI_S2MM} Slave {/processing_system7_0/S_AXI_HP0} ddr_seg {Auto} intc_ip {/axi_mem_intercon} master_apm {0}}  [get_bd_intf_pins axi_dma_0/M_AXI_S2MM]
 
 startgroup
-create_bd_cell -type ip -vlnv xilinx.com:hls:${myproject}_axi:1.0 ${myproject}_axi_0
+create_bd_cell -type ip -vlnv xilinx.com:hls:${project_name}_axi:1.0 ${project_name}_axi_0
 endgroup
 
-connect_bd_intf_net [get_bd_intf_pins axi_dma_0/M_AXIS_MM2S] [get_bd_intf_pins ${myproject}_axi_0/in_r]
-connect_bd_intf_net [get_bd_intf_pins ${myproject}_axi_0/out_r] [get_bd_intf_pins axi_dma_0/S_AXIS_S2MM]
+connect_bd_intf_net [get_bd_intf_pins axi_dma_0/M_AXIS_MM2S] [get_bd_intf_pins ${project_name}_axi_0/in_r]
+connect_bd_intf_net [get_bd_intf_pins ${project_name}_axi_0/out_r] [get_bd_intf_pins axi_dma_0/S_AXIS_S2MM]
 
-apply_bd_automation -rule xilinx.com:bd_rule:clkrst -config { Clk {/processing_system7_0/FCLK_CLK0 (100 MHz)} Freq {100} Ref_Clk0 {} Ref_Clk1 {} Ref_Clk2 {}}  [get_bd_pins ${myproject}_axi_0/ap_clk]
+apply_bd_automation -rule xilinx.com:bd_rule:clkrst -config { Clk {/processing_system7_0/FCLK_CLK0 (100 MHz)} Freq {100} Ref_Clk0 {} Ref_Clk1 {} Ref_Clk2 {}}  [get_bd_pins ${project_name}_axi_0/ap_clk]
 
-group_bd_cells hier_0 [get_bd_cells axi_dma_0] [get_bd_cells ${myproject}_axi_0]
+group_bd_cells hier_0 [get_bd_cells axi_dma_0] [get_bd_cells ${project_name}_axi_0]
 
-make_wrapper -files [get_files ./${myproject}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/design_1.bd] -top
+make_wrapper -files [get_files ./${project_name}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/design_1.bd] -top
 
-add_files -norecurse ./${myproject}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/hdl/design_1_wrapper.v
+add_files -norecurse ./${project_name}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/hdl/design_1_wrapper.v
 
 reset_run impl_1
 reset_run synth_1

--- a/hls4ml/templates/vivado_accelerator/zcu102/tcl_scripts/axi_stream_design.tcl
+++ b/hls4ml/templates/vivado_accelerator/zcu102/tcl_scripts/axi_stream_design.tcl
@@ -2,14 +2,14 @@
 set tcldir [file dirname [info script]]
 source [file join $tcldir project.tcl]
 
-create_project project_1 ${myproject}_vivado_accelerator -part xczu9eg-ffvb1156-2-e -force
+create_project project_1 ${project_name}_vivado_accelerator -part xczu9eg-ffvb1156-2-e -force
 
 set_property board_part xilinx.com:zcu102:part0:3.3 [current_project]
-set_property  ip_repo_paths  ${myproject}_prj [current_project]
+set_property  ip_repo_paths  ${project_name}_prj [current_project]
 update_ip_catalog
 
 create_bd_design "design_1"
-set_property  ip_repo_paths ${myproject}_prj/solution1/impl/ip [current_project]
+set_property  ip_repo_paths ${project_name}_prj/solution1/impl/ip [current_project]
 update_ip_catalog
 
 startgroup
@@ -37,17 +37,17 @@ apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {Auto} Cl
 endgroup
 
 startgroup
-create_bd_cell -type ip -vlnv xilinx.com:hls:${myproject}_axi:1.0 ${myproject}_axi_0
+create_bd_cell -type ip -vlnv xilinx.com:hls:${project_name}_axi:1.0 ${project_name}_axi_0
 endgroup
-connect_bd_intf_net [get_bd_intf_pins axi_dma_0/M_AXIS_MM2S] [get_bd_intf_pins ${myproject}_axi_0/in_r]
-connect_bd_intf_net [get_bd_intf_pins axi_dma_0/S_AXIS_S2MM] [get_bd_intf_pins ${myproject}_axi_0/out_r]
+connect_bd_intf_net [get_bd_intf_pins axi_dma_0/M_AXIS_MM2S] [get_bd_intf_pins ${project_name}_axi_0/in_r]
+connect_bd_intf_net [get_bd_intf_pins axi_dma_0/S_AXIS_S2MM] [get_bd_intf_pins ${project_name}_axi_0/out_r]
 
-apply_bd_automation -rule xilinx.com:bd_rule:clkrst -config { Clk {/zynq_ultra_ps_e_0/pl_clk0 (99 MHz)} Freq {100} Ref_Clk0 {} Ref_Clk1 {} Ref_Clk2 {}}  [get_bd_pins ${myproject}_axi_0/ap_clk]
-group_bd_cells hier_0 [get_bd_cells axi_dma_0] [get_bd_cells ${myproject}_axi_0]
+apply_bd_automation -rule xilinx.com:bd_rule:clkrst -config { Clk {/zynq_ultra_ps_e_0/pl_clk0 (99 MHz)} Freq {100} Ref_Clk0 {} Ref_Clk1 {} Ref_Clk2 {}}  [get_bd_pins ${project_name}_axi_0/ap_clk]
+group_bd_cells hier_0 [get_bd_cells axi_dma_0] [get_bd_cells ${project_name}_axi_0]
 
-make_wrapper -files [get_files ./${myproject}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/design_1.bd] -top
+make_wrapper -files [get_files ./${project_name}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/design_1.bd] -top
 
-add_files -norecurse ./${myproject}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/hdl/design_1_wrapper.v
+add_files -norecurse ./${project_name}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/hdl/design_1_wrapper.v
 
 reset_run impl_1
 reset_run synth_1

--- a/hls4ml/writer/vivado_accelerator_writer.py
+++ b/hls4ml/writer/vivado_accelerator_writer.py
@@ -205,8 +205,8 @@ class VivadoAcceleratorWriter(VivadoWriter):
                     model.config.get_project_name())
             elif '{}_cosim'.format(model.config.get_project_name()) in line:
                 newline = line.replace('{}_cosim'.format(model.config.get_project_name()), '{}_axi_cosim'.format(model.config.get_project_name()))
-            elif '${myproject}.tcl' in line:
-                newline = line.replace('${myproject}.tcl', '${myproject}_axi.tcl')
+            elif '${project_name}.tcl' in line:
+                newline = line.replace('${project_name}.tcl', '${project_name}_axi.tcl')
             else:
                 newline = line
             fout.write(newline)

--- a/hls4ml/writer/vivado_accelerator_writer.py
+++ b/hls4ml/writer/vivado_accelerator_writer.py
@@ -327,13 +327,19 @@ class VivadoAcceleratorWriter(VivadoWriter):
             src_dir=os.path.join(filedir, self.vivado_accelerator_config.get_krnl_rtl_src_dir())
             dst_dir= os.path.abspath(model.config.get_output_dir())+'/src'
             copy_tree(src_dir,dst_dir)
+
+        ###################
+        # project.tcl
+        ###################
         f = open('{}/project.tcl'.format(model.config.get_output_dir()), 'w')
-        f.write('variable myproject\n')
-        f.write('set myproject "{}"\n'.format(model.config.get_project_name()))
-        f.write('variable backend\nset backend vivadoaccelerator\n')
-        if self.vivado_accelerator_config.get_board().startswith('alveo'):
-             f.write('variable part\n')
-             f.write('set part "{}"\n'.format(self.vivado_accelerator_config.get_part()))
+        f.write('variable project_name\n')
+        f.write('set project_name "{}"\n'.format(model.config.get_project_name()))
+        f.write('variable backend\n')
+        f.write('set backend "vivadoaccelerator"\n')
+        f.write('variable part\n')
+        f.write('set part "{}"\n'.format(self.vivado_accelerator_config.get_part()))
+        f.write('variable clock_period\n')
+        f.write('set clock_period {}\n'.format(model.config.get_config_value('ClockPeriod')))
         if self.vivado_accelerator_config.get_interface() == 'axi_stream':
             in_bit, out_bit = self.vivado_accelerator_config.get_io_bitwidth()
             f.write('set bit_width_hls_output {}\n'.format(in_bit))

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -501,25 +501,8 @@ class VivadoWriter(Writer):
         fout.close()
 
     def write_build_script(self, model):
-        ###################
-        # build_prj.tcl
-        ###################
 
         filedir = os.path.dirname(os.path.abspath(__file__))
-
-        f = open(os.path.join(filedir,'../templates/vivado/build_prj.tcl'),'r')
-        fout = open('{}/build_prj.tcl'.format(model.config.get_output_dir()),'w')
-
-        for line in f.readlines():
-
-            if 'set_part {xcku115-flvb2104-2-i}' in line:
-                line = 'set_part {{{}}}\n'.format(model.config.get_config_value('Part'))
-            elif 'create_clock -period 5 -name default' in line:
-                line = 'create_clock -period {} -name default\n'.format(model.config.get_config_value('ClockPeriod'))
-
-            fout.write(line)
-        f.close()
-        fout.close()
 
         ###################
         # project.tcl
@@ -529,22 +512,27 @@ class VivadoWriter(Writer):
         f.write('set myproject "{}"\n'.format(model.config.get_project_name()))
         f.write('variable backend\n')
         f.write('set backend "vivado"\n')
+        f.write('variable part\n')
+        f.write('set part "{}"\n'.format(model.config.get_config_value('Part')))
+        f.write('variable clock_period\n')
+        f.write('set clock_period "{}"\n'.format(model.config.get_config_value('ClockPeriod')))
         f.close()
+
+        ###################
+        # build_prj.tcl
+        ###################
+
+        srcpath = os.path.join(filedir,'../templates/vivado/build_prj.tcl')
+        dstpath = '{}/build_prj.tcl'.format(model.config.get_output_dir())
+        copyfile(srcpath, dstpath)
 
         ###################
         # vivado_synth.tcl
         ###################
 
-        f = open(os.path.join(filedir,'../templates/vivado/vivado_synth.tcl'),'r')
-        fout = open('{}/vivado_synth.tcl'.format(model.config.get_output_dir()),'w')
-        for line in f.readlines():
-            line = line.replace('myproject', model.config.get_project_name())
-            if '-part' in line:
-                line = 'synth_design -top {} -part {}\n'.format(model.config.get_project_name(), model.config.get_config_value('Part'))
-
-            fout.write(line)
-        f.close()
-        fout.close()
+        srcpath = os.path.join(filedir,'../templates/vivado/vivado_synth.tcl')
+        dstpath = '{}/vivado_synth.tcl'.format(model.config.get_output_dir())
+        copyfile(srcpath, dstpath)
 
         ###################
         # build_lib.sh

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -512,8 +512,6 @@ class VivadoWriter(Writer):
 
         for line in f.readlines():
 
-            line = line.replace('myproject',model.config.get_project_name())
-
             if 'set_part {xcku115-flvb2104-2-i}' in line:
                 line = 'set_part {{{}}}\n'.format(model.config.get_config_value('Part'))
             elif 'create_clock -period 5 -name default' in line:

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -508,14 +508,14 @@ class VivadoWriter(Writer):
         # project.tcl
         ###################
         f = open('{}/project.tcl'.format(model.config.get_output_dir()), 'w')
-        f.write('variable myproject\n')
-        f.write('set myproject "{}"\n'.format(model.config.get_project_name()))
+        f.write('variable project_name\n')
+        f.write('set project_name "{}"\n'.format(model.config.get_project_name()))
         f.write('variable backend\n')
         f.write('set backend "vivado"\n')
         f.write('variable part\n')
         f.write('set part "{}"\n'.format(model.config.get_config_value('Part')))
         f.write('variable clock_period\n')
-        f.write('set clock_period "{}"\n'.format(model.config.get_config_value('ClockPeriod')))
+        f.write('set clock_period {}\n'.format(model.config.get_config_value('ClockPeriod')))
         f.close()
 
         ###################


### PR DESCRIPTION
# Description

As discussed in #624, convert_from_keras_model with project_name set to nondefault  value (e.g. mynewprojname) fails to build, because in build.tcl the variable ${mynewprojname} is not defined. This fixes the problem my always leaving the variable called `myproject`, but just changing the value of the variable. Some changes in the tcl code were requried since now since the variable name does not always match the value it contains. The build.tcl indentation was fixed, and the parsing of the Vivado report was fixed. Note that this is broken in main even in the default case currently.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Testing was done offline by modifying and running part1 of the hls4ml-tutorial, as mentioned in #624. Nevertheless, we probably should add a test. The complication is that the test requires synthesis, and generally our pytests don't do synthesis. Plus, synthesis is long. Do we want to add another synthesis test for this case or modify an existing one?

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/master/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.