### PR TITLE
update isort to fix pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
       - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
     args: ["--profile", "black", --line-length=125]


### PR DESCRIPTION
update isort 5.11.4->5.12.0 and python 3.7->3.8 to fix pre-commit github action

See: https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff