### PR TITLE
Register layer attributes in VivadoAccelerator backend

### DIFF
--- a/hls4ml/backends/vivado_accelerator/vivado_accelerator_backend.py
+++ b/hls4ml/backends/vivado_accelerator/vivado_accelerator_backend.py
@@ -8,6 +8,7 @@ from hls4ml.report import parse_vivado_report
 class VivadoAcceleratorBackend(VivadoBackend):
     def __init__(self):
         super(VivadoBackend, self).__init__(name='VivadoAccelerator')
+        self._register_layer_attributes()
         self._register_flows()
 
     def build(


### PR DESCRIPTION
# Description

`VivadoAccelerator` backend doesn't call `_register_layer_attributes()` so the layers with backend-specific attributes don't get extended as with the `Vivado` backend. This means the layers that expect some default values don't get them, causing conversion issues. Fixes #722 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Test from #722 should suffice.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
