### PR TITLE
Fix function call in Alveo tcl script

### DIFF
--- a/hls4ml/templates/vivado_accelerator/alveo/tcl_scripts/axi_stream_design.tcl
+++ b/hls4ml/templates/vivado_accelerator/alveo/tcl_scripts/axi_stream_design.tcl
@@ -7,8 +7,8 @@ set_property  ip_repo_paths  ${project_name}_prj [current_project]
 update_ip_catalog
 
 
-add_files -scan_for_includes {src/krnl_rtl_int.sv src/krnl_rtl_axi_read_master.sv src/krnl_rtl_counter.sv src/${project_name}_kernel.v src/krnl_rtl_axi_write_master.sv src/krnl_rtl_control_s_axi.v}
-import_files {src/krnl_rtl_int.sv src/krnl_rtl_axi_read_master.sv src/krnl_rtl_counter.sv src/${project_name}_kernel.v src/krnl_rtl_axi_write_master.sv src/krnl_rtl_control_s_axi.v}
+add_files -scan_for_includes [list src/krnl_rtl_int.sv src/krnl_rtl_axi_read_master.sv src/krnl_rtl_counter.sv src/${project_name}_kernel.v src/krnl_rtl_axi_write_master.sv src/krnl_rtl_control_s_axi.v]
+import_files [list src/krnl_rtl_int.sv src/krnl_rtl_axi_read_master.sv src/krnl_rtl_counter.sv src/${project_name}_kernel.v src/krnl_rtl_axi_write_master.sv src/krnl_rtl_control_s_axi.v]
 
 
 


### PR DESCRIPTION
# Description

After changes in #626 the file list passed to the `add_files` and `import_files` tcl functions is using a variable, but the `{...}` syntax doesn't do expansion so the name of the file is never properly made, causing the script to fail. This can be solved in several ways buy since the functions expect list of strings, the cleanest approach is to use `[list ...]`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Not really needed, this is a syntax fix.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
