### PR TITLE
Don't use reader in ModelGraph and layers

### DIFF
--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -6,6 +6,7 @@ import yaml
 
 from hls4ml.converters.keras_to_hls import KerasFileReader  # noqa: F401
 from hls4ml.converters.keras_to_hls import KerasModelReader  # noqa: F401
+from hls4ml.converters.keras_to_hls import KerasReader  # noqa: F401
 from hls4ml.converters.keras_to_hls import get_supported_keras_layers  # noqa: F401
 from hls4ml.converters.keras_to_hls import parse_keras_model  # noqa: F401
 from hls4ml.converters.keras_to_hls import keras_to_hls, register_keras_layer_handler

--- a/hls4ml/converters/keras/convolution.py
+++ b/hls4ml/converters/keras/convolution.py
@@ -10,7 +10,7 @@ def parse_conv1d_layer(keras_layer, input_names, input_shapes, data_reader):
 
     (layer['in_width'], layer['n_chan']) = parse_data_format(input_shapes[0], layer['data_format'])
 
-    if layer['class_name'] == 'Conv1D':
+    if layer['class_name'] in ['Conv1D', 'QConv1D']:
         layer['weight_data'] = get_weights_data(data_reader, layer['name'], 'kernel')
     else:  # SeparableConv1D
         layer['depthwise_data'], layer['pointwise_data'], layer['bias_data'] = get_weights_data(
@@ -44,9 +44,9 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader):
 
     (layer['in_height'], layer['in_width'], layer['n_chan']) = parse_data_format(input_shapes[0], layer['data_format'])
 
-    if layer['class_name'] == 'Conv2D':
+    if layer['class_name'] in ['Conv2D', 'QConv2D']:
         layer['weight_data'] = get_weights_data(data_reader, layer['name'], 'kernel')
-    elif layer['class_name'] == 'SeparableConv2D':
+    elif layer['class_name'] in ['SeparableConv2D', 'QSeparableConv2D']:
         layer['depthwise_data'], layer['pointwise_data'] = get_weights_data(
             data_reader, layer['name'], ['depthwise_kernel', 'pointwise_kernel']
         )

--- a/hls4ml/converters/keras/convolution.py
+++ b/hls4ml/converters/keras/convolution.py
@@ -1,4 +1,4 @@
-from hls4ml.converters.keras_to_hls import keras_handler, parse_default_keras_layer
+from hls4ml.converters.keras_to_hls import get_weights_data, keras_handler, parse_default_keras_layer
 from hls4ml.converters.utils import compute_padding_1d, compute_padding_2d, parse_data_format
 
 
@@ -9,6 +9,15 @@ def parse_conv1d_layer(keras_layer, input_names, input_shapes, data_reader):
     layer = parse_default_keras_layer(keras_layer, input_names)
 
     (layer['in_width'], layer['n_chan']) = parse_data_format(input_shapes[0], layer['data_format'])
+
+    if layer['class_name'] == 'Conv1D':
+        layer['weight_data'] = get_weights_data(data_reader, layer['name'], 'kernel')
+    else:  # SeparableConv1D
+        layer['depthwise_data'], layer['pointwise_data'], layer['bias_data'] = get_weights_data(
+            data_reader, layer['name'], ['depthwise_kernel', 'pointwise_kernel', 'bias']
+        )
+
+    layer['bias_data'] = get_weights_data(data_reader, layer['name'], 'bias')
 
     layer['n_filt'] = keras_layer['config']['filters']
     layer['filt_width'] = keras_layer['config']['kernel_size'][0]
@@ -34,6 +43,17 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader):
     layer = parse_default_keras_layer(keras_layer, input_names)
 
     (layer['in_height'], layer['in_width'], layer['n_chan']) = parse_data_format(input_shapes[0], layer['data_format'])
