### PR TITLE
Fix incorrectly linted build() command

### DIFF
--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -189,13 +189,13 @@ class VivadoBackend(FPGABackend):
         curr_dir = os.getcwd()
         os.chdir(model.config.get_output_dir())
         vivado_cmd = (
-            f'vivado_hls -f build_prj.tcl "reset={reset}'
-            f'csim={csim}'
-            f'synth={synth}'
-            f'cosim={cosim}'
-            f'validation={validation}'
-            f'export={export}'
-            f'vsynth={vsynth}'
+            f'vivado_hls -f build_prj.tcl "reset={reset} '
+            f'csim={csim} '
+            f'synth={synth} '
+            f'cosim={cosim} '
+            f'validation={validation} '
+            f'export={export} '
+            f'vsynth={vsynth} '
             f'fifo_opt={fifo_opt}"'
         )
         os.system(vivado_cmd)


### PR DESCRIPTION
# Description

Recent reformatting of the code changed the build command in `build()` of `vivado_backend.py`. The multi-line string is missing spaces between the parameters. The following error happens:

```
---------error message---------
Sourcing Tcl script 'build_prj.tcl'
expected boolean value but got "Falsecsim"
    while executing
"if {$opt(reset)} {
    open_project -reset ${project_name}_prj
} else {
    open_project ${project_name}_prj
}"
    (file "build_prj.tcl" line 149)
    invoked from within
"source build_prj.tcl"
    ("uplevel" body line 1)
    invoked from within
"uplevel \#0 [list source $arg] "
```

Hopefully the linter doesn't complain about this.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

The Jenkins tests should prove that this works.

## Checklist
- [ ] I have installed and run `pre-commit` on the files I edited or added. -> I actually can't run this and it is Friday evening, so I can't be bothered with fixing my setup.
