### PR TITLE
Fix parsing of QConv2DBatchnorm weights

### DIFF
--- a/hls4ml/converters/keras/convolution.py
+++ b/hls4ml/converters/keras/convolution.py
@@ -44,7 +44,7 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader):
 
     (layer['in_height'], layer['in_width'], layer['n_chan']) = parse_data_format(input_shapes[0], layer['data_format'])
 
-    if layer['class_name'] in ['Conv2D', 'QConv2D']:
+    if layer['class_name'] in ['Conv2D', 'QConv2D', 'QConv2DBatchnorm']:
         layer['weight_data'] = get_weights_data(data_reader, layer['name'], 'kernel')
     elif layer['class_name'] in ['SeparableConv2D', 'QSeparableConv2D']:
         layer['depthwise_data'], layer['pointwise_data'] = get_weights_data(


### PR DESCRIPTION
# Description

With the recent reorganization of code in the Keras converter, we missed parsing the `QConv2DBatchnorm`'s weights. The fix is a one liner.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

There's a test added to `test_qkeras.py`

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
