### PR TITLE
remove obsolete np.int and np.float

### DIFF
--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -195,7 +195,7 @@ class QuartusWriter(Writer):
                     newline += 'hls_max_concurrency(0)\n'
                     newline += f'hls_component_ii({self.get_max_reuse_factor(model)})\n'
                 clock_mhz = 1000 / (model.config.get_config_value('ClockPeriod'))
-                newline += f'hls_scheduler_target_fmax_mhz({np.ceil(clock_mhz).astype(np.int)})\n'
+                newline += f'hls_scheduler_target_fmax_mhz({np.ceil(clock_mhz).astype(int)})\n'
 
             # In io_parallel, an output (struct) is returned from the top-level function
             # Therefore, it needs to be initialised before returning
@@ -342,7 +342,7 @@ class QuartusWriter(Writer):
                     newline += 'hls_max_concurrency(0)\n'
                     newline += f'hls_component_ii({self.get_max_reuse_factor(model)})\n'
                 clock_mhz = 1000 / (model.config.get_config_value('ClockPeriod'))
-                newline += f'hls_scheduler_target_fmax_mhz({np.ceil(clock_mhz).astype(np.int)})\n'
+                newline += f'hls_scheduler_target_fmax_mhz({np.ceil(clock_mhz).astype(int)})\n'
 
             # For io_stream, no inputs/outputs are instantiated, as they are passed by reference
             # For io_parallel, input/output structs are required

--- a/test/pytest/test_embed.py
+++ b/test/pytest/test_embed.py
@@ -1,16 +1,20 @@
-import pytest
-import hls4ml
-import numpy as np
 from pathlib import Path
+
+import numpy as np
+import pytest
+from tensorflow.keras.layers import Embedding, Input
 from tensorflow.keras.models import Model
-from tensorflow.keras.layers import Input, Embedding
+
+import hls4ml
 
 test_root_path = Path(__file__).parent
+
 
 @pytest.fixture(scope='module')
 def data():
     X = np.random.randint(10, size=(32, 100))
     return X
+
 
 @pytest.fixture(scope='module')
 def keras_model():
@@ -19,23 +23,21 @@ def keras_model():
     model = Model(inputs=inputs, outputs=embedding)
     return model
 
+
 @pytest.fixture
 @pytest.mark.parametrize('backend', ['Vivado', 'Quartus'])
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
 def hls_model(keras_model, backend, io_type):
-    hls_config = hls4ml.utils.config_from_keras_model(keras_model,
-                                                      default_precision='ap_fixed<16,6>',
-                                                      granularity='name')
+    hls_config = hls4ml.utils.config_from_keras_model(keras_model, default_precision='ap_fixed<16,6>', granularity='name')
     hls_config['LayerName']['embedding_input']['Precision']['result'] = 'ap_uint<4>'
     out_dir = str(test_root_path / 'hls4mlprj_embed_{}_{}').format(backend, io_type)
-    hls_model = hls4ml.converters.convert_from_keras_model(keras_model,
-                                                           backend=backend,
-                                                           hls_config=hls_config,
-                                                           io_type=io_type,
-                                                           output_dir=out_dir)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        keras_model, backend=backend, hls_config=hls_config, io_type=io_type, output_dir=out_dir
+    )
 
     hls_model.compile()
     return hls_model
+
 
 @pytest.mark.parametrize('backend', ['Vivado', 'Quartus'])
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
@@ -44,6 +46,6 @@ def test_embedding_accuracy(data, keras_model, hls_model):
     model = keras_model
     # model under test predictions and accuracy
     y_keras = model.predict(X)
-    y_hls4ml   = hls_model.predict(X.astype(np.float)).reshape(y_keras.shape)
+    y_hls4ml = hls_model.predict(X.astype(float)).reshape(y_keras.shape)
     # "accuracy" of hls4ml predictions vs keras
     np.testing.assert_allclose(y_keras, y_hls4ml, rtol=0, atol=1e-03, verbose=True)


### PR DESCRIPTION
# Description

Starting with numpy 1.24 `np.int` and `np.float` are no longer just deprecated but raise an error. This PR just changes them to `int` and `float`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Pytests with the quartus backend and `test_embedded.py` both fail without this change.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
