### PR TITLE
Propagate zeros from Conv layers to multiplication config

### DIFF
--- a/hls4ml/backends/vivado/passes/convolution_templates.py
+++ b/hls4ml/backends/vivado/passes/convolution_templates.py
@@ -9,7 +9,7 @@ conv_mult_config_template = """struct config{index}_mult : nnet::dense_config {{
     static const unsigned n_out = {n_out};
     static const unsigned reuse_factor = {reuse};
     static const unsigned strategy = nnet::{strategy};
-    static const unsigned n_zeros = 0;
+    static const unsigned n_zeros = {nzeros};
     static const unsigned multiplier_limit = DIV_ROUNDUP(n_in * n_out, reuse_factor) - n_zeros / reuse_factor;
     typedef {accum_t.name} accum_t;
     typedef {bias_t.name} bias_t;
@@ -83,6 +83,7 @@ class Conv1DConfigTemplate(LayerConfigTemplate):
         mult_params = self._default_config_params(node)
         mult_params['n_in'] = node.get_attr('n_chan') * node.get_attr('filt_width')
         mult_params['n_out'] = node.get_attr('n_filt')
+        mult_params['nzeros'] = node.get_weights('weight').nzeros
         mult_params['product_type'] = get_backend('vivado').product_type(
             node.get_input_variable().type.precision, node.get_weights('weight').type.precision
         )
@@ -189,6 +190,7 @@ class Conv2DConfigTemplate(LayerConfigTemplate):
         mult_params = self._default_config_params(node)
         mult_params['n_in'] = node.get_attr('n_chan') * node.get_attr('filt_height') * node.get_attr('filt_width')
         mult_params['n_out'] = node.get_attr('n_filt')
+        mult_params['nzeros'] = node.get_weights('weight').nzeros
         mult_params['product_type'] = get_backend('vivado').product_type(
             node.get_input_variable().type.precision, node.get_weights('weight').type.precision
         )
@@ -274,6 +276,7 @@ class SeparableConv1DConfigTemplate(LayerConfigTemplate):
         mult_params['index'] = str(node.index) + '_depthwise'
         mult_params['n_in'] = node.get_attr('n_chan') * node.get_attr('filt_width')
         mult_params['n_out'] = node.get_attr('n_chan')
+        mult_params['nzeros'] = node.get_weights('depthwise').nzeros
         mult_params['weight_t'] = node.get_weights('depthwise').type
         mult_params['product_type'] = get_backend('vivado').product_type(
             node.get_input_variable().type.precision, node.get_weights('depthwise').type.precision
@@ -313,6 +316,7 @@ class SeparableConv1DConfigTemplate(LayerConfigTemplate):
         mult_params['index'] = str(node.index) + '_pointwise'
         mult_params['n_in'] = node.get_attr('n_chan')
         mult_params['n_out'] = node.get_attr('n_filt')
+        mult_params['nzeros'] = node.get_weights('pointwise').nzeros
         mult_params['weight_t'] = node.get_weights('pointwise').type
         mult_params['product_type'] = get_backend('vivado').product_type(
             node.get_input_variable().type.precision, node.get_weights('pointwise').type.precision
@@ -395,6 +399,7 @@ class SeparableConv2DConfigTemplate(LayerConfigTemplate):
         mult_params['index'] = str(node.index) + '_depthwise'
         mult_params['n_in'] = node.get_attr('n_chan') * node.get_attr('filt_height') * node.get_attr('filt_width')
         mult_params['n_out'] = node.get_attr('n_chan')
+        mult_params['nzeros'] = node.get_weights('depthwise').nzeros
         mult_params['weight_t'] = node.get_weights('depthwise').type
         mult_params['product_type'] = get_backend('vivado').product_type(
             node.get_input_variable().type.precision, node.get_weights('depthwise').type.precision
@@ -438,6 +443,7 @@ class SeparableConv2DConfigTemplate(LayerConfigTemplate):
         mult_params['index'] = str(node.index) + '_pointwise'
         mult_params['n_in'] = node.get_attr('n_chan')
         mult_params['n_out'] = node.get_attr('n_filt')
+        mult_params['nzeros'] = node.get_weights('pointwise').nzeros
         mult_params['weight_t'] = node.get_weights('pointwise').type
         mult_params['product_type'] = get_backend('vivado').product_type(
             node.get_input_variable().type.precision, node.get_weights('pointwise').type.precision


### PR DESCRIPTION
## Description

> :memo: Convolutional layers use Dense matrix multiplication at its core, but do not fully utilise the benefit of `n_zeros` in the Latency strategy of Dense layers. 
>
> * When there are zeros, HLS can optimise the number of DSPs in Latency strategy, by using the resource pragma. 
> * This is currently done for Dense layers and works quite well, even for RF != 1 (Tested as part of #768 )
> * However, `n_zeros` is always set to zero for Conv2D layers.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Tests
>
>
> * No new tests, the current PyTests should verify no changes in Conv implementations
> * I can add some results from my synthesis of #768 to verify changes are correct. 

## Checklist
- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