+
+    if layer['class_name'] == 'Conv2D':
+        layer['weight_data'] = get_weights_data(data_reader, layer['name'], 'kernel')
+    elif layer['class_name'] == 'SeparableConv2D':
+        layer['depthwise_data'], layer['pointwise_data'] = get_weights_data(
+            data_reader, layer['name'], ['depthwise_kernel', 'pointwise_kernel']
+        )
+    else:  # DepthwiseConv2D
+        layer['depthwise_data'] = get_weights_data(data_reader, layer['name'], 'depthwise_kernel')
+
+    layer['bias_data'] = get_weights_data(data_reader, layer['name'], 'bias')
 
     if 'filters' in keras_layer['config']:
         layer['n_filt'] = keras_layer['config']['filters']

--- a/hls4ml/converters/keras/core.py
+++ b/hls4ml/converters/keras/core.py
@@ -1,4 +1,4 @@
-from hls4ml.converters.keras_to_hls import keras_handler, parse_default_keras_layer
+from hls4ml.converters.keras_to_hls import get_weights_data, keras_handler, parse_default_keras_layer
 from hls4ml.model.types import BinaryQuantizer, IntegerPrecisionType, TernaryQuantizer
 
 
@@ -32,9 +32,9 @@ def parse_dense_layer(keras_layer, input_names, input_shapes, data_reader):
 
     layer = parse_default_keras_layer(keras_layer, input_names)
 
-    weights_shape = data_reader.get_weights_shape(layer['name'], 'kernel')
-    layer['n_in'] = weights_shape[0]
-    layer['n_out'] = weights_shape[1]
+    layer['weight_data'], layer['bias_data'] = get_weights_data(data_reader, layer['name'], ['kernel', 'bias'])
+    layer['n_in'] = layer['weight_data'].shape[0]
+    layer['n_out'] = layer['weight_data'].shape[1]
     if 'Binary' in layer['class_name']:
         layer['weight_quantizer'] = BinaryQuantizer(bits=2)
         layer['bias_quantizer'] = BinaryQuantizer(bits=2)
@@ -69,6 +69,8 @@ def parse_activation_layer(keras_layer, input_names, input_shapes, data_reader):
         layer['activ_param'] = keras_layer['config'].get('alpha', 1.0)
     elif layer['class_name'] == 'ReLU':
         layer['class_name'] = 'Activation'
+    elif layer['class_name'] == 'PReLU':
+        layer['alpha_data'] = get_weights_data(data_reader, layer['name'], 'alpha')
 
     if layer['class_name'] == 'Activation' and layer['activation'] == 'softmax':
         layer['class_name'] = 'Softmax'
@@ -99,7 +101,20 @@ def parse_batchnorm_layer(keras_layer, input_names, input_shapes, data_reader):
         layer['n_filt'] = input_shapes[0][3]
 
     layer['use_gamma'] = keras_layer['config']['scale']
+    if layer['use_gamma']:
+        layer['gamma_data'] = get_weights_data(data_reader, layer['name'], 'gamma')
+    else:
+        layer['gamma_data'] = 1
+
     layer['use_beta'] = keras_layer['config']['center']
+    if layer['use_beta']:
+        layer['beta_data'] = get_weights_data(data_reader, layer['name'], 'beta')
+    else:
+        layer['beta_data'] = 0
+
+    layer['mean_data'], layer['variance_data'] = get_weights_data(
+        data_reader, layer['name'], ['moving_mean', 'moving_variance']
+    )
 
     return layer, [shape for shape in input_shapes[0]]
 
@@ -113,6 +128,8 @@ def parse_embedding_layer(keras_layer, input_names, input_shapes, data_reader):
     layer['n_in'] = input_shapes[0][1]
     layer['vocab_size'] = keras_layer['config']['input_dim']
     layer['n_out'] = keras_layer['config']['output_dim']
+
+    layer['embeddings_data'] = get_weights_data(data_reader, layer['name'], 'embeddings')
 
     output_shape = input_shapes[0] + [layer['n_out']]
 

--- a/hls4ml/converters/keras/graph.py
+++ b/hls4ml/converters/keras/graph.py
@@ -1,5 +1,5 @@
 from hls4ml.converters.keras.core import TernaryQuantizer
