### PR TITLE
fix Vitis pragmas messed up by pre-commit

### DIFF
--- a/hls4ml/templates/vitis/nnet_utils/nnet_pooling.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_pooling.h
@@ -198,8 +198,8 @@ void pooling2d_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
 
     // TODO partition the arrays according to the reuse factor
     const int limit = pool_op_limit<CONFIG_T>();
-    #pragma HLS ALLOCATION function instances=pool_op<data_T, CONFIG_T::pool_height*CONFIG_T::pool_width,
-    // CONFIG_T::pool_op> limit=limit
+    #pragma HLS ALLOCATION function instances=pool_op<data_T, CONFIG_T::pool_height*CONFIG_T::pool_width, \
+        CONFIG_T::pool_op> limit=limit
     // Add any necessary padding
     unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
     unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
@@ -255,8 +255,8 @@ void pooling2d_cf(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
 
     // TODO partition the arrays according to the reuse factor
     const int limit = pool_op_limit<CONFIG_T>();
-    #pragma HLS ALLOCATION function instances=pool_op<data_T, CONFIG_T::pool_height*CONFIG_T::pool_width,
-    // CONFIG_T::pool_op> limit=limit
+    #pragma HLS ALLOCATION function instances=pool_op<data_T, CONFIG_T::pool_height*CONFIG_T::pool_width, \
+        CONFIG_T::pool_op> limit=limit
     // Add any necessary padding
     unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
     unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
@@ -317,8 +317,8 @@ void global_pooling2d_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * 
     #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
     const int limit = pool_op_limit<CONFIG_T>();
-    #pragma HLS ALLOCATION function instances=pool_op<data_T, CONFIG_T::pool_width * CONFIG_T::pool_height,
-    // CONFIG_T::pool_op> limit=limit
+    #pragma HLS ALLOCATION function instances=pool_op<data_T, CONFIG_T::pool_width * CONFIG_T::pool_height, \
+        CONFIG_T::pool_op> limit=limit
 
 FiltLoop:
     for (int filt = 0; filt < CONFIG_T::n_filt; filt++) {


### PR DESCRIPTION
# Description

Pre-commit modified some long pragmas incorrectly. This fixes the issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Should would have been caught by Vitis builds, which we need to add to the CI. We should do that, but probably not hold this PR for that. Vitis pytests should confirm that this doesn't mess up compilation.

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
