### PR TITLE
Fixed sign parsing for ac_fixed and ac_int

### DIFF
--- a/hls4ml/backends/fpga/fpga_backend.py
+++ b/hls4ml/backends/fpga/fpga_backend.py
@@ -342,20 +342,16 @@ class FPGABackend(Backend):
             integer = int(bits[1])
             fields = 2
             if len(bits) > 2:
-                if bits[2].lower() == "false":
+                if bits[2].strip().lower() in ['false', '0']:
                     signed = False
-                else:
-                    signed = bool(bits[2])
                 fields = 3
         elif 'int' in precision:
             width = int(bits[0])
             integer = width
             fields = 1
             if len(bits) > 1:
-                if bits[1].lower() == "false":
+                if bits[1].strip().lower() in ['false', '0']:
                     signed = False
-                else:
-                    signed = bool(bits[1])
                 fields = 2
         if len(bits) > fields:
             round_mode = bits[fields]

--- a/hls4ml/backends/fpga/fpga_backend.py
+++ b/hls4ml/backends/fpga/fpga_backend.py
@@ -342,9 +342,7 @@ class FPGABackend(Backend):
             integer = int(bits[1])
             fields = 2
             if len(bits) > 2:
-                if bits[2] == "true":
-                    signed = True
-                elif bits[2] == "false":
+                if bits[2].lower() == "false":
                     signed = False
                 else:
                     signed = bool(bits[2])
@@ -354,9 +352,7 @@ class FPGABackend(Backend):
             integer = width
             fields = 1
             if len(bits) > 1:
-                if bits[1] == "true":
-                    signed = True
-                elif bits[1] == "false":
+                if bits[1].lower() == "false":
                     signed = False
                 else:
                     signed = bool(bits[1])

--- a/hls4ml/backends/fpga/fpga_backend.py
+++ b/hls4ml/backends/fpga/fpga_backend.py
@@ -342,14 +342,24 @@ class FPGABackend(Backend):
             integer = int(bits[1])
             fields = 2
             if len(bits) > 2:
-                signed = bool(bits[2])
+                if bits[2] == "true":
+                    signed = True
+                elif bits[2] == "false":
+                    signed = False
+                else:
+                    signed = bool(bits[2])
                 fields = 3
         elif 'int' in precision:
             width = int(bits[0])
             integer = width
             fields = 1
             if len(bits) > 1:
-                signed = bool(bits[1])
+                if bits[1] == "true":
+                    signed = True
+                elif bits[1] == "false":
+                    signed = False
+                else:
+                    signed = bool(bits[1])
                 fields = 2
         if len(bits) > fields:
             round_mode = bits[fields]

--- a/hls4ml/backends/fpga/fpga_backend.py
+++ b/hls4ml/backends/fpga/fpga_backend.py
@@ -342,6 +342,8 @@ class FPGABackend(Backend):
             integer = int(bits[1])
             fields = 2
             if len(bits) > 2:
+                # only if the third argument is false or 0, set signed to False
+                # (default is True)
                 if bits[2].strip().lower() in ['false', '0']:
                     signed = False
                 fields = 3
@@ -350,6 +352,8 @@ class FPGABackend(Backend):
             integer = width
             fields = 1
             if len(bits) > 1:
+                # only if the second argument is false or 0, set signed to False
+                # (default is True)
                 if bits[1].strip().lower() in ['false', '0']:
                     signed = False
                 fields = 2

--- a/test/pytest/test_precision_parsing.py
+++ b/test/pytest/test_precision_parsing.py
@@ -27,4 +27,3 @@ def test_sign_parsing(prec_pair):
 
     evalprec = hls4ml.backends.fpga.fpga_backend.FPGABackend.convert_precision_string(strprec)
     assert evalprec.signed == signed
-    print(evalprec)

--- a/test/pytest/test_precision_parsing.py
+++ b/test/pytest/test_precision_parsing.py
@@ -21,6 +21,7 @@ import hls4ml
     ],
 )
 def test_sign_parsing(prec_pair):
+    '''Test that convert_precions_string determines the signedness correctly'''
     strprec = prec_pair[0]
     signed = prec_pair[1]
 

--- a/test/pytest/test_precision_parsing.py
+++ b/test/pytest/test_precision_parsing.py
@@ -1,0 +1,29 @@
+import pytest
+
+import hls4ml
+
+
+@pytest.mark.parametrize(
+    'prec_pair',
+    [
+        ('ap_fixed<3, 2>', True),
+        ('ap_ufixed<3, 2>', False),
+        ('ac_fixed<3, 2, true>', True),
+        ('ac_fixed<3, 2, false>', False),
+        ('ac_fixed<3, 2, 1>', True),
+        ('ac_fixed<3, 2, 0>', False),
+        ('ap_int<3, 2>', True),
+        ('ap_uint<3>', False),
+        ('ac_int<3, TRue>', True),
+        ('ac_int<3, FALse>', False),
+        ('ac_int<3, 1>', True),
+        ('ac_int<3, 0>', False),
+    ],
+)
+def test_sign_parsing(prec_pair):
+    strprec = prec_pair[0]
+    signed = prec_pair[1]
+
+    evalprec = hls4ml.backends.fpga.fpga_backend.FPGABackend.convert_precision_string(strprec)
+    assert evalprec.signed == signed
+    print(evalprec)


### PR DESCRIPTION
# Description

Previously 'ac_fixed<..>' and 'ac_int<..>' strings in the configuration were always parsed as signed. This fixes the issue

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

I added a pytest to just directly call `convert_precision_string` and make sure that signed was correctly evaluated


## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
