### PR TITLE
Explicitly set strategy for pointwise conv

### DIFF
--- a/hls4ml/backends/vivado/passes/pointwise.py
+++ b/hls4ml/backends/vivado/passes/pointwise.py
@@ -82,6 +82,11 @@ class OptimizePointwiseConv(OptimizerPass):
             expand_axis = tuple(range(int(dim[0])))
             pw_node.weights['weight'].data = np.expand_dims(node.weights['weight'].data, axis=expand_axis)
         pw_node.weights['bias'].data = node.weights['bias'].data
+        # Set strategy to ensure lowercase string is passed to the template
+        if model.config.is_resource_strategy(pw_node):
+            pw_node.set_attr('strategy', 'resource')
+        else:
+            pw_node.set_attr('strategy', 'latency')
         model.replace_node(node, pw_node)
 
         return True


### PR DESCRIPTION
# Description

When optimizing 1x1 convolution a new node will be inserted with the same name and the user config will be used. This means the new `PointwiseConv1D/2D` node will pick up whatever string the user set in the config and unless that matches lowercase `latency` or `resource` the compilation will fail. This was observed in #782.

The solution is not elegant, but it was the least intrusive. It should be fine until we rework the config itself.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

The `test_pointwiseconv.py` was extended to incude a test for this scenario.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
