### PR TITLE
Improve parsing of non-nn.Sequential PyTorch models

### DIFF
--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -30,15 +30,12 @@ class PyTorchModelReader:
             'moving_variance': 'running_var',
         }
 
-        # Workaround for naming schme in nn.Sequential,
+        # Workaround for naming scheme in nn.Sequential,
         # have to remove the prefix we previously had to add to make sure the tensors are found
         if 'layer_' in layer_name:
             layer_name = layer_name.split('layer_')[-1]
 
-        if var_name not in list(torch_paramap.keys()) + ['weight', 'bias']:
-            raise Exception('Pytorch parameter not yet supported!')
-
-        elif var_name in list(torch_paramap.keys()):
+        if var_name in list(torch_paramap.keys()):
             var_name = torch_paramap[var_name]
 
         # if a layer is reused in the model, torch.FX will append a "_n" for the n-th use
@@ -46,10 +43,11 @@ class PyTorchModelReader:
         if layer_name.split('_')[-1].isdigit() and len(layer_name.split('_')) > 1:
             layer_name = '_'.join(layer_name.split('_')[:-1])
 
-        if layer_name + '.' + var_name in self.state_dict:
-            data = self.state_dict[layer_name + '.' + var_name].numpy()
-            return data
+        key = layer_name + '.' + var_name
 
+        if key in self.state_dict:
+            data = self.state_dict[key].numpy()
+            return data
         else:
             return None
 


### PR DESCRIPTION
# Description

In case of skipped layers, like Flatten or Dropout, PyTorch converter will incorrectly parse the model inputs, we need to create an input map similar to how Keras handles it. This was the case in #839. Additionally, as observed in #838, parsing of BN weights was broken. These fixes are cherrypicked from my development branch for parsing GNNs, not fully tested standalone, so I'm making this a draft PR for now before I add proper tests.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Currently lacking. Will add something along the lines of code shared in #838 and #839

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works. <-- Will do in a follow-up commit
