### PR TITLE
append applied_flows container before filling instead of after

### DIFF
--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -348,7 +348,7 @@ class ModelGraph(object):
             applied_flows = {}
 
             for flow_group in self._applied_flows:
-                applied_flows.update({flow: [] for flow in flow_group.keys()})
+                applied_flows.update({flow: set() for flow in flow_group.keys()})
 
             return applied_flows
 
@@ -364,8 +364,8 @@ class ModelGraph(object):
             if flow in applied_flows:
                 return
 
-        self._apply_sub_flow(flow, applied_flows)
         self._applied_flows.append(applied_flows)
+        self._apply_sub_flow(flow, applied_flows)
 
     def _apply_sub_flow(self, flow_name, applied_flows):
         if flow_name in applied_flows:
@@ -379,7 +379,7 @@ class ModelGraph(object):
         if len(flow.optimizers) > 0:
             applied_passes = optimize_model(self, flow.optimizers)
         else:
-            applied_passes = []
+            applied_passes = set()
         applied_flows[flow.name] = applied_passes
 
     def make_node(self, kind, name, attributes, inputs, outputs=None):


### PR DESCRIPTION
# Description

This change simply appends `applied_flows` to `ModelGraph._applied_flows` in the beginning, before it is filled, so that  `ModelGraph._applied_flows` always has an accurate description of what has been applied. This is important in the FIFO depth optimization, because the `FifoDepthOptimization` runs the writer flow outside of the main flow, before the flow is finished and before `ModelGraph._applied_flows` is updated, so currently it sees `ModelGraph._applied_flows == []`, and since the writer depends on `'vivado:ip'`, all the optimizers are run again, which sometimes messes things up. For example, running on a ResNet sample, rerunning the optimizers changes a type from being `PackedType` to just being `FixedPrecisionType`, causing it to fail. This way,   `ModelGraph._applied_flows` is always current so the out of main flow writer does not run `'vivado:ip'` again.

I also updated a few empty lists to empty sets so that applied_flows is always a dictionary of sets, not a dictionary of sets or empty lists. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

The main test is to see that this doesn't break the current pytests. The FIFO optimization is too long to run as a standard test.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
