### PR TITLE
Fix conv1d stream implementation hls directives

### DIFF
--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv_stream.h
@@ -156,13 +156,13 @@ void kernel_shift_1d(
     typename data_T::value_type kernel_window[CONFIG_T::filt_width * CONFIG_T::n_chan]
 ) {
     #pragma HLS inline
-    #pragma HLS PIPELINE II = 1
     
     // Shift kernel_window by one step to the left (manual shift operation)
     static const int filt_width = CONFIG_T::filt_width - 1;
     KernelShiftWidth: for (int i_iw = 0; i_iw < filt_width; i_iw++) {
-        #pragma HLS UNROLL
+        #pragma HLS PIPELINE II = 1
         KernelShiftChannel: for (unsigned i_ic = 0; i_ic < CONFIG_T::n_chan; i_ic++) {
+            #pragma HLS UNROLL
             // Shift every element in kernel_window to the left
             kernel_window[i_iw * CONFIG_T::n_chan + i_ic] = kernel_window[(i_iw + 1) * CONFIG_T::n_chan + i_ic];
         }


### PR DESCRIPTION
# Description

Fixed compiler directives for conv1d io_stream implementation. A loop was given the unroll directive, when it should have been pipelined. This loop is used to shift the kernel data when a new input is read by the stream. The new directives match those used in the conv2d implementation. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Tests

The existing tests for conv1d still pass

**Test Configuration**:

To see the improvements of the fix, I just ran synthesis on a large conv1d layer. The layer's parameters in this test are 8 channels, 16 filters, length 4096, with a kernel size of 7 and a stride of 2. The fix reduces the latency from 635,968 cycles to 53,342 cycles when using a reuse factor of 1 and resource strategy.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.B