### PR TITLE
Bug fix for named nn.Sequential in pytorch parser

### DIFF
--- a/hls4ml/converters/pytorch/convolution.py
+++ b/hls4ml/converters/pytorch/convolution.py
@@ -1,4 +1,4 @@
-from hls4ml.converters.pytorch_to_hls import get_weights_data, pytorch_handler
+from hls4ml.converters.pytorch_to_hls import pytorch_handler
 from hls4ml.converters.utils import compute_padding_1d_pytorch, compute_padding_2d_pytorch, parse_data_format
 
 
@@ -12,8 +12,12 @@ def parse_conv1d_layer(operation, layer_name, input_names, input_shapes, node, c
     layer['class_name'] = 'Conv1D'
     layer['data_format'] = 'channels_first'  # Pytorch default (can't change)
 
-    layer['weight_data'] = get_weights_data(data_reader, layer['name'], 'weight')
-    layer['bias_data'] = get_weights_data(data_reader, layer['name'], 'bias')
+    layer['weight_data'] = class_object.weight.data.numpy()
+    if class_object.bias is not None:
+        layer['bias_data'] = class_object.bias.data.numpy()
+    else:
+        layer['bias_data'] = None
+
     # Input info
     (layer['in_width'], layer['n_chan']) = parse_data_format(
         input_shapes[0], 'channels_first'
@@ -57,8 +61,12 @@ def parse_conv2d_layer(operation, layer_name, input_names, input_shapes, node, c
     layer['class_name'] = 'Conv2D'
     layer['data_format'] = 'channels_first'  # Pytorch default (can't change)
 
-    layer['weight_data'] = get_weights_data(data_reader, layer['name'], 'weight')
-    layer['bias_data'] = get_weights_data(data_reader, layer['name'], 'bias')
+    layer['weight_data'] = class_object.weight.data.numpy()
+    if class_object.bias is not None:
+        layer['bias_data'] = class_object.bias.data.numpy()
+    else:
+        layer['bias_data'] = None
+
     # Input info
     (layer['in_height'], layer['in_width'], layer['n_chan']) = parse_data_format(
         input_shapes[0], 'channels_first'

--- a/hls4ml/converters/pytorch/convolution.py
+++ b/hls4ml/converters/pytorch/convolution.py
@@ -9,6 +9,7 @@ def parse_conv1d_layer(operation, layer_name, input_names, input_shapes, node, c
     layer = {}
 
     layer['name'] = layer_name
+    layer['inputs'] = input_names
     layer['class_name'] = 'Conv1D'
     layer['data_format'] = 'channels_first'  # Pytorch default (can't change)
 
@@ -58,6 +59,7 @@ def parse_conv2d_layer(operation, layer_name, input_names, input_shapes, node, c
     layer = {}
 
     layer['name'] = layer_name
+    layer['inputs'] = input_names
     layer['class_name'] = 'Conv2D'
     layer['data_format'] = 'channels_first'  # Pytorch default (can't change)
 

--- a/hls4ml/converters/pytorch/core.py
+++ b/hls4ml/converters/pytorch/core.py
@@ -9,6 +9,7 @@ def parse_linear_layer(operation, layer_name, input_names, input_shapes, node, c
 
     layer['class_name'] = 'Dense'
     layer['name'] = layer_name
+    layer['inputs'] = input_names
 
     layer['weight_data'] = class_object.weight.data.numpy()
     if class_object.bias is not None:
@@ -44,6 +45,7 @@ def parse_activation_layer(operation, layer_name, input_names, input_shapes, nod
     layer['class_name'] = operation
     layer['activation'] = layer['class_name']
     layer['name'] = layer_name
+    layer['inputs'] = input_names
 
     # if layer['class_name'] != 'Activation':
     #    layer['activation'] = layer['class_name']
@@ -97,6 +99,7 @@ def parse_batchnorm_layer(operation, layer_name, input_names, input_shapes, node
     layer['class_name'] = 'BatchNormalization'
     layer['data_format'] = 'channels_first'
     layer['name'] = layer_name
+    layer['inputs'] = input_names
 
     # batchnorm para
     if node.op == 'call_module':

--- a/hls4ml/converters/pytorch/core.py
+++ b/hls4ml/converters/pytorch/core.py
@@ -1,4 +1,4 @@
-from hls4ml.converters.pytorch_to_hls import get_weights_data, pytorch_handler
+from hls4ml.converters.pytorch_to_hls import pytorch_handler
 
 
 @pytorch_handler('Linear')
@@ -10,7 +10,12 @@ def parse_linear_layer(operation, layer_name, input_names, input_shapes, node, c
     layer['class_name'] = 'Dense'
     layer['name'] = layer_name
 
-    layer['weight_data'], layer['bias_data'] = get_weights_data(data_reader, layer['name'], ['weight', 'bias'])
+    layer['weight_data'] = class_object.weight.data.numpy()
+    if class_object.bias is not None:
+        layer['bias_data'] = class_object.bias.data.numpy()
+    else:
+        layer['bias_data'] = None
+
     if class_object is not None:
         layer['n_in'] = class_object.in_features
         layer['n_out'] = class_object.out_features
@@ -50,7 +55,7 @@ def parse_activation_layer(operation, layer_name, input_names, input_shapes, nod
         if layer['class_name'] == 'ELU':
             layer['activ_param'] = class_object.alpha
         if layer['class_name'] == 'PReLU':
-            layer['alpha_data'] = get_weights_data(data_reader, layer['name'], 'weight')
+            layer['alpha_data'] = class_object.weight.data.numpy()
         if layer['class_name'] == 'Threshold':
             layer['activ_param'] = class_object.threshold
             layer['class_name'] = 'ThresholdedReLU'
@@ -99,18 +104,18 @@ def parse_batchnorm_layer(operation, layer_name, input_names, input_shapes, node
         layer['use_gamma'] = layer['use_beta'] = class_object.affine
 
         if layer['use_gamma']:
-            layer['gamma_data'] = get_weights_data(data_reader, layer['name'], 'weight')
+            layer['gamma_data'] = class_object.weight.data.numpy()
         else:
             layer['gamma_data'] = 1
 
         if layer['use_beta']:
-            layer['beta_data'] = get_weights_data(data_reader, layer['name'], 'bias')
+            layer['beta_data'] = class_object.bias.data.numpy()
         else:
             layer['beta_data'] = 0
 
-        layer['mean_data'], layer['variance_data'] = get_weights_data(
-            data_reader, layer['name'], ['running_mean', 'running_var']
-        )
+        layer['mean_data'] = class_object.running_mean.data.numpy()
+        layer['variance_data'] = class_object.running_var.data.numpy()
+
     in_size = 1
     for dim in input_shapes[0][1:]:
         in_size *= dim

--- a/hls4ml/converters/pytorch/pooling.py
+++ b/hls4ml/converters/pytorch/pooling.py
@@ -20,6 +20,7 @@ def parse_pooling_layer(operation, layer_name, input_names, input_shapes, node, 
         layer['class_name'] = 'AveragePooling2D'
 
     layer['name'] = layer_name
+    layer['inputs'] = input_names
     layer['data_format'] = 'channels_first'  # Pytorch default (can't change)
     if node.op == 'call_module' and 'Avg' in operation:
         if class_object.count_include_pad:

--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -27,3 +27,55 @@ def parse_reshape_layer(operation, layer_name, input_names, input_shapes, node, 
     output_shape = input_shapes[0][:1] + layer['target_shape']
 
     return layer, output_shape
+
+@pytorch_handler('squeeze')
+def parse_squeeze_layer(operation, layer_name, input_names, input_shapes, node, class_object, data_reader, config):
+    assert operation == 'squeeze'
+
+    layer = {}
+    layer['class_name'] = 'Reshape'
+    layer['name'] = layer_name
+
+    if len(node.args) > 1 or len(node.kwargs) > 0: # 'dim' argument is specified
+        output_shape = [i for i in input_shapes[0]]
+        squeeze_dim = node.kwargs.get('dim', None)
+        if squeeze_dim is None:
+            squeeze_dim = node.args[1]
+        if isinstance(squeeze_dim, tuple):
+            for dim in squeeze_dim:
+                del output_shape[dim]
+        else:
+            del output_shape[squeeze_dim]
+    else:
+        output_shape = [i for i in input_shapes[0] if i != 1]
+
+    layer['target_shape'] = output_shape.copy()
+    if layer['target_shape'][0] is None:
+        del layer['target_shape'][0]
+
+    return layer, output_shape
+
+
+@pytorch_handler('unsqueeze')
+def parse_unsqueeze_layer(operation, layer_name, input_names, input_shapes, node, class_object, data_reader, config):
+    assert operation == 'unsqueeze'
+
+    layer = {}
+    layer['class_name'] = 'Reshape'
+    layer['name'] = layer_name
+
+    # Unlike in 'squeeze' in 'unsqueeze', dim argument must exist
+    output_shape = [i for i in input_shapes[0]]
+    if len(node.args) > 1:  # Specified as unsqueeze(x, n)
+        squeeze_dim = node.args[1]
+    else: # Specified as unsqueeze(x, dim=n)
+        squeeze_dim = node.kwargs['dim']
+    # insert() will add an element before the index, unsqueeze expects the location
+    index = output_shape.index(output_shape[squeeze_dim])# + 1
+    output_shape.insert(index, 1)
+
+    layer['target_shape'] = output_shape.copy()
+    if layer['target_shape'][0] is None:
+        del layer['target_shape'][0]
+
+    return layer, output_shape

--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -12,6 +12,7 @@ def parse_reshape_layer(operation, layer_name, input_names, input_shapes, node, 
     layer = {}
     layer['class_name'] = 'Reshape'
     layer['name'] = layer_name
+    layer['inputs'] = input_names
 
     layer['target_shape'] = [int(i) for i in node.args[1:]]
     # View can have -1 as one as the dimensions,
@@ -64,6 +65,7 @@ def parse_unsqueeze_layer(operation, layer_name, input_names, input_shapes, node
     layer = {}
     layer['class_name'] = 'Reshape'
     layer['name'] = layer_name
+    layer['inputs'] = input_names
 
     # Unlike in 'squeeze' in 'unsqueeze', dim argument must exist
     output_shape = [i for i in input_shapes[0]]

--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -28,6 +28,7 @@ def parse_reshape_layer(operation, layer_name, input_names, input_shapes, node, 
 
     return layer, output_shape
 
+
 @pytorch_handler('squeeze')
 def parse_squeeze_layer(operation, layer_name, input_names, input_shapes, node, class_object, data_reader, config):
     assert operation == 'squeeze'
@@ -36,7 +37,7 @@ def parse_squeeze_layer(operation, layer_name, input_names, input_shapes, node, 
     layer['class_name'] = 'Reshape'
     layer['name'] = layer_name
 
-    if len(node.args) > 1 or len(node.kwargs) > 0: # 'dim' argument is specified
+    if len(node.args) > 1 or len(node.kwargs) > 0:  # 'dim' argument is specified
         output_shape = [i for i in input_shapes[0]]
         squeeze_dim = node.kwargs.get('dim', None)
         if squeeze_dim is None:
@@ -59,20 +60,27 @@ def parse_squeeze_layer(operation, layer_name, input_names, input_shapes, node, 
 @pytorch_handler('unsqueeze')
 def parse_unsqueeze_layer(operation, layer_name, input_names, input_shapes, node, class_object, data_reader, config):
     assert operation == 'unsqueeze'
-    
+
+    layer = {}
+    layer['class_name'] = 'Reshape'
+    layer['name'] = layer_name
+
     # Unlike in 'squeeze' in 'unsqueeze', dim argument must exist
     output_shape = [i for i in input_shapes[0]]
     if len(node.args) > 1:  # Specified as unsqueeze(x, n)
         squeeze_dim = node.args[1]
-    else: # Specified as unsqueeze(x, dim=n)
+    else:  # Specified as unsqueeze(x, dim=n)
         squeeze_dim = node.kwargs['dim']
     # insert() will add an element before the index, unsqueeze expects the location
-    index = output_shape.index(output_shape[squeeze_dim])# + 1
+    index = output_shape.index(output_shape[squeeze_dim])  # + 1
     output_shape.insert(index, 1)
 
     layer['target_shape'] = output_shape.copy()
     if layer['target_shape'][0] is None:
-        del layer['target_shape'][0]    
+        del layer['target_shape'][0]
+
+    return layer, output_shape
+
 
 @pytorch_handler('Flatten')
 def parse_flatten_layer(operation, layer_name, input_names, input_shapes, node, class_object, data_reader, config):

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -33,7 +33,7 @@ class PyTorchModelReader:
         tensorName = layer_name + '.' + var_name
         if "layer." in tensorName and not layerInKeyName:
             tensorName = tensorName.lstrip("layer.")
-        print(tensorName)
+
         if tensorName in self.state_dict:
             data = self.state_dict[tensorName].numpy()
             return data

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -23,6 +23,7 @@ class PyTorchModelReader:
         # were an named nn.Sequential with "layer" in it's name is used.
         # We make sure that we pick the correct name for the tensor
         layerInKeyName = False
+
         for key in self.state_dict.keys():
             if "layer." in key:
                 layerInKeyName = True
@@ -37,7 +38,11 @@ class PyTorchModelReader:
         if tensorName in self.state_dict:
             data = self.state_dict[tensorName].numpy()
             return data
-
+        # if a layer is reused in the model, torch.FX will append a "_n" for the n-th use
+        # have to remove that integer to find the tensors
+        elif '.'.join(layer_name.split('.')[:-1]) + '.' + var_name in self.state_dict:
+            data = self.state_dict['.'.join(layer_name.split('.')[:-1]) + '.' + var_name].numpy()
+            return data
         else:
             return None
 

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -21,7 +21,9 @@ class PyTorchModelReader:
         # have to remove the prefix we previously had to add to make sure the tensors are found
         if 'layer_' in layer_name:
             layer_name = layer_name.split('layer_')[-1]
-
+        # naming convention for tensors in named nn.Sequentials
+        elif '_' in layer_name:
+            layer_name = '.'.join(layer_name.split('_'))
         # if a layer is reused in the model, torch.FX will append a "_n" for the n-th use
         # have to snap that off to find the tensors
         if layer_name.split('_')[-1].isdigit() and len(layer_name.split('_')) > 1:

--- a/test/pytest/test_pytorch_api.py
+++ b/test/pytest/test_pytorch_api.py
@@ -583,7 +583,7 @@ class BatchNormModel(nn.Module):
 
     def forward(self, x):
         x = self.linear(x)
-        x = self.relu(x) # This is to prevent merging of BN into Linear
+        x = self.relu(x)  # This is to prevent merging of BN into Linear
         return self.bn(x)
 
 
@@ -620,13 +620,13 @@ class SqueezeModel(nn.Module):
         super().__init__()
         self.linear = nn.Linear(5, 3, bias=False)
         self.bn = nn.BatchNorm1d(3)
-        nn.init.ones_(self.linear.weight) # This test is not about precision, so put 1's here
+        nn.init.ones_(self.linear.weight)  # This test is not about precision, so put 1's here
 
     def forward(self, x):
-        x = torch.unsqueeze(x, dim=1) # (1, 5) -> (1, 1, 5)
-        x = self.linear(x) # (1, 1, 3)
-        x = torch.squeeze(x) # (3,)
-        x = torch.relu(x) # (3,)
+        x = torch.unsqueeze(x, dim=1)  # (1, 5) -> (1, 1, 5)
+        x = self.linear(x)  # (1, 1, 3)
+        x = torch.squeeze(x)  # (3,)
+        x = torch.relu(x)  # (3,)
         return x
 
 
@@ -641,7 +641,7 @@ def test_squeeze(backend, io_type):
     pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy().flatten()
 
     config = config_from_pytorch_model(model)
-    del config['Model']['InputsChannelLast'] # We don't want anything touched for this test
+    del config['Model']['InputsChannelLast']  # We don't want anything touched for this test
     output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_squeeze_{backend}_{io_type}')
 
     hls_model = convert_from_pytorch_model(
@@ -662,9 +662,10 @@ def test_squeeze(backend, io_type):
     elif io_type == 'io_stream':
         assert list(hls_model.get_layers())[1].class_name == 'Repack'
         assert list(hls_model.get_layers())[1].attributes['target_shape'] == [1, 5]
-        assert list(hls_model.get_layers())[3].attributes['class_name'] == 'Reshape' # Exists as in-place variable
+        assert list(hls_model.get_layers())[3].attributes['class_name'] == 'Reshape'  # Exists as in-place variable
         assert list(hls_model.get_layers())[3].attributes['target_shape'] == [3]
-        
+
+
 @pytest.mark.parametrize('backend', ['Vivado', 'Quartus'])
 def test_flatten(backend):
     input = torch.randn(1, 1, 5, 5)

--- a/test/pytest/test_sequential_parsing_pytorch.py
+++ b/test/pytest/test_sequential_parsing_pytorch.py
@@ -2,18 +2,31 @@ from pathlib import Path
 
 import pytest
 import torch.nn as nn
+from collections import OrderedDict
 
 from hls4ml.converters import convert_from_pytorch_model
 from hls4ml.utils.config import config_from_pytorch_model
 
 test_root_path = Path(__file__).parent
 
-# simple model with unnamed sequential
-model = nn.Sequential(nn.Conv2d(1, 20, 5), nn.ReLU(), nn.Conv2d(20, 64, 5), nn.ReLU())
+# Model with unnamed Sequential and no named layers
+seq_unnamed = nn.Sequential(nn.Conv2d(1, 20, 5), nn.ReLU(), nn.Conv2d(20, 64, 5), nn.ReLU())
+
+# Model with unnamed Sequential and named layers 
+seq_named = nn.Sequential(
+    OrderedDict(
+        [
+            ('conv_1', nn.Conv2d(1, 20, 5)),
+            ('relu_1', nn.ReLU()),
+            ('conv_2', nn.Conv2d(20, 64, 5)),
+            ('relu_2', nn.ReLU())
+        ]
+    )
+)
 
 
-# simple model with namend sequential
-class SeqModel(nn.Module):
+# Model with named Sequential and no named layers
+class SeqModelUnnamedLayers(nn.Module):
     def __init__(self):
         super().__init__()
         self.layer = nn.Sequential(nn.Conv2d(1, 20, 5), nn.ReLU(), nn.Conv2d(20, 64, 5), nn.ReLU())
@@ -22,12 +35,35 @@ class SeqModel(nn.Module):
         output = self.layer(x)
         return output
 
+# Model with named Sequential and named layers
+class SeqModelNamedLayers(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = nn.Sequential(
+                OrderedDict(
+                    [
+                        ('conv_1', nn.Conv2d(1, 20, 5)),
+                        ('relu_1', nn.ReLU()),
+                        ('conv_2', nn.Conv2d(20, 64, 5)),
+                        ('relu_2', nn.ReLU())
+                    ]
+                )
+            )
+
+    def forward(self, x):
+        output = self.layer(x)
+        return output
 
 @pytest.mark.parametrize('backend', ['Vivado'])
 @pytest.mark.parametrize('io_type', ['io_parallel'])
-def test_named(backend, io_type):
+@pytest.mark.parametrize('named_layers', [True, False])
+def test_unnamed_seq(backend, io_type, named_layers):
+    if named_layers:
+        model = seq_named
+    else:
+        model = seq_unnamed
     config = config_from_pytorch_model(model)
-    output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_gru_{backend}_{io_type}')
+    output_dir = str(test_root_path / f'hls4mlprj_pytorch_seq_unnamed_{backend}_{io_type}_{named_layers}')
 
     convert_from_pytorch_model(
         model, (None, 1, 5, 5), hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
@@ -36,11 +72,15 @@ def test_named(backend, io_type):
 
 @pytest.mark.parametrize('backend', ['Vivado'])
 @pytest.mark.parametrize('io_type', ['io_parallel'])
-def test_unnnamed(backend, io_type):
-    pytorch_model = SeqModel()
-    config = config_from_pytorch_model(pytorch_model)
-    output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_gru_{backend}_{io_type}')
+@pytest.mark.parametrize('named_layers', [True, False])
+def test_named_seq(backend, io_type, named_layers):
+    if named_layers:
+        model = SeqModelNamedLayers()
+    else:
+        model = SeqModelUnnamedLayers()
+    config = config_from_pytorch_model(model)
+    output_dir = str(test_root_path / f'hls4mlprj_pytorch_seq_named_{backend}_{io_type}_{named_layers}')
 
     convert_from_pytorch_model(
-        pytorch_model, (None, 1, 5, 5), hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
+        model, (None, 1, 5, 5), hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
     )

--- a/test/pytest/test_sequential_parsing_pytorch.py
+++ b/test/pytest/test_sequential_parsing_pytorch.py
@@ -1,8 +1,8 @@
+from collections import OrderedDict
 from pathlib import Path
 
 import pytest
 import torch.nn as nn
-from collections import OrderedDict
 
 from hls4ml.converters import convert_from_pytorch_model
 from hls4ml.utils.config import config_from_pytorch_model
@@ -12,15 +12,10 @@ test_root_path = Path(__file__).parent
 # Model with unnamed Sequential and no named layers
 seq_unnamed = nn.Sequential(nn.Conv2d(1, 20, 5), nn.ReLU(), nn.Conv2d(20, 64, 5), nn.ReLU())
 
-# Model with unnamed Sequential and named layers 
+# Model with unnamed Sequential and named layers
 seq_named = nn.Sequential(
     OrderedDict(
-        [
-            ('conv_1', nn.Conv2d(1, 20, 5)),
-            ('relu_1', nn.ReLU()),
-            ('conv_2', nn.Conv2d(20, 64, 5)),
-            ('relu_2', nn.ReLU())
-        ]
+        [('conv_1', nn.Conv2d(1, 20, 5)), ('relu_1', nn.ReLU()), ('conv_2', nn.Conv2d(20, 64, 5)), ('relu_2', nn.ReLU())]
     )
 )
 
@@ -35,24 +30,26 @@ class SeqModelUnnamedLayers(nn.Module):
         output = self.layer(x)
         return output
 
+
 # Model with named Sequential and named layers
 class SeqModelNamedLayers(nn.Module):
     def __init__(self):
         super().__init__()
         self.layer = nn.Sequential(
-                OrderedDict(
-                    [
-                        ('conv_1', nn.Conv2d(1, 20, 5)),
-                        ('relu_1', nn.ReLU()),
-                        ('conv_2', nn.Conv2d(20, 64, 5)),
-                        ('relu_2', nn.ReLU())
-                    ]
-                )
+            OrderedDict(
+                [
+                    ('conv_1', nn.Conv2d(1, 20, 5)),
+                    ('relu_1', nn.ReLU()),
+                    ('conv_2', nn.Conv2d(20, 64, 5)),
+                    ('relu_2', nn.ReLU()),
+                ]
             )
+        )
 
     def forward(self, x):
         output = self.layer(x)
         return output
+
 
 @pytest.mark.parametrize('backend', ['Vivado'])
 @pytest.mark.parametrize('io_type', ['io_parallel'])

--- a/test/pytest/test_sequential_parsing_pytorch.py
+++ b/test/pytest/test_sequential_parsing_pytorch.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+import torch.nn as nn
+
+from hls4ml.converters import convert_from_pytorch_model
+from hls4ml.utils.config import config_from_pytorch_model
+
+test_root_path = Path(__file__).parent
+
+# simple model with unnamed sequential
+model = nn.Sequential(nn.Conv2d(1, 20, 5), nn.ReLU(), nn.Conv2d(20, 64, 5), nn.ReLU())
+
+
+# simple model with namend sequential
+class SeqModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = nn.Sequential(nn.Conv2d(1, 20, 5), nn.ReLU(), nn.Conv2d(20, 64, 5), nn.ReLU())
+
+    def forward(self, x):
+        output = self.layer(x)
+        return output
+
+
+@pytest.mark.parametrize('backend', ['Vivado'])
+@pytest.mark.parametrize('io_type', ['io_parallel'])
+def test_named(backend, io_type):
+    config = config_from_pytorch_model(model)
+    output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_gru_{backend}_{io_type}')
+
+    convert_from_pytorch_model(
+        model, (None, 1, 5, 5), hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
+    )
+
+
+@pytest.mark.parametrize('backend', ['Vivado'])
+@pytest.mark.parametrize('io_type', ['io_parallel'])
+def test_unnnamed(backend, io_type):
+    pytorch_model = SeqModel()
+    config = config_from_pytorch_model(pytorch_model)
+    output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_gru_{backend}_{io_type}')
+
+    convert_from_pytorch_model(
+        pytorch_model, (None, 1, 5, 5), hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
+    )


### PR DESCRIPTION
Parsing of nn.Sequentials that are named members of a model class results in a naming convention for the tensors in the `state_dict` of the model different from what the parser expects, since it was so far tested only on unnamed nn.Sequentials. This PR catches this and adjusts the name of the tensors we are importing from the `state_dict` accordingly. A test is added to ensure that we keep parsing both cases successfully. 

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

To reproduce, this will fail with this PR:

```

import torch.nn as nn

from hls4ml.converters import convert_from_pytorch_model
from hls4ml.utils.config import config_from_pytorch_model



#simple model with namend sequential
class SeqModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.layer = nn.Sequential(
          nn.Conv2d(1,20,5),
          nn.ReLU(),
          nn.Conv2d(20,64,5),
          nn.ReLU()
        )   

    def forward(self, x):
        output = self.layer(x)
        return output

model = SeqModel()

config = config_from_pytorch_model(model)
output_dir = 'test_pytorch'

convert_from_pytorch_model(
        model, (None, 1, 5, 5), hls_config=config, output_dir=output_dir)
```

pytests have been added to verify that this keeps working. 

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
