### PR TITLE
Add causal padding

### DIFF
--- a/hls4ml/backends/vivado/passes/conv_same_pad.py
+++ b/hls4ml/backends/vivado/passes/conv_same_pad.py
@@ -6,7 +6,7 @@ class InsertZeroPaddingBeforeConv1D(OptimizerPass):
     
     def match(self, node):
         is_match = isinstance(node, (Conv1D, SeparableConv1D)) and \
-            node.get_attr('padding') == 'same' and \
+            ((node.get_attr('padding') == 'same') or (node.get_attr('padding') == 'causal')) and \
             node.get_attr('filt_width') != 1
         return is_match
 

--- a/hls4ml/converters/utils.py
+++ b/hls4ml/converters/utils.py
@@ -32,6 +32,14 @@ def compute_padding_1d(pad_type, in_size, stride, filt_size):
         n_out = int(math.ceil(float(in_size - filt_size + 1) / float(stride)))
         pad_left = 0
         pad_right = 0
+    elif pad_type.lower() == 'causal':        
+        n_out = int(math.ceil(float(in_size) / float(stride)))
+        if (in_size % stride == 0):
+            pad_along_size = max(filt_size - stride, 0)       
+        else:
+            pad_along_size = max(filt_size - (in_size % stride), 0)
+        pad_left  = pad_along_size
+        pad_right  = 0
     else:
         raise Exception('Unknown padding type: {}'.format(pad_type))
 

--- a/test/pytest/test_causalpadding.py
+++ b/test/pytest/test_causalpadding.py
@@ -22,7 +22,7 @@ def test_causalpadding(io_type, backend):
     data = np.expand_dims(data, axis=-1)
 
     config = hls4ml.utils.config_from_keras_model(model,
-                                                  default_precision='ap_fixed<32,1>',
+                                                  default_precision='ap_fixed<32,16>',
                                                   granularity='name')
     odir = str(test_root_path / f'hls4mlprj_validpadding_{backend}_{io_type}')
     hls_model = hls4ml.converters.convert_from_keras_model(model,

--- a/test/pytest/test_causalpadding.py
+++ b/test/pytest/test_causalpadding.py
@@ -1,0 +1,36 @@
+import pytest
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Conv1D
+import numpy as np
+import hls4ml
+from pathlib import Path
+
+test_root_path = Path(__file__).parent
+
+atol = 5e-3
+
+@pytest.mark.parametrize('io_type', ['io_stream', 'io_parallel'])
+@pytest.mark.parametrize('backend', ['Vivado', 'Quartus'])
+def test_validpadding(io_type, backend):
+    
+    model = Sequential()
+    model.add(Conv1D(1, 5, padding="causal"))
+    model.compile()
+
+    data = np.random.normal(0, 1, 100)
+
+    config = hls4ml.utils.config_from_keras_model(model,
+                                                  default_precision='ap_fixed<32,1>',
+                                                  granularity='name')
+    odir = str(test_root_path / f'hls4mlprj_validpadding_{backend}_{io_type}')
+    hls_model = hls4ml.converters.convert_from_keras_model(model,
+                                                           hls_config=config,
+                                                           io_type=io_type,
+                                                           output_dir=odir,
+                                                           backend=backend)
+    hls_model.compile()
+
+    # Predict
+    y_keras = model.predict(data).flatten()
+    y_hls = hls_model.predict(data).flatten()
+    np.testing.assert_allclose(y_keras, y_hls, rtol=0, atol=atol, verbose=True)

--- a/test/pytest/test_causalpadding.py
+++ b/test/pytest/test_causalpadding.py
@@ -14,10 +14,12 @@ atol = 5e-3
 def test_causalpadding(io_type, backend):
     
     model = Sequential()
-    model.add(Conv1D(1, 5, padding="causal"))
+    model.add(Conv1D(1, 5, padding="causal", input_shape=(100, 1)))
     model.compile()
 
-    data = np.random.normal(0, 1, 100)
+    data = np.random.randint(0, 10, 100).astype(float)
+    data = np.expand_dims(data, axis=0)
+    data = np.expand_dims(data, axis=-1)
 
     config = hls4ml.utils.config_from_keras_model(model,
                                                   default_precision='ap_fixed<32,1>',

--- a/test/pytest/test_causalpadding.py
+++ b/test/pytest/test_causalpadding.py
@@ -11,7 +11,7 @@ atol = 5e-3
 
 @pytest.mark.parametrize('io_type', ['io_stream', 'io_parallel'])
 @pytest.mark.parametrize('backend', ['Vivado', 'Quartus'])
-def test_validpadding(io_type, backend):
+def test_causalpadding(io_type, backend):
     
     model = Sequential()
     model.add(Conv1D(1, 5, padding="causal"))


### PR DESCRIPTION
This code implements the "causal" padding for Keras Conv1D layers. This padding only adds leading zeros at the left of the input. This means, CNNs only look into the past but can not see into the future for temporal ordered data points.

The implementation is rather easy:
Instead of setting the left and right padding to (kernel size - 1) // 2 just set the left padding to (kernel size - 1) and the right padding to 0. To enable causal padding, also a .py file in backends is changed so that padding is activated if padding is "causal"

Also a simple test file is added.