### PR TITLE
Decouple pipeline style from strategy

### DIFF
--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -210,9 +210,9 @@ class VivadoBackend(FPGABackend):
         return parse_vivado_report(model.config.get_output_dir())
 
     def _validate_conv_strategy(self, layer):
-        if layer.model.config.model_strategy.lower() != 'resource':
-            print(f'WARNING: Cannot use "Latency" model strategy for {layer.name} layer. Switching to "Resource" strategy.')
-            layer.model.config.model_strategy = 'Resource'
+        if layer.model.config.pipeline_style.lower() != 'dataflow':
+            print(f'WARNING: Layer {layer.name} requires "dataflow" pipeline style. Switching to "dataflow" pipeline style.')
+            layer.model.config.pipeline_style = 'dataflow'
 
     @layer_optimizer(Layer)
     def init_base_layer(self, layer):

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -279,7 +279,7 @@ class HLSConfig:
     def _validate_hls_config(self):
         use_dataflow = False
         if self.pipeline_style.lower() == 'pipeline' and self.model_compression:
-            print('WARNING: Compression enabled while model strategy set to "Latency".')
+            print('WARNING: Compression enabled while pipeline style set to "pipeline".')
             use_dataflow = True
         for layer_type, strategy in self.layer_type_strategy.items():
             if strategy.lower() == 'resource' and self.pipeline_style.lower() == 'pipeline':

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -49,6 +49,8 @@ class HLSConfig:
 
         self.trace_output = self.get_config_value('TraceOutput', False)
 
+        self.pipeline_style = 'pipeline'
+
         self._parse_hls_config()
         self._validate_hls_config()
 
@@ -212,6 +214,7 @@ class HLSConfig:
             self.model_conv_implementation = model_cfg.get('ConvImplementation', 'LineBuffer')
             self.model_strategy = model_cfg.get('Strategy', 'Latency')
             self.model_compression = bool(model_cfg.get('Compression', 0))
+            self.pipeline_style = model_cfg.get('PipelineStyle', 'pipeline')
 
         layer_type_cfg = hls_config.get('LayerType')
         if layer_type_cfg is not None:
@@ -274,45 +277,48 @@ class HLSConfig:
                     self.layer_name_compression[layer_name.lower()] = bool(compression)
 
     def _validate_hls_config(self):
-        use_resource = False
-        if self.model_strategy.lower() == 'latency' and self.model_compression:
+        use_dataflow = False
+        if self.pipeline_style.lower() == 'pipeline' and self.model_compression:
             print('WARNING: Compression enabled while model strategy set to "Latency".')
-            use_resource = True
+            use_dataflow = True
         for layer_type, strategy in self.layer_type_strategy.items():
-            if strategy.lower() == 'resource' and self.model_strategy.lower() == 'latency':
+            if strategy.lower() == 'resource' and self.pipeline_style.lower() == 'pipeline':
                 print(
-                    'WARNING: Strategy for layer type {} set to "Resource", while model strategy set to "Latency".'.format(
+                    'WARNING: Strategy for layer type {} set to "Resource", while pipeline style set to "pipeline".'.format(
                         layer_type
                     )
                 )
-                use_resource = True
+                use_dataflow = True
 
         for layer_name, strategy in self.layer_name_strategy.items():
-            if strategy.lower() == 'resource' and self.model_strategy.lower() == 'latency':
+            if strategy.lower() == 'resource' and self.pipeline_style.lower() == 'pipeline':
                 print(
-                    'WARNING: Strategy for layer {} set to "Resource", while model strategy set to "Latency".'.format(
+                    'WARNING: Strategy for layer {} set to "Resource", while pipeline style set to "pipeline".'.format(
                         layer_name
                     )
                 )
-                use_resource = True
+                use_dataflow = True
 
         for layer_type, compression in self.layer_type_compression.items():
-            if compression and self.model_strategy.lower() == 'latency':
+            if compression and self.pipeline_style.lower() == 'pipeline':
                 print(
-                    'WARNING: Compression enabled for layer type {}, while model strategy set to "Latency".'.format(
+                    'WARNING: Compression enabled for layer type {}, while pipeline style set to "pipeline".'.format(
                         layer_type
                     )
                 )
-                use_resource = True
+                use_dataflow = True
 
         for layer_name, compression in self.layer_name_compression.items():
-            if compression and self.model_strategy.lower() == 'latency':
-                print(f'WARNING: Compression enabled for layer {layer_name}, while model strategy set to "Latency".')
-                use_resource = True
+            if compression and self.pipeline_style.lower() == 'pipeline':
+                print(f'WARNING: Compression enabled for layer {layer_name}, while pipeline style set to "pipeline".')
+                use_dataflow = True
 
-        if use_resource:
-            print('WARNING: Changing model strategy to "Resource"')
-            self.model_strategy = 'Resource'
+        if self.model_strategy.lower() == 'resource':
+            use_dataflow = True
+
+        if use_dataflow:
+            print('WARNING: Changing pipeline style to "dataflow".')
+            self.pipeline_style = 'dataflow'
 
 
 class ModelGraph:

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -171,7 +171,7 @@ class VivadoWriter(Writer):
                     newline += indent + '#pragma HLS INTERFACE ap_vld port={},{} \n'.format(
                         ','.join(all_inputs), ','.join(all_outputs)
                     )
-                    if model.config.model_strategy.lower() == 'resource':
+                    if model.config.pipeline_style.lower() == 'dataflow':
                         newline += indent + '#pragma HLS DATAFLOW \n'
                     else:
                         newline += indent + '#pragma HLS PIPELINE \n'


### PR DESCRIPTION
# Description

We control the top function pipeline style with the strategy, and while this works, sometimes the change to the top pipelining is forced by a layer (the conv layer) and as a consequence this causes all other layers to use `resource` strategy which is unintended. Decoupling the strategy from the pipeline style fixes this. The explicitly set resource strategy still forces the `dataflow` style to be used. The configuration can be explicitly set with `PipelineStyle` (values can be `pipeline` and `dataflow`), but normally the users would still continue using the `Strategy` config parameter. Fixes #699 and #759.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Tests

I didn't add any extra tests. The best way to test this is to verify the generated HLS has the correct pragmas and `parameters.h`. I manually tested a whole lot of combinations of this. Checking the IR in python may also be possible, but I'm not sure if this will capture all combinations.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
