### PR TITLE
Quartus Merge layers

### DIFF
--- a/hls4ml/backends/quartus/passes/merge_templates.py
+++ b/hls4ml/backends/quartus/passes/merge_templates.py
@@ -1,0 +1,103 @@
+from hls4ml.backends.backend import get_backend
+from hls4ml.model.layers import Concatenate, Dot, Merge
+from hls4ml.backends.template import LayerConfigTemplate, FunctionCallTemplate
+
+# TODO - Very similar to vivado/merge_templates.py - only difference is on line 67: get_backend('vivado').product_type(inp1.type.precision, inp2.type.precision)
+# TODO - Look into ways of having passes similar accross many backends in a shared folder thorugh inheritance and overriding.
+
+# Merge templates
+merge_config_template = """struct config{index} : nnet::merge_config {{
+    static const unsigned n_elem = {n_elem};
+}};\n"""
+
+merge_function_template = 'nnet::{merge}<{input1_t}, {input2_t}, {output_t}, {config}>({input1}, {input2}, {output});'
+merge_include_list = ['nnet_utils/nnet_merge.h', 'nnet_utils/nnet_merge_stream.h']
+
+class MergeConfigTemplate(LayerConfigTemplate):
+    def __init__(self):
+        super().__init__(Merge)
+        self.template = merge_config_template
+
+    def format(self, node):
+        params = self._default_config_params(node)
+        params['n_elem'] = node.get_input_variable(node.inputs[0]).size_cpp()
+
+        return self.template.format(**params)
+
+class MergeFunctionTemplate(FunctionCallTemplate):
+    def __init__(self):
+        super().__init__((Merge, Concatenate, Dot), include_header=merge_include_list)
+        self.template = merge_function_template
+
+    def format(self, node):
+        params = {}
+        params['merge'] = node.get_attr('op').lower()
+        params['config'] = 'config{}'.format(node.index)
+        params['input1_t'] = node.get_input_variable(node.inputs[0]).type.name
+        params['input2_t'] = node.get_input_variable(node.inputs[1]).type.name
+        params['output_t'] = node.get_output_variable().type.name
+        params['input1'] = node.get_input_variable(node.inputs[0]).name
+        params['input2'] = node.get_input_variable(node.inputs[1]).name
+        params['output'] = node.get_output_variable().name
+
+        return self.template.format(**params)
+
+
+# Dot templates
+dot_config_template = """struct config{index} : nnet::dot_config {{
+    static const unsigned n_in = {n_in};
+    static const unsigned n_out = {n_out};
+    
+    static const unsigned reuse_factor = {reuse};
+    
+    typedef {accum_t.name} accum_t;
+    
+    template<class x_T, class y_T>
+    using product = nnet::product::{product_type}<x_T, y_T>;
+}};\n"""
+
+class DotConfigTemplate(LayerConfigTemplate):
+    def __init__(self):
+        super().__init__(Dot)
+        self.template = dot_config_template
+
+    def format(self, node):
+        inp1 = node.get_input_variable(node.inputs[0])
+        inp2 = node.get_input_variable(node.inputs[1])
+        params = node._default_config_params()
+        params['n_out'] = 1
+        params['n_in'] = inp1.shape[0]
+        params['product_type'] = get_backend('quartus').product_type(inp1.type.precision, inp2.type.precision)
+        
+        return self.template.format(**params)
+
+
+# Concatenate templates
+concat_config_template = """struct config{index} : nnet::concat_config {{
+    static const unsigned n_elem1_0 = {n_elem1_0};
+    static const unsigned n_elem1_1 = {n_elem1_1};
+    static const unsigned n_elem1_2 = {n_elem1_2};
+    static const unsigned n_elem2_0 = {n_elem2_0};
+    static const unsigned n_elem2_1 = {n_elem2_1};
+    static const unsigned n_elem2_2 = {n_elem2_2};
+
+    static const int axis = {axis};
+}};\n"""
+
+class ConcatenateConfigTemplate(LayerConfigTemplate):
+    def __init__(self):
+        super().__init__(Concatenate)
+        self.template = concat_config_template
+
+    def format(self, node):
+        params = self._default_config_params(node)
+        for i in range(3):
+            params.setdefault('n_elem1_{}'.format(i), 0)
+            params.setdefault('n_elem2_{}'.format(i), 0)
+        inp1 = node.get_input_variable(node.inputs[0])
+        inp2 = node.get_input_variable(node.inputs[1])
+        for i, (s1, s2) in enumerate(zip(inp1.shape, inp2.shape)):
+            params['n_elem1_{}'.format(i)] = s1
+            params['n_elem2_{}'.format(i)] = s2
+
+        return self.template.format(**params)

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_merge.h
@@ -1,0 +1,285 @@
+#ifndef NNET_MERGE_H_
+#define NNET_MERGE_H_
+
+#include "nnet_mult.h"
+
+namespace nnet {
+
+struct merge_config {
+    static const unsigned n_elem = 10;
+};
+
+struct dot_config {
+    static const unsigned n_in = 10;
+    static const unsigned n_out = 1;
+    
+    static const unsigned reuse_factor = 1;
+    
+    typedef float accum_t;
+    
+    template<class x_T, class y_T>
+    using product = nnet::product::mult<x_T, y_T>;
+};
+
+struct concat_config {
+    static const unsigned n_elem1_0 = 10;
+    static const unsigned n_elem1_1 = 10;
+    static const unsigned n_elem1_2 = 10;
+    static const unsigned n_elem2_0 = 10;
+    static const unsigned n_elem2_1 = 10;
+    static const unsigned n_elem2_2 = 10;
+
+    static const unsigned axis = -1;
+};
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void add(
+    input1_T data1[CONFIG_T::n_elem],
+    input2_T data2[CONFIG_T::n_elem],
+    res_T    res[CONFIG_T::n_elem]
+) {
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem; i++) {
+        res[i] = static_cast<res_T>(data1[i] + data2[i]);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void subtract(
+    input1_T data1[CONFIG_T::n_elem],
+    input2_T data2[CONFIG_T::n_elem],
+    res_T    res[CONFIG_T::n_elem]
+) {
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem; i++) {
+        res[i] = static_cast<res_T>(data1[i] - data2[i]);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void multiply(
+    input1_T data1[CONFIG_T::n_elem],
+    input2_T data2[CONFIG_T::n_elem],
+    res_T    res[CONFIG_T::n_elem]
+) {
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem; i++) {
+        res[i] = static_cast<res_T>(data1[i] * data2[i]);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void average(
+    input1_T data1[CONFIG_T::n_elem],
+    input2_T data2[CONFIG_T::n_elem],
+    res_T    res[CONFIG_T::n_elem]
+) {
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem; i++) {
+        res[i] = static_cast<res_T>((data1[i] + data2[i]) / (res_T) 2);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void maximum(
+    input1_T data1[CONFIG_T::n_elem],
+    input2_T data2[CONFIG_T::n_elem],
+    res_T    res[CONFIG_T::n_elem]
+) {
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem; i++) {
+        res[i] = (data1[i] > data2[i]) ? static_cast<res_T>(data1[i]) : static_cast<res_T>(data2[i]);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void minimum(
+    input1_T data1[CONFIG_T::n_elem],
+    input2_T data2[CONFIG_T::n_elem],
+    res_T    res[CONFIG_T::n_elem]
+) {
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem; i++) {
+        res[i] = (data1[i] < data2[i]) ? static_cast<res_T>(data1[i]) : static_cast<res_T>(data2[i]);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void dot1d(
+    input1_T data1[CONFIG_T::n_in],
+    input2_T data2[CONFIG_T::n_in],
+    res_T    res[CONFIG_T::n_out]
+) {
+    constexpr unsigned multiplier_limit = DIV_ROUNDUP(CONFIG_T::n_in, CONFIG_T::reuse_factor);
+
+    hls_register typename CONFIG_T::accum_t mult[CONFIG_T::n_in];
+    Product: 
+    #pragma unroll multiplier_limit
+    for(int i=0; i < CONFIG_T::n_in; i++) {
+        mult[i] = CONFIG_T::template product<input1_T, input2_T>::product(data1[i], data2[i]);
+    }
+
+    hls_register typename CONFIG_T::accum_t acc = 0;
+    Accum: 
+    #pragma unroll
+    for(int i = 0; i < CONFIG_T::n_in; i++) {
+        acc += mult[i];
+    }
+
+    res[0] = static_cast<res_T>(acc);
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate1d(
+    input1_T data1[CONFIG_T::n_elem1_0],
+    input2_T data2[CONFIG_T::n_elem2_0],
+    res_T    res[CONFIG_T::n_elem1_0 + CONFIG_T::n_elem2_0]
+) {
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem1_0; i++) {
+        res[i] = static_cast<res_T>(data1[i]);
+    }
+
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem2_0; i++) {
+        res[CONFIG_T::n_elem1_0 + i] = static_cast<res_T>(data2[i]);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d_0(
+    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1],
+    input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
+    res_T    res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1] 
+) {
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1; i++) {
+        res[i] = static_cast<res_T>(data1[i]);
+    }
+
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1; i++) {
+        res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + i] = static_cast<res_T>(data2[i]);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d_1(
+    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1],
+    input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
+    res_T    res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1] 
+){
+    for (int i = 0; i < CONFIG_T::n_elem1_0; i++) {
+        #pragma unroll
+        for (int j = 0; j < CONFIG_T::n_elem1_1; j++) {
+            res[i * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) + j] = static_cast<res_T>(data1[i * CONFIG_T::n_elem1_1 + j]);
+        }
+        
+        #pragma unroll
+        for (int j = 0; j < CONFIG_T::n_elem2_1; j++) {
+            res[i * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) + CONFIG_T::n_elem1_1 + j] = static_cast<res_T>(data2[i * CONFIG_T::n_elem2_1 + j]);
+        }
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d(
+    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1],
+    input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
+    res_T    res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1] 
+) {
+    if (CONFIG_T::axis == 2 || CONFIG_T::axis == -1) {
+        concatenate2d_1<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    } else {
+        concatenate2d_0<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_0(
+    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
+    input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+    res_T    res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2] 
+) {
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2; i++) {
+        res[i] = static_cast<res_T>(data1[i]);
+    }
+
+    #pragma unroll
+    for (int i = 0; i < CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2; i++) {
+        res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + i] = static_cast<res_T>(data2[i]);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_1(
+    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
+    input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+    res_T    res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2] 
+) {
+    for (int i = 0; i < CONFIG_T::n_elem1_0; i++) {
+        for (int j = 0; j < CONFIG_T::n_elem1_1; j++) {
+            #pragma unroll
+            for (int k = 0; k < CONFIG_T::n_elem1_2; k++) {
+                int res_idx = i * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) * CONFIG_T::n_elem1_2 + j * CONFIG_T::n_elem1_2 + k;
+                int data_idx = i * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + j * CONFIG_T::n_elem1_2 + k;
+                res[res_idx] = static_cast<res_T>(data1[data_idx]);
+            }
+        }
+
+        for (int j = 0; j < CONFIG_T::n_elem2_1; j++) {
+            #pragma unroll
+            for (int k=0; k<CONFIG_T::n_elem2_2; k++) {
+                int res_idx = i * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) * CONFIG_T::n_elem1_2 + (j + CONFIG_T::n_elem1_1) * CONFIG_T::n_elem1_2 + k;
+                int data_idx = i * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2 + j * CONFIG_T::n_elem2_2 + k;
+                res[res_idx] = static_cast<res_T>(data2[data_idx]);
+            }
+        }
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_2(
+    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
+    input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2]
+) {
+    for (int i = 0; i < CONFIG_T::n_elem1_0; i++) {
+        for (int j = 0; j < CONFIG_T::n_elem1_1; j++) {
+            
+            #pragma unroll
+            for (int k = 0; k < CONFIG_T::n_elem1_2; k++) {
+                int res_idx = i * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) + j * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) + k;
+                int data_idx = i * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + j * CONFIG_T::n_elem1_2 + k;
+                res[res_idx] = static_cast<res_T>(data1[data_idx]);
+            }
+
+            #pragma unroll
+            for (int k = 0; k < CONFIG_T::n_elem1_2; k++) {
+                int res_idx = i * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) + j * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) + k + CONFIG_T::n_elem1_2;
+                int data_idx = i * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2 + j * CONFIG_T::n_elem2_2 + k;
+                res[res_idx] = static_cast<res_T>(data2[data_idx]);
+            }
+        }
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d(
+    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
+    input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2] 
+) {
+    if (CONFIG_T::axis == 3 || CONFIG_T::axis == -1) {
+        concatenate3d_2<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    } else if (CONFIG_T::axis == 2 || CONFIG_T::axis == -2) {
+        concatenate3d_1<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    } else {
+        concatenate3d_0<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    }
+}
+
+}
+
+#endif

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_merge_stream.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_merge_stream.h
@@ -1,0 +1,353 @@
+#ifndef NNET_MERGE_STREAM_H_
+#define NNET_MERGE_STREAM_H_
+
+namespace nnet {
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void add(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
+
+    AddLoop: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+        hls_register input1_T in_data1 = data1.read();
+        hls_register input2_T in_data2 = data2.read();
+        
+        hls_register res_T out_data;
+        
+        AddPack: 
+        #pragma unroll
+        for (int j = 0; j < res_T::size; j++) {
+            out_data[j] = static_cast<typename res_T::value_type>(in_data1[j] + in_data2[j]);
+        }
+
+        res.write(out_data);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void subtract(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
+
+    SubtractLoop: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+        hls_register input1_T in_data1 = data1.read();
+        hls_register input2_T in_data2 = data2.read();
+        
+        hls_register res_T out_data;
+        
+        SubtractPack: 
+        #pragma unroll
+        for (int j = 0; j < res_T::size; j++) {
+            out_data[j] = static_cast<typename res_T::value_type>(in_data1[j] - in_data2[j]);
+        }
+
+        res.write(out_data);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void multiply(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
+
+    MultLoop: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+        hls_register input1_T in_data1 = data1.read();
+        hls_register input2_T in_data2 = data2.read();
+        
+        hls_register res_T out_data;
+        
+        MultPack: 
+        #pragma unroll
+        for (int j = 0; j < res_T::size; j++) {
+            out_data[j] = static_cast<typename res_T::value_type>(in_data1[j] * in_data2[j]);
+        }
+
+        res.write(out_data);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void average(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
+
+    AvgLoop: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+        hls_register input1_T in_data1 = data1.read();
+        hls_register input2_T in_data2 = data2.read();
+        
+        hls_register res_T out_data;
+        
+        AvgPack: 
+        #pragma unroll
+        for (int j = 0; j < res_T::size; j++) {
+            out_data[j] = static_cast<typename res_T::value_type>((in_data1[j] + in_data2[j]) / (typename res_T::value_type) 2);
+        }
+
+        res.write(out_data);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void maximum(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
+
+    MaxLoop: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+        hls_register input1_T in_data1 = data1.read();
+        hls_register input2_T in_data2 = data2.read();
+        
+        hls_register res_T out_data;
+        
+        MaxPack: 
+        #pragma unroll
+        for (int j = 0; j < res_T::size; j++) {
+            out_data[j] = static_cast<typename res_T::value_type>(out_data[j] = (in_data1[j] > in_data2[j]) ? in_data1[j] : in_data2[j]);
+        }
+
+        res.write(out_data);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void minimum(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    assert(input1_T::size == input2_T::size && input1_T::size == res_T::size);
+
+    MinLoop: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem / input1_T::size; i++) {
+        hls_register input1_T in_data1 = data1.read();
+        hls_register input2_T in_data2 = data2.read();
+        
+        hls_register res_T out_data;
+        
+        MinPack: 
+        #pragma unroll
+        for (int j = 0; j < res_T::size; j++) {
+            out_data[j] = static_cast<typename res_T::value_type>(out_data[j] = (in_data1[j] < in_data2[j]) ? in_data1[j] : in_data2[j]);
+        }
+
+        res.write(out_data);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate1d(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    hls_register res_T out_data;
+    
+    ConcatLoop1: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem1_0 / input1_T::size; i++) {	 
+        hls_register input1_T in_data1 = data1.read();
+        ConcatPack1: 
+        #pragma unroll
+        for (int j = 0; j < input1_T::size; j++) {
+            out_data[j] = static_cast<typename res_T::value_type>(in_data1[j]);
+        }
+    }
+
+    ConcatLoop2: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem2_0 / input2_T::size; i++) {
+        hls_register input2_T in_data2 = data2.read();
+        ConcatPack2: 
+        #pragma unroll
+        for (int j = 0; j < input2_T::size; j++) {
+            out_data[input1_T::size + j] = static_cast<typename res_T::value_type>(in_data2[j]);
+        }
+
+    }
+    res.write(out_data);
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d_0(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    ConcatLoopHeight1: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem1_0; i++) {
+
+        hls_register input1_T in_data1 = data1.read();
+        hls_register res_T out_data;
+        
+        ConcatPackInput1: 
+        #pragma unroll
+        for (int k = 0; k < input1_T::size; k++) {
+            out_data[k] = static_cast<typename res_T::value_type>(in_data1[k]);
+        }
+
+        res.write(out_data);
+    }
+    
+    ConcatLoopHeight2: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem2_0; i++) {
+        hls_register input2_T in_data2 = data2.read();
+        hls_register res_T out_data;
+        
+        ConcatPackInput2: 
+        #pragma unroll
+        for (int k = 0; k < input2_T::size; k++) {
+            out_data[k] = static_cast<typename res_T::value_type>(in_data2[k]);
+        }
+
+        res.write(out_data);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d_1(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    ConcatLoopHeight: 
+    #pragma ii 1
+    for (int i = 0; i < CONFIG_T::n_elem1_0; i++) {
+        hls_register input1_T in_data1 = data1.read();
+        hls_register input2_T in_data2 = data2.read();
+        hls_register res_T out_data;
+        
+        ConcatPackInput1: 
+        #pragma unroll
+        for (int k = 0; k < input1_T::size; k++) {
+            out_data[k] = static_cast<typename res_T::value_type>(in_data1[k]);
+        }
+        
+        ConcatPackInput2: 
+        #pragma unroll
+        for (int k = 0; k < input2_T::size; k++) {     
+            out_data[input1_T::size + k] = static_cast<typename res_T::value_type>(in_data2[k]);
+        }
+
+        res.write(out_data);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    if (CONFIG_T::axis == 2 || CONFIG_T::axis == -1) {
+        concatenate2d_1<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    } else {
+        concatenate2d_0<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_0(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    ConcatLoopHeight1: 
+    for (int i = 0; i < CONFIG_T::n_elem1_0; i++) {
+        ConcatLoopWidth1: 
+        #pragma ii 1
+        for (int j = 0; j < CONFIG_T::n_elem1_1; j++) {
+              
+            hls_register input1_T in_data1 = data1.read();
+            hls_register res_T out_data;
+            ConcatPackInput1: 
+            #pragma unroll
+            for (int k = 0; k < input1_T::size; k++) {
+                out_data[k] = static_cast<typename res_T::value_type>(in_data1[k]);
+            }
+
+            res.write(out_data);
+        }
+    }
+
+    ConcatLoopHeight2: 
+    for (int i = 0; i < CONFIG_T::n_elem2_0; i++) {
+        ConcatLoopWidth2:
+        #pragma ii 1
+        for (int j = 0; j < CONFIG_T::n_elem2_1; j++) {
+
+            hls_register input2_T in_data2 = data2.read();
+            hls_register res_T out_data;
+            
+            ConcatPackInput2: 
+            #pragma unroll
+            for (int k = 0; k < input2_T::size; k++) {     
+                out_data[k] = static_cast<typename res_T::value_type>(in_data2[k]);
+            }
+
+            res.write(out_data);
+        }
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_1(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    ConcatLoopHeight: 
+    for (int i = 0; i < CONFIG_T::n_elem1_0; i++) {
+        ConcatLoopWidth1: 
+        #pragma ii 1
+        for (int j = 0; j < CONFIG_T::n_elem1_1; j++) {
+
+            hls_register input1_T in_data1 = data1.read();
+            hls_register res_T out_data;
+            
+            ConcatPackInput1: 
+            #pragma unroll
+            for (int k = 0; k < input1_T::size; k++) {
+                out_data[k] = static_cast<typename res_T::value_type>(in_data1[k]);
+            }
+
+            res.write(out_data);
+        }
+        ConcatLoopWidth2: 
+        #pragma ii 1
+        for (int j = 0; j < CONFIG_T::n_elem2_1; j++) {
+        
+            hls_register input2_T in_data2 = data2.read();
+            hls_register res_T out_data;
+            
+            ConcatPackInput2: 
+            #pragma unroll
+            for (int k = 0; k < input2_T::size; k++) {
+                out_data[k] = static_cast<typename res_T::value_type>(in_data2[k]);
+            }
+
+            res.write(out_data);
+        }
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_2(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    ConcatLoopHeight: for (int i = 0; i < CONFIG_T::n_elem1_0; i++) {
+        ConcatLoopWidth: 
+        #pragma ii 1
+        for (int j = 0; j < CONFIG_T::n_elem1_1; j++) {
+
+            hls_register input1_T in_data1 = data1.read();
+            hls_register input2_T in_data2 = data2.read();
+            hls_register res_T out_data;
+            
+            ConcatPackInput1: 
+            #pragma unroll
+            for (int k = 0; k < input1_T::size; k++) {
+                out_data[k] = static_cast<typename res_T::value_type>(in_data1[k]);
+            }
+            
+            ConcatPackInput2: 
+            #pragma unroll
+            for (int k = 0; k < input2_T::size; k++) {
+                out_data[input1_T::size + k] = static_cast<typename res_T::value_type>(in_data2[k]);
+            }
+
+            res.write(out_data);
+        }
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d(stream<input1_T> &data1, stream<input2_T> &data2, stream<res_T> &res) {
+    if (CONFIG_T::axis == 3 || CONFIG_T::axis == -1) {
+        concatenate3d_2<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    } else if (CONFIG_T::axis == 2 || CONFIG_T::axis == -2) {
+        concatenate3d_1<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    } else {
+        concatenate3d_0<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    }
+}
+
+}
+
+#endif

--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -111,8 +111,10 @@ class QuartusWriter(Writer):
                 newline = line
                 if io_type == 'io_stream':
                     newline += 'void myproject(\n'
-                    newline += indent+'stream_in<{}> &input_stream,\n'.format(model_inputs[0].type.name)
-                    newline += indent+'stream_out<{}> &output_stream\n'.format(model_outputs[0].type.name)
+                    for inp in model_inputs:
+                        newline += indent+'stream_in<{}> &{}_stream,\n'.format(inp.type.name, inp.name)
+                    for out in model_outputs:
+                        newline += indent+'stream_out<{}> &{}_stream\n'.format(out.type.name, out.name)
                     newline += ') {\n'
                 if io_type == 'io_parallel':
                     newline = 'output_data myproject(\n'
@@ -124,8 +126,10 @@ class QuartusWriter(Writer):
                 newline = line
                 if io_type == 'io_stream':
                     newline += 'component void myproject(\n'
-                    newline += indent+'stream_in<{}> &input_stream,\n'.format(model_inputs[0].type.name)
-                    newline += indent+'stream_out<{}> &output_stream\n'.format(model_outputs[0].type.name)
+                    for inp in model_inputs:
+                        newline += indent+'stream_in<{}> &{}_stream,\n'.format(inp.type.name, inp.name)
+                    for out in model_outputs:
+                        newline += indent+'stream_out<{}> &{}_stream\n'.format(out.type.name, out.name)
                     newline += ') {\n'
                 if io_type == 'io_parallel':
                     newline += 'component output_data myproject(\n'
@@ -148,10 +152,11 @@ class QuartusWriter(Writer):
             elif '//hls-fpga-machine-learning initialize input/output' in line:
                 if io_type == 'io_stream':
                     newline = line
-                    newline += indent + f'for (size_t i = 0; i < {model_inputs[0].size_cpp()} / {model_inputs[0].type.name}::size; i++) {{\n'
-                    newline += indent + f'  {model_inputs[0].type.name} tmp = input_stream.read();\n'
-                    newline += indent + f'  {model_inputs[0].name}.write(tmp);\n'
-                    newline += indent + f'}}\n'
+                    for inp in model_inputs:
+                        newline += indent + f'for (size_t i = 0; i < {inp.size_cpp()} / {inp.type.name}::size; i++) {{\n'
+                        newline += indent + f'  {inp.type.name} tmp = {inp.name}_stream.read();\n'
+                        newline += indent + f'  {inp.name}.write(tmp);\n'
+                        newline += indent + f'}}\n'
                 else:
                     newline = line
                     newline += indent+'hls_register output_data outputs;\n'
@@ -195,11 +200,12 @@ class QuartusWriter(Writer):
             elif '//hls-fpga-machine-learning return' in line:
                 if io_type == 'io_stream':
                     newline = line
-                    newline += indent + f'for (size_t i = 0; i < {model_outputs[0].size_cpp()} / {model_outputs[0].type.name}::size; i++) {{\n'
-                    newline += indent + f'  {model_outputs[0].type.name} tmp = {model_outputs[0].name}.read();\n'
-                    newline += indent + f'  output_stream.write(tmp);\n'
-                    newline += indent + f'}}\n'
-                    newline += '}\n'
+                    for out in model_outputs:
+                        newline += indent + f'for (size_t i = 0; i < {out.size_cpp()} / {out.type.name}::size; i++) {{\n'
+                        newline += indent + f'  {out.type.name} tmp = {out.name}.read();\n'
+                        newline += indent + f'  {out.name}_stream.write(tmp);\n'
+                        newline += indent + f'}}\n'
+                        newline += '}\n'
                 else:
                     newline = line
                     newline += indent+'return outputs;\n'
@@ -242,8 +248,10 @@ class QuartusWriter(Writer):
                 # For io_stream, input and output are passed by reference; see myproject.h & myproject.cpp for more details
                 if io_type == 'io_stream':
                     newline += 'void myproject(\n'
-                    newline += indent+'stream_in<{}> &input_stream,\n'.format(model_inputs[0].type.name)
-                    newline += indent+'stream_out<{}> &output_stream\n'.format(model_outputs[0].type.name)
+                    for inp in model_inputs:
+                        newline += indent+'stream_in<{}> &{}_stream,\n'.format(inp.type.name, inp.name)
+                    for out in model_outputs:
+                        newline += indent+'stream_out<{}> &{}_stream\n'.format(out.type.name, out.name)
                     newline += ');\n'
                 # In io_parallel, a struct is returned; see myproject.h & myproject.cpp for more details
                 else:
@@ -256,8 +264,10 @@ class QuartusWriter(Writer):
                 newline = line
                 if io_type == 'io_stream':
                     newline += 'component void myproject(\n'
-                    newline += indent+'stream_in<{}> &input_stream,\n'.format(model_inputs[0].type.name)
-                    newline += indent+'stream_out<{}> &output_stream\n'.format(model_outputs[0].type.name)
+                    for inp in model_inputs:
+                        newline += indent+'stream_in<{}> &{}_stream,\n'.format(inp.type.name, inp.name)
+                    for out in model_outputs:
+                        newline += indent+'stream_out<{}> &{}_stream\n'.format(out.type.name, out.name)
                     newline += ');\n'
                 else:
                     newline += 'component output_data myproject(\n'
@@ -452,7 +462,9 @@ class QuartusWriter(Writer):
             return
 
         outvar = model.get_output_variables()[0]
-        invar = model.get_input_variables()[0]
+
+        model_inputs = model.get_input_variables()
+        model_outputs = model.get_output_variables()
 
         filedir = os.path.dirname(os.path.abspath(__file__))
 
@@ -479,10 +491,7 @@ class QuartusWriter(Writer):
         
         f = open(os.path.join(filedir, '../templates/quartus/myproject_test_stream.cpp'), 'r')
         fout = open('{}/{}_test.cpp'.format(model.config.get_output_dir(), model.config.get_project_name()), 'w')
-
-        if len(model.get_input_variables()) > 1 or len(model.get_output_variables()) > 1:
-                raise Exception('Quartus io_stream supports exactly one input/output per model')
-            
+    
         for line in f.readlines():
             indent = ' ' * (len(line) - len(line.lstrip(' ')))
 
@@ -491,29 +500,39 @@ class QuartusWriter(Writer):
             
             elif '//hls-fpga-machine learning instantiate inputs and outputs' in line:
                 newline = line
-                newline += indent + 'stream_in<{}> inputs;\n'.format(invar.type.name)
-                newline += indent + 'stream_out<{}> outputs;\n'.format(outvar.type.name)
-
+                for inp in model_inputs:
+                    newline += indent+'stream_in<{}> {}_input;\n'.format(inp.type.name, inp.name)
+                for out in model_outputs:
+                    newline += indent+'stream_out<{}> {}_output;\n'.format(out.type.name, out.name)
+                
             # TODO - This is one-input specific (are multiple model inputs needed at all?)
             elif '//hls-fpga-machine-learning insert data' in line:
                 newline = line
-                newline += indent + f'float vals[{invar.size_cpp()}]; \n'
-                newline += indent + f'for (int j = 0 ; j < {invar.size_cpp()} ; j++) {{\n'
-                newline += indent + f'  vals[j] = in[j]; \n'
-                newline += indent + f'}}'
-                newline += indent + f'nnet::convert_data<float, {invar.type.name}, {invar.size_cpp()}>(vals, inputs);\n'
-            
+                c = 0
+                for inp in model_inputs:
+                    newline += indent + f'float vals_{c}[{inp.size_cpp()}]; \n'
+                    newline += indent + f'for (int j = 0 ; j < {inp.size_cpp()} ; j++) {{\n'
+                    newline += indent + indent + f'vals_{c}[j] = in[j]; \n'
+                    newline += indent + f'}}\n'
+                    newline += indent + f'nnet::convert_data<float, {inp.type.name}, {inp.size_cpp()}>(vals_{c}, {inp.name}_input);\n'
+                    c += 1
+
             elif '//hls-fpga-machine-learning insert zero' in line:
                 newline = line
-                newline += indent + f'float vals[{invar.size_cpp()}]; \n'
-                newline += indent + f'for (int j = 0 ; j < {invar.size_cpp()} ; j++) {{'
-                newline += indent + f'  vals[j] = 0.0; \n'
-                newline += indent + f'}}'
-                newline += indent + f'nnet::convert_data<float, {invar.type.name}, {invar.size_cpp()}>(vals, inputs);\n'
+                c = 0
+                for inp in model_inputs:
+                    newline += indent + f'float vals_{c}[{inp.size_cpp()}]; \n'
+                    newline += indent + f'for (int j = 0 ; j < {inp.size_cpp()} ; j++) {{\n'
+                    newline += indent + indent + f'vals_{c}[j] = 0.0; \n'
+                    newline += indent + f'}}\n'
+                    newline += indent + f'nnet::convert_data<float, {inp.type.name}, {inp.size_cpp()}>(vals_{c}, {inp.name}_input);\n'
+                    c += 1
 
             elif '//hls-fpga-machine-learning insert top-level-function' in line:
                 newline = line
-                newline += indent + f'ihc_hls_enqueue_noret(&{model.config.get_project_name()}, inputs, outputs); \n'
+                input_params = ', '.join([f'{i.name}_input' for i in model_inputs])
+                output_params = ', '.join([f'{o.name}_output' for o in model_outputs])
+                newline += indent + f'ihc_hls_enqueue_noret(&{model.config.get_project_name()}, {input_params}, {output_params}); \n'
             
             elif 'hls-fpga-machine-learning insert run' in line:
                 newline = line
@@ -522,8 +541,9 @@ class QuartusWriter(Writer):
             elif '//hls-fpga-machine-learning convert output' in line:
                 newline = line
                 newline += indent + 'float res[{}];\n'.format(outvar.size_cpp())
-                newline += indent + 'nnet::convert_data_back<{}, float, {}>(outputs, res);\n'.format(outvar.type.name,
-                                                                                                    outvar.size_cpp())
+                newline += indent + 'nnet::convert_data_back<{}, float, {}>({}_output, res);\n'.format(outvar.type.name,
+                                                                                                    outvar.size_cpp(),
+                                                                                                    outvar.name)
 
             elif '//hls-fpga-machine-learning insert tb-output' in line:
                 newline += indent + 'for(int i = 0; i < {}; i++) {{\n'.format(outvar.size_cpp())
@@ -617,32 +637,36 @@ class QuartusWriter(Writer):
             elif '//hls-fpga-machine-learning insert wrapper' in line:
                 dtype = line.split('#', 1)[1].strip()
                 if io_type == 'io_stream':
-                    if len(model_inputs) > 1 or len(model_outputs) > 1:
-                        raise Exception('io_stream Quartus supports exactly one input/output')
-                    i = model_inputs[0]
-                    o = model_outputs[0]
-
-                    # Initialise stream object and store input data (C-array) to a 'stream' object
-                    newline = indent + 'stream_in<{}> inputs;\n'.format(model_inputs[0].type.name)
-                    newline += indent + 'nnet::convert_data<{}, {}, {}>({}, inputs);\n'.format(dtype, 
-                                                                                            i.type.name,
-                                                                                            i.size_cpp(),
-                                                                                            i.name,
-                                                                                        )
-                    
+                    newline = ''
+                    for i in model_inputs:
+                        # Initialise stream object and store input data (C-array) to a 'stream' object
+                        newline += indent + 'stream_in<{}> {}_input;\n'.format(i.type.name, i.name)
+                        newline += indent + 'nnet::convert_data<{}, {}, {}>({}, {}_input);\n'.format(dtype, 
+                                                                                                i.type.name,
+                                                                                                i.size_cpp(),
+                                                                                                i.name,
+                                                                                                i.name
+                                                                                            )
+                        
                     # Initialise stream output
-                    newline += '\n'
-                    newline += indent + 'stream_out<{}> outputs;\n'.format(model_outputs[0].type.name)                    
-                    
+                    for o in model_outputs:
+                        newline += '\n'
+                        newline += indent + 'stream_out<{}> {}_output;\n'.format(o.type.name, o.name)                    
+                        
                     # Execute top-level function
-                    top_level = indent + '{}(inputs, outputs);\n'.format(model.config.get_project_name())
+                    input_params = ', '.join([f'{i.name}_input' for i in model_inputs])
+                    output_params = ', '.join([f'{o.name}_output' for o in model_outputs])
+
+                    top_level = indent + '{}({}, {});\n'.format(model.config.get_project_name(), input_params, output_params)
                     newline += top_level
                     newline += '\n'
 
                     # Store data from 'stream' output to C-array, to be then returned and handled in Python
-                    newline += indent + 'nnet::convert_data_back<{}, {}, {}>(outputs, {});\n'.format(o.type.name,
+                    for o in model_outputs:
+                        newline += indent + 'nnet::convert_data_back<{}, {}, {}>({}_output, {});\n'.format(o.type.name,
                                                                                                 dtype,
                                                                                                 o.size_cpp(),
+                                                                                                o.name,
                                                                                                 o.name
                                                                                             )
                 


### PR DESCRIPTION
A# Description

> :memo: Merge, Concatenate and Dot layers for the Quartus backend
>  
> * Extend support in `io_stream` to allow multiple inputs per model
> * Add support for Merge (Add, Subtract, Multiply, Average, Minimum, Maximum) layers in Quartus backend
> * Add support for Dot layers in Quartus backend
> * Add support for Concatenate (1D, 2D and 3D) layers in Quartus backend

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests  
> * Expanded existing PyTest to include the Quartus backend under `pytest/test_merge.py`  
> * HLS Synnthesis to verify correct synthesis, resource usage and layers.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.