### PR TITLE
Use wider accum_t for (average) pooling

### DIFF
--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -573,7 +573,6 @@ class Pooling1D(Layer):
             dims = ['N_FILT_{}'.format(self.index), 'N_OUTPUTS_{}'.format(self.index)]
         self.add_output_variable(shape, dims)
         self.set_attr('pool_op', self.get_attr('class_name').split('Pooling')[0])
-        self.set_attr('implementation', self.model.config.get_conv_implementation(self).lower())
 
 class Pooling2D(Layer):
     _expected_attributes = [
@@ -607,7 +606,6 @@ class Pooling2D(Layer):
             dims = ['N_FILT_{}'.format(self.index), 'OUT_HEIGHT_{}'.format(self.index), 'OUT_WIDTH_{}'.format(self.index)]
         self.add_output_variable(shape, dims)
         self.set_attr('pool_op', self.get_attr('class_name').split('Pooling')[0])
-        self.set_attr('implementation', self.model.config.get_conv_implementation(self).lower())
 
 class GlobalPooling1D(Layer):
     _expected_attributes = [

--- a/hls4ml/templates/vivado/nnet_utils/nnet_pooling_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_pooling_stream.h
@@ -169,7 +169,7 @@ void compute_pool_buffer_2d(
     static int sX = 0; // stride X
     static int sY = 0; // stride Y
 
-    typename data_T::value_type pool_window[CONFIG_T::pool_height * CONFIG_T::pool_width];
+    typename CONFIG_T::accum_t pool_window[CONFIG_T::pool_height * CONFIG_T::pool_width];
     #pragma HLS ARRAY_PARTITION variable=pool_window complete
 
     static typename data_T::value_type kernel_data[CONFIG_T::pool_height * CONFIG_T::pool_width * CONFIG_T::n_filt];
@@ -192,7 +192,7 @@ void compute_pool_buffer_2d(
             }
 
             // Compute Pooling
-            res_pack[i_ic] = reduce_pool<typename data_T::value_type, CONFIG_T::pool_height * CONFIG_T::pool_width, CONFIG_T>(pool_window);
+            res_pack[i_ic] = reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_height * CONFIG_T::pool_width, CONFIG_T>(pool_window);
         }
 
         // Write to output
@@ -378,7 +378,7 @@ void compute_pool_buffer_1d(
     static int pX = 0;
     static int sX = 0;
 
-    typename data_T::value_type pool_window[CONFIG_T::pool_width];
+    typename CONFIG_T::accum_t pool_window[CONFIG_T::pool_width];
     #pragma HLS ARRAY_PARTITION variable=pool_window complete
 
     static typename data_T::value_type kernel_data[CONFIG_T::pool_width * CONFIG_T::n_filt];
@@ -402,7 +402,7 @@ void compute_pool_buffer_1d(
             }
 
             // Compute Pooling
-            res_pack[i_ic] = reduce_pool<typename data_T::value_type, CONFIG_T::pool_width, CONFIG_T>(pool_window);
+            res_pack[i_ic] = reduce_pool<typename CONFIG_T::accum_t, CONFIG_T::pool_width, CONFIG_T>(pool_window);
         }
 
         // Write to output

--- a/test/pytest/test_cnn_mnist.py
+++ b/test/pytest/test_cnn_mnist.py
@@ -45,10 +45,13 @@ def keras_model(mnist_data):
   keras_model.fit(x_train, y_train, batch_size=32, epochs=5,  verbose=0)
   return keras_model
 
-@pytest.mark.parametrize('backend, io_type, strategy', [
+@pytest.mark.parametrize('backend,io_type,strategy', [
                                       ('Quartus', 'io_parallel', 'resource'),
+  
                                       ('Vivado', 'io_parallel', 'resource'),
-                                      ('Vivado', 'io_parallel', 'latency')
+                                      ('Vivado', 'io_parallel', 'latency'),
+                                      ('Vivado', 'io_stream', 'latency'),
+                                      ('Vivado', 'io_stream', 'resource')
                                     ])
 def test_mnist_cnn(keras_model, mnist_data, backend, io_type, strategy):
   x_train, y_train, x_test, y_test = mnist_data


### PR DESCRIPTION
# Description

As discussed in [656](https://github.com/fastmachinelearning/hls4ml/pull/656/files#r1015777210) `io_stream` implementation of AveragePooling doesn't use the wider type for summing up the values of the pool window. This fixes it (bugs 1 and 2 from that discussion).

I'd appreciate an expedited review so that we can merge #656 (the test in main branch will fail if we merge that one before this one).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

I expanded the `test_cnn_mnist.py` to include `io_stream` implementations where this issue was first observed.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.