### PR TITLE
Update Jenkins test environment to avoid dependency hell

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     docker {
-      image 'vivado-el7:2'
+      image 'vivado-el7:3'
       args  '-v /data/Xilinx:/data/Xilinx'
     }
   }
@@ -14,9 +14,8 @@ pipeline {
       steps {
         dir(path: 'test') {
           sh '''#!/bin/bash --login
-              conda activate hls4ml-py37
+              conda activate hls4ml-py38
               pip install tensorflow pyparsing
-              pip install onnx==1.12
               pip install -U ../ --user
               ./convert-keras-models.sh -x -f keras-models.txt
               pip uninstall hls4ml -y'''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
           sh '''#!/bin/bash --login
               conda activate hls4ml-py37
               pip install tensorflow pyparsing
+              pip install onnx==1.12
               pip install -U ../ --user
               ./convert-keras-models.sh -x -f keras-models.txt
               pip uninstall hls4ml -y'''


### PR DESCRIPTION
# Description

Jenkins tests are based on python 3.7 environment, in which we can install TF 2.11 as the latest version. When hls4ml is installed on top, `onnx` dependency causes the update of `protobuf` package (to 4.21) causing the environment to break and hls4ml (and tensorflow and qkeras) are unusable. We should consider updating the Python requirement to 3.8 for the next version of hls4ml to avoid this, but as an immediate band-aid solution to ensure tests run, ~~we can install `onnx==1.12` prior to hls4ml, that won't cause the update of `protobuf` and the environment works.~~ we can update just the Jenkins environment to Python 3.8.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Jenkins tests should run now, they fail on every branch currently.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