-from hls4ml.converters.keras_to_hls import keras_handler, parse_default_keras_layer
+from hls4ml.converters.keras_to_hls import get_weights_data, keras_handler, parse_default_keras_layer
 
 
 @keras_handler('GarNet', 'GarNetStack')
@@ -31,6 +31,17 @@ def parse_garnet_layer(keras_layer, input_names, input_shapes, data_reader):
         layer['n_in_features'] = input_shapes[0][2]
         n_out_features = layer['n_out_features']
 
+        weights_source = [
+            'FLR_kernel',
+            'FLR_bias',
+            'S_kernel',
+            'S_bias',
+            'Fout_kernel',
+            'Fout_bias',
+        ]
+        for weight in weights_source:
+            layer[weight + '_data'] = get_weights_data(data_reader, layer['name'], weight)
+
     elif layer['class_name'] == 'GarNetStack':
         layer['n_sublayers'] = keras_layer['config']['n_sublayers']
         layer['n_in_features'] = [input_shapes[0][2]]
@@ -38,7 +49,16 @@ def parse_garnet_layer(keras_layer, input_names, input_shapes, data_reader):
         for il in range(1, layer['n_sublayers']):
             layer['n_in_features'].append(layer['n_out_features'][il - 1])
 
+            weights_source = [
+                f'S{il}_kernel',
+                f'S{il}_bias',
+                f'Fout{il}_bias',
+            ]
+            for weight in weights_source:
+                layer[weight + '_data'] = get_weights_data(data_reader, layer['name'], weight)
+
         n_out_features = layer['n_out_features'][-1]
+            
 
     if layer['collapse'] in ['mean', 'sum', 'max']:
         output_shape = [input_shapes[0][0], n_out_features]

--- a/hls4ml/converters/keras/graph.py
+++ b/hls4ml/converters/keras/graph.py
@@ -58,7 +58,6 @@ def parse_garnet_layer(keras_layer, input_names, input_shapes, data_reader):
                 layer[weight + '_data'] = get_weights_data(data_reader, layer['name'], weight)
 
         n_out_features = layer['n_out_features'][-1]
-            
 
     if layer['collapse'] in ['mean', 'sum', 'max']:
         output_shape = [input_shapes[0][0], n_out_features]

--- a/hls4ml/converters/keras/recurrent.py
+++ b/hls4ml/converters/keras/recurrent.py
@@ -1,4 +1,4 @@
-from hls4ml.converters.keras_to_hls import keras_handler, parse_default_keras_layer
+from hls4ml.converters.keras_to_hls import get_weights_data, keras_handler, parse_default_keras_layer
 
 rnn_layers = ['SimpleRNN', 'LSTM', 'GRU']
 
@@ -26,8 +26,18 @@ def parse_rnn_layer(keras_layer, input_names, input_shapes, data_reader):
 
     layer['n_out'] = keras_layer['config']['units']
 
+    layer['weight_data'], layer['recurrent_weight_data'], layer['bias_data'] = get_weights_data(
+        data_reader, layer['name'], ['kernel', 'recurrent_kernel', 'bias']
+    )
+
     if layer['class_name'] == 'GRU':
         layer['apply_reset_gate'] = 'after' if keras_layer['config']['reset_after'] else 'before'
+
+        # biases array is actually a 2-dim array of arrays (bias + recurrent bias)
+        # both arrays have shape: n_units * 3 (z, r, h_cand)
+        biases = layer['bias_data']
+        layer['bias_data'] = biases[0]
+        layer['recurrent_bias_data'] = biases[1]
 
     if layer['return_sequences']:
         output_shape = [input_shapes[0][0], layer['n_timesteps'], layer['n_out']]

--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -7,7 +7,12 @@ from hls4ml.model import ModelGraph
 MAXMULT = 4096
 
 
