### PR TITLE
Fix loading weights in n-dim dense -> 1x1 conv

### DIFF
--- a/hls4ml/model/optimizer/passes/multi_dense.py
+++ b/hls4ml/model/optimizer/passes/multi_dense.py
@@ -23,6 +23,8 @@ class ReplaceMultidimensionalDenseWithConv(OptimizerPass):
             'padding': 'valid',
             'n_chan': input_shape[-1],
             'n_filt': node.get_attr('n_out'),
+            'weight_data': node.get_attr('weight_data'),
+            'bias_data': node.get_attr('bias_data'),
         }
 
         if dim == 1:

--- a/hls4ml/templates/vivado/nnet_utils/nnet_sepconv_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_sepconv_stream.h
@@ -145,7 +145,7 @@ void pointwise_mult_buffer(const data_T &data_pack, hls::stream<res_T> &res_stre
     #pragma HLS ARRAY_PARTITION variable=res complete
 
     res_T res_pack;
-    PRAGMA_DATA_PACK(out_data)
+    PRAGMA_DATA_PACK(res_pack)
 
 InitData:
     for (int id = 0; id < CONFIG_T::n_chan; id++) {
@@ -192,7 +192,7 @@ void compute_depthwise_output_buffer_1d(const data_T &in_elem, hls::stream<res_T
     #pragma HLS ARRAY_PARTITION variable=res_out complete dim = 0
 
     res_T res_pack;
-    PRAGMA_DATA_PACK(out_data)
+    PRAGMA_DATA_PACK(res_pack)
 
     // Add pixel to buffer
     nnet::kernel_shift_1d<data_T, CONFIG_T>(in_elem, kernel_data);
@@ -257,7 +257,7 @@ void compute_depthwise_output_buffer_2d(const data_T &in_elem,
     #pragma HLS ARRAY_PARTITION variable=res_out complete dim = 0
 
     res_T res_pack;
-    PRAGMA_DATA_PACK(out_data)
+    PRAGMA_DATA_PACK(res_pack)
 
     // Add pixel to buffer
     nnet::shift_line_buffer<data_T, CONFIG_T>(in_elem, line_buffer, kernel_data);

--- a/test/pytest/test_multi_dense.py
+++ b/test/pytest/test_multi_dense.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from tensorflow.keras.layers import Dense
+
+import hls4ml
+
+test_root_path = Path(__file__).parent
+
+
+@pytest.mark.parametrize(
+    'backend, io_type',
+    [
+        ('Quartus', 'io_parallel'),
+        ('Vivado', 'io_parallel'),
+        ('Vitis', 'io_parallel'),
+        ('Vivado', 'io_stream'),
+        ('Vivado', 'io_stream'),
+        ('Vitis', 'io_stream'),
+    ],
+)
+def test_multi_dense(backend, io_type):
+    model = tf.keras.models.Sequential()
+    model.add(
+        Dense(
+            4,
+            input_shape=(
+                8,
+                8,
+            ),
+            name='Dense',
+            use_bias=True,
+            kernel_initializer=tf.keras.initializers.RandomUniform(minval=1, maxval=10),
+            bias_initializer='zeros',
+            kernel_regularizer=None,
+            bias_regularizer=None,
+            activity_regularizer=None,
+            kernel_constraint=None,
+            bias_constraint=None,
+            activation='relu',
+        )
+    )
+    model.compile(optimizer='adam', loss='mse')
+
+    X_input = np.random.rand(100, 8, 8)
+
+    keras_prediction = model.predict(X_input)
+
+    default_precision = 'ap_fixed<32, 16>' if backend in ['Vivado', 'Vitis'] else 'ac_fixed<32, 16, true>'
+    config = hls4ml.utils.config_from_keras_model(model, default_precision=default_precision)
+    output_dir = str(test_root_path / f'hls4mlprj_multi_dense_{backend}_{io_type}')
+
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
+    )
+
+    hls_model.compile()
+
+    hls_prediction = hls_model.predict(X_input).reshape(keras_prediction.shape)
+
+    np.testing.assert_allclose(hls_prediction, keras_prediction, rtol=1e-2, atol=0.01)
+
+    assert list(hls_model.get_layers())[1].class_name == 'PointwiseConv1D'


### PR DESCRIPTION
# Description

In a change from using the readder to storing weights as attributes we missed the case of creating PointwiseConv nodes from n-dimensional Dense layer. This fixes it and adds a test for the future.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Added a test in `test_multi_dense.py`

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
