### PR TITLE
Fix keras model loading issue with loading model with KerasH5

### DIFF
--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -232,7 +232,7 @@ def keras_to_hls(config):
             if model_arch is None:
                 raise ValueError('No model found in config file.')
             else:
-                # model_arch should be a string by default. Keeping this if just for compatibility.
+                # model_arch is string by default since h5py 3.0.0, keeping this condition for compatibility.
                 if isinstance(model_arch, bytes): 
                     model_arch = model_arch.decode('utf-8')
                 model_arch = json.loads(model_arch) 

--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -232,7 +232,10 @@ def keras_to_hls(config):
             if model_arch is None:
                 raise ValueError('No model found in config file.')
             else:
-                model_arch = json.loads(model_arch.decode('utf-8'))
+                # model_arch should be a string by default. Keeping this if just for compatibility.
+                if isinstance(model_arch, bytes): 
+                    model_arch = model_arch.decode('utf-8')
+                model_arch = json.loads(model_arch) 
         reader = KerasFileReader(config)
     else:
         raise ValueError('No model found in config file.')

--- a/test/pytest/test_keras_h5_loader.py
+++ b/test/pytest/test_keras_h5_loader.py
@@ -1,0 +1,37 @@
+import pytest
+import hls4ml
+import tensorflow as tf
+import numpy as np
+from pathlib import Path
+
+
+test_root_path = Path(__file__).parent
+
+test_root_path = Path('/tmp')
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Quartus'])
+def test_keras_h5_loader(backend):
+    input_shape = (10,)
+    model = tf.keras.models.Sequential([
+        tf.keras.layers.InputLayer(input_shape=input_shape),
+        tf.keras.layers.Activation(activation='relu'),
+    ])
+
+    hls_config = hls4ml.utils.config_from_keras_model(model, granularity='name')
+
+    config = {'OutputDir': 'KerasH5_loader_test',
+              'ProjectName': 'KerasH5_loader_test',
+              'Backend': backend,
+              'ClockPeriod': 25.0,
+              'IOType': 'io_parallel',
+              'HLSConfig': hls_config,
+              'KerasH5': str(test_root_path / 'KerasH5_loader_test.h5'),
+              'output_dir': str(test_root_path / 'KerasH5_loader_test')}
+
+    model.save(config['KerasH5'])
+    hls_model = hls4ml.converters.keras_to_hls(config)
+    hls_model.compile()
+    data = np.random.rand(1000, 10).astype(np.float32)
+    pred = hls_model.predict(data)
+    np.testing.assert_allclose(pred, model.predict(data), rtol=5e-3, atol=5e-3)


### PR DESCRIPTION
A# Description

In the current version of hls4ml, if one use the key "KerasH5" and not supplying the json model file to load the Keras model, the framework will try to decode the string in h5.attrs[ ] in utf-8 and fails. This PR patchs this issue by doing a type check first.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  

**Test Configuration**:
Unit test added for KerasH5 loader at `test/pytest/test_keras_h5_loader.py`
Create any keras model, save it to .h5 and use only the `KerasH5` without providing the in the config dictionary (or command line interface) to load it model json -> crash

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.B