-class KerasFileReader:
+class KerasReader:
+    def get_weights_data(self, layer_name, var_name):
+        raise NotImplementedError
+
+
+class KerasFileReader(KerasReader):
     def __init__(self, config):
         self.config = config
         self.h5file = h5py.File(config['KerasH5'], mode='r')
@@ -39,15 +44,28 @@ class KerasFileReader:
         else:
             return None
 
-    def get_weights_shape(self, layer_name, var_name):
-        data = self._find_data(layer_name, var_name)
-        if data is not None:
-            return data.shape
+
+class KerasNestedFileReader(KerasFileReader):
+    def __init__(self, data_reader, nested_path):
+        self.config = data_reader.config
+        self.h5file = h5py.File(self.config['KerasH5'], mode='r')
+        self.nested_path = nested_path
+
+    def _find_data(self, layer_name, var_name):
+        def h5_visitor_func(name):
+            if var_name in name:
+                return name
+
+        layer_path = f'model_weights/{self.nested_path}/{layer_name}'
+
+        data_path = self.h5file[layer_path].visit(h5_visitor_func)
+        if data_path:
+            return self.h5file[f'/{layer_path}/{data_path}']
         else:
             return None
 
 
-class KerasModelReader:
+class KerasModelReader(KerasReader):
     def __init__(self, keras_model):
         self.model = keras_model
 
@@ -62,13 +80,17 @@ class KerasModelReader:
 
         return None
 
-    def get_weights_shape(self, layer_name, var_name):
-        layer = self.model.get_layer(layer_name)
-        for w in layer.weights:
-            if var_name in w.name:
-                return w.shape.as_list()
 
-        return None
+def get_weights_data(data_reader, layer_name, var_name):
+    if not isinstance(var_name, (list, tuple)):
+        var_name = [var_name]
+
+    data = [data_reader.get_weights_data(layer_name, var) for var in var_name]
+
+    if len(data) == 1:
+        return data[0]
+    else:
+        return (*data,)
 
 
 layer_handlers = {}
@@ -214,7 +236,7 @@ def parse_keras_model(model_arch, reader):
             input_layer['input_shape'] = layer_config[0]['config']['batch_input_shape'][1:]
             layer_list.append(input_layer)
             print('Input shape:', input_layer['input_shape'])
-    elif model_arch['class_name'] in ['Model', 'Functional']:  # TF >= 2.3 calls it 'Funcational' API
+    elif model_arch['class_name'] in ['Model', 'Functional']:  # TF >= 2.3 calls it 'Functional' API
         print('Interpreting Model')
         layer_config = model_arch['config']['layers']
         input_layers = [inp[0] for inp in model_arch['config']['input_layers']]
@@ -311,5 +333,5 @@ def keras_to_hls(config):
     model_arch, reader = get_model_arch(config)
     layer_list, input_layers, output_layers = parse_keras_model(model_arch, reader)
     print('Creating HLS model')
-    hls_model = ModelGraph(config, reader, layer_list, input_layers, output_layers)
+    hls_model = ModelGraph(config, layer_list, input_layers, output_layers)
     return hls_model

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -320,15 +320,13 @@ class ModelGraph:
 
     Args:
         config (dict):  The configuration dictionary
