### PR TITLE
Fix over-allocation of bits for quantised po2

### DIFF
--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_mult.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_mult.h
@@ -73,17 +73,13 @@ template <class x_T, class w_T> class mult : public Product {
 
 template <class x_T, class w_T> class weight_exponential : public Product {
   public:
-    // Construct the return type from the multiplication equivalent to the largest shifts
-    // ac_int<pow2(decltype(w_T::weight)::width-1)-1, true> is the type if the multiplicand equivalent to the largest lshift
-    // << ac_fixed<pow2(decltype(w_T::weight)::width-1)-1,0, true> is the type of the multiplicand equivalent to the largest
-    // rshift >>
-    using r_T = decltype(x_T(0) * (ac_int<pow2(decltype(w_T::weight)::width - 1) - 1, true>(1) +
-                                   ac_fixed<pow2(decltype(w_T::weight)::width - 1) - 1, 0, true>(1)));
+    using r_T = ac_fixed<2 * (decltype(w_T::weight)::width + x_T::width), (decltype(w_T::weight)::width + x_T::width), true>;
     inline static r_T product(x_T a, w_T w) {
         // Shift product for exponential weights
-        // shift by the exponent. Negative weights shift right
+        // Shift by the exponent. Negative weights shift right
         r_T y = static_cast<r_T>(a) << w.weight;
-        // negate or not depending on weight sign
+
+        // Negate or not depending on weight sign
         return w.sign == 1 ? y : static_cast<r_T>(-y);
     }
 };

--- a/hls4ml/templates/vivado/nnet_utils/nnet_mult.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_mult.h
@@ -76,17 +76,15 @@ template <class x_T, class w_T> class mult : public Product {
 
 template <class x_T, class w_T> class weight_exponential : public Product {
   public:
-    // Construct the return type from the multiplication equivalent to the largest shifts
-    // ap_int<pow2(decltype(w_T::weight)::width-1)-1> is the type if the multiplicand equivalent to the largest lshift <<
-    // ap_fixed<pow2(decltype(w_T::weight)::width-1)-1,0> is the type of the multiplicand equivalent to the largest rshift >>
-    using r_T = decltype(x_T(0) * (ap_int<pow2(decltype(w_T::weight)::width - 1) - 1>(1) +
-                                   ap_fixed<pow2(decltype(w_T::weight)::width - 1) - 1, 0>(1)));
+    using r_T = ap_fixed<2 * (decltype(w_T::weight)::width + x_T::width), (decltype(w_T::weight)::width + x_T::width)>;
     static r_T product(x_T a, w_T w) {
         // Shift product for exponential weights
         #pragma HLS INLINE
-        // shift by the exponent. Negative weights shift right
+
+        // Shift by the exponent. Negative weights shift right
         r_T y = static_cast<r_T>(a) << w.weight;
-        // negate or not depending on weight sign
+
+        // Negate or not depending on weight sign
         return w.sign == 1 ? y : static_cast<r_T>(-y);
     }
 };


### PR DESCRIPTION
# Description

> * When using power-of-2 multiplications, the current implementation assigns too many bits
> * In Vivado, there is a limit of 65,536 bits, which will be allocated when the weights are quantised in QKeras with 17 or more bits and a power of 2
>* The multiplication can be computed in far less bits - it only requires the width of the input and weights combined, not the power of that.
>* This problem is very sneaky - it is very rare to train with QKeras with a bit-width of more than 16 - however, the `alpha` parameter in QKeras can often be more than 16 bits (when it is not specified by the user to be 1 - attached is a quantised jet classification model that initially found this bug - [model](https://cernbox.cern.ch/s/oZl0lx1vyxwMSY9)) 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Tests
> * Extend test_qkeras.py to test power of 2 multiplication with a high number and ensure the outputs match.

## Checklist
- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.

