### PR TITLE
No longer make ExponentPrecisionType and XnorPrecisionType inherit from IntegerPrecisionType

### DIFF
--- a/hls4ml/model/types.py
+++ b/hls4ml/model/types.py
@@ -221,6 +221,10 @@ class PrecisionType:
         self.width = width
         self.signed = signed
 
+    def __eq__(self, other):
+        eq = self.width == other.width
+        eq = eq and self.signed == other.signed
+
 
 class IntegerPrecisionType(PrecisionType):
     """Arbitrary precision integer  data type.
@@ -311,7 +315,7 @@ class FixedPrecisionType(PrecisionType):
         return eq
 
 
-class XnorPrecisionType(IntegerPrecisionType):
+class XnorPrecisionType(PrecisionType):
     """
     Convenience class to differentiate 'regular' integers from BNN Xnor ones
     """
@@ -319,8 +323,12 @@ class XnorPrecisionType(IntegerPrecisionType):
     def __init__(self):
         super().__init__(width=1, signed=False)
 
+    def __str__(self):
+        typestring = 'xnor'
+        return typestring
 
-class ExponentPrecisionType(IntegerPrecisionType):
+
+class ExponentPrecisionType(PrecisionType):
     """
     Convenience class to differentiate 'regular' integers from those which represent exponents,
     for QKeras po2 quantizers, for example.
@@ -328,6 +336,10 @@ class ExponentPrecisionType(IntegerPrecisionType):
 
     def __init__(self, width=16, signed=True):
         super().__init__(width=width, signed=signed)
+
+    def __str__(self):
+        typestring = '{signed}exp<{width}>'.format(signed='u' if not self.signed else '', width=self.width)
+        return typestring
 
 
 def find_minimum_width(data, signed=True):

--- a/hls4ml/model/types.py
+++ b/hls4ml/model/types.py
@@ -45,7 +45,7 @@ class BinaryQuantizer(Quantizer):
 
     def __init__(self, bits=2):
         if bits == 1:
-            hls_type = IntegerPrecisionType(width=1, signed=False)
+            hls_type = XnorPrecisionType()
         elif bits == 2:
             hls_type = IntegerPrecisionType(width=2)
         else:
@@ -321,6 +321,7 @@ class XnorPrecisionType(PrecisionType):
 
     def __init__(self):
         super().__init__(width=1, signed=False)
+        self.integer = 1
 
     def __str__(self):
         typestring = 'uint<1>'


### PR DESCRIPTION
# Description

When trying to propagate precisions, `isinstance(var, (IntegerPrecisionType, FixedPrecisionType))` produces incorrect results if the variable is `ExponentPrecisionType` or `XnorPrecisionType`. The "is a" requirement for inheritance is violated. Therefore it's better to remove the inheritance, which this PR does. It also cleans up a bit of the remaining string parsing there was and switches from the old `%` string formatting to f-strings or `.format()`. 

## Type of change

It is not really a "bug" but the previous inheritance structure caused issues with yet to be added precision propagation.

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

This should not break anything. The qkeras tests in particular are the main tests for this.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