-        data_reader:  The data reader from where weights can be extracted
         layer_list (list(dict)):  The list contains a dictionary for each input layer
         inputs (list, optional):  The inputs to the model. If None, determined from layer_list
         outputs (list, optional):  The outputs to the model. If None, determined from layer_list
     """
 
-    def __init__(self, config, data_reader, layer_list, inputs=None, outputs=None):
+    def __init__(self, config, layer_list, inputs=None, outputs=None):
         self.config = HLSConfig(config)
-        self.reader = data_reader
 
         # keep track of the applied flows
         self._applied_flows = []
@@ -589,9 +587,6 @@ class ModelGraph:
         node_outputs = [out for node in self.graph.values() for out in node.outputs]
         node_inputs = [inp for node in self.graph.values() for inp in node.inputs]
         self.outputs = [out for out in node_outputs if out not in node_inputs]
-
-    def get_weights_data(self, layer_name, var_name):
-        return self.reader.get_weights_data(layer_name, var_name)
 
     def next_layer(self):
         self.index += 1

--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -1164,7 +1164,7 @@ class GarNet(Layer):
             ]
 
         for op_name, lname, wtype in weights_source:
-            data = self.model.get_weights_data(self.name, f'{self.name}/{lname}_{wtype}:0')
+            data = self.get_attr(f'{lname}_{wtype}_data')
             if wtype == 'kernel':
                 data = data.transpose((1, 0))
                 vtype = 'weights'
@@ -1181,22 +1181,20 @@ class GarNet(Layer):
     def _make_input_transform_weights(self, n_propagate, n_aggregators, n_out_features, quantize=False, sublayer=''):
         # Due to linearity of the input transform, input weights and biases can be contracted away at conversion time
 
-        output_transform_kernel = self.model.get_weights_data(
-            self.name, f'{self.name}/Fout{sublayer}_kernel:0'
+        output_transform_kernel = self.get_attr(
+            f'Fout{sublayer}_kernel_data'
         )  # [(n_aggregators, n_propagate), n_out_features]
         output_transform_kernel = output_transform_kernel.reshape((n_aggregators, n_propagate, n_out_features))
         if quantize:
             output_transform_kernel = self.get_attr('quantizer')(output_transform_kernel)
 
-        input_transform_kernel = self.model.get_weights_data(
-            self.name, f'{self.name}/FLR{sublayer}_kernel:0'
-        )  # [n_in_features, n_propagate]
+        input_transform_kernel = self.get_attr(f'FLR{sublayer}_kernel_data')  # [n_in_features, n_propagate]
         if quantize:
             input_transform_kernel = self.get_attr('quantizer')(input_transform_kernel)
         data = np.dot(input_transform_kernel, output_transform_kernel)  # [n_in_features, n_aggregators, n_out_features]
         kernel = data.transpose((2, 1, 0))
 
-        input_transform_bias = self.model.get_weights_data(self.name, f'{self.name}/FLR{sublayer}_bias:0')  # [n_propagate]
+        input_transform_bias = self.get_attr(f'FLR{sublayer}_bias_data')  # [n_propagate]
         if quantize:
             input_transform_bias = self.get_attr('quantizer')(input_transform_bias)
         data = np.dot(input_transform_bias, output_transform_kernel)  # [n_aggregators, n_out_features]
@@ -1255,7 +1253,7 @@ class GarNetStack(GarNet):
             ]
 
             for op_name, lname, wtype in weights_source:
-                data = self.model.get_weights_data(self.name, f'{self.name}/{lname}_{wtype}:0')
+                data = self.get_attr(f'{lname}_{wtype}_data')
                 if wtype == 'kernel':
                     data = data.transpose((1, 0))
                     vtype = 'weights'

--- a/test/pytest/test_flows.py
+++ b/test/pytest/test_flows.py
@@ -54,7 +54,7 @@ DummyFlowCReqBReqA = hls4ml.model.flow.register_flow('CReqBReqA', ['C'], require
 def dummy_flow_model():
     layers = [{'class_name': 'Input', 'name': 'layer0_input', 'input_shape': [1]}]
     config = {'HLSConfig': {'Model': {'Precision': 'ap_fixed<32,16>', 'ReuseFactor': 1}, 'Flows': []}}
-    model = hls4ml.model.ModelGraph(config, None, layers)
+    model = hls4ml.model.ModelGraph(config, layers)
     return model
 
 


### PR DESCRIPTION
# Description

Currently, adding weights data happens during initialization of layers by using the supplied reader. This is a relic of old design that required splitting this from converter. Upcoming ONNX support and nested model require this step to be done during conversion. This PR removes reader from `ModelGraph` and its subsequent use to read weights data. This is now moved to converters themselves and weights data is available as an attribute.

## Type of change

- [x] (not exactly) New feature (non-breaking change which adds functionality)

## Tests

This just changes the existing functionality so existing tests should verify that it works as expected

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
