### PR TITLE
Remove obsolete parameter mapping between pytorch and keras

### DIFF
--- a/hls4ml/converters/pytorch/core.py
+++ b/hls4ml/converters/pytorch/core.py
@@ -111,7 +111,6 @@ def parse_batchnorm_layer(operation, layer_name, input_names, input_shapes, node
         layer['mean_data'], layer['variance_data'] = get_weights_data(
             data_reader, layer['name'], ['running_mean', 'running_var']
         )
-    print(layer['epsilon'])
     in_size = 1
     for dim in input_shapes[0][1:]:
         in_size *= dim

--- a/hls4ml/converters/pytorch/core.py
+++ b/hls4ml/converters/pytorch/core.py
@@ -109,9 +109,9 @@ def parse_batchnorm_layer(operation, layer_name, input_names, input_shapes, node
             layer['beta_data'] = 0
 
         layer['mean_data'], layer['variance_data'] = get_weights_data(
-            data_reader, layer['name'], ['running_mean', 'running_variance']
+            data_reader, layer['name'], ['running_mean', 'running_var']
         )
-
+    print(layer['epsilon'])
     in_size = 1
     for dim in input_shapes[0][1:]:
         in_size *= dim

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -26,8 +26,10 @@ class PyTorchModelReader:
         # have to snap that off to find the tensors
         if layer_name.split('_')[-1].isdigit() and len(layer_name.split('_')) > 1:
             layer_name = '_'.join(layer_name.split('_')[:-1])
-
+        print(layer_name, var_name)
+        print(self.state_dict)
         if layer_name + '.' + var_name in self.state_dict:
+            print("found")
             data = self.state_dict[layer_name + '.' + var_name].numpy()
             return data
 

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -17,29 +17,10 @@ class PyTorchModelReader:
     def get_weights_data(self, layer_name, var_name):
         data = None
 
-        # Parameter mapping from pytorch to keras
-        torch_paramap = {
-            # Conv
-            'kernel': 'weight',
-            # Batchnorm
-            'gamma': 'weight',
-            # Activiation
-            'alpha': 'weight',
-            'beta': 'bias',
-            'moving_mean': 'running_mean',
-            'moving_variance': 'running_var',
-        }
-
         # Workaround for naming schme in nn.Sequential,
         # have to remove the prefix we previously had to add to make sure the tensors are found
         if 'layer_' in layer_name:
             layer_name = layer_name.split('layer_')[-1]
-
-        if var_name not in list(torch_paramap.keys()) + ['weight', 'bias']:
-            raise Exception('Pytorch parameter not yet supported!')
-
-        elif var_name in list(torch_paramap.keys()):
-            var_name = torch_paramap[var_name]
 
         # if a layer is reused in the model, torch.FX will append a "_n" for the n-th use
         # have to snap that off to find the tensors

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -26,10 +26,8 @@ class PyTorchModelReader:
         # have to snap that off to find the tensors
         if layer_name.split('_')[-1].isdigit() and len(layer_name.split('_')) > 1:
             layer_name = '_'.join(layer_name.split('_')[:-1])
-        print(layer_name, var_name)
-        print(self.state_dict)
+
         if layer_name + '.' + var_name in self.state_dict:
-            print("found")
             data = self.state_dict[layer_name + '.' + var_name].numpy()
             return data
 

--- a/test/pytest/test_batchnorm_pytorch.py
+++ b/test/pytest/test_batchnorm_pytorch.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+import hls4ml
+
+test_root_path = Path(__file__).parent
+
+in_shape = 16
+atol = 5e-3
+
+
+@pytest.fixture(scope='module')
+def data():
+    np.random.seed(0)
+    X = np.random.rand(100, in_shape)
+    return X
+
+
+@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus'])
+def test_batchnorm(data, backend, io_type):
+    model = nn.Sequential(
+        nn.BatchNorm1d(in_shape),
+    ).to()
+    model.eval()
+
+    default_precision = 'ac_fixed<32, 1, true>' if backend == 'Quartus' else 'ac_fixed<32, 1>'
+
+    config = hls4ml.utils.config_from_pytorch_model(model, default_precision=default_precision, granularity='name')
+    output_dir = str(test_root_path / f'hls4mlprj_batchnorm_{backend}_{io_type}')
+    hls_model = hls4ml.converters.convert_from_pytorch_model(
+        model, (None, in_shape), backend=backend, hls_config=config, io_type=io_type, output_dir=output_dir
+    )
+    hls_model.compile()
+
+    # Predict
+    pytorch_prediction = model(torch.Tensor(data)).detach().numpy()
+    hls_prediction = hls_model.predict(data)
+    np.testing.assert_allclose(pytorch_prediction, hls_prediction, rtol=0, atol=atol, verbose=True)


### PR DESCRIPTION
The pytorch parser still uses a mapping between tensor names from keras to pytorch which has become obsolete. In its current form, it breaks BatchNorm layers. This PR simply removes this functionality, restoring BatchNorm functionality and removing clutter. A test for BatchNorm in pytorch is added to prevent further breaking of this functionality

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Ran pytests to verify that nothing gets broken, verified that BatchNorm layers parse successfully after the fix. 

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
