### PR TITLE
Add option to configure IP version

### DIFF
--- a/hls4ml/templates/vivado/build_prj.tcl
+++ b/hls4ml/templates/vivado/build_prj.tcl
@@ -229,7 +229,7 @@ if {$opt(validation)} {
 if {$opt(export)} {
     puts "***** EXPORT IP *****"
     set time_start [clock clicks -milliseconds]
-    export_design -format ip_catalog
+    export_design -format ip_catalog -version $version
     set time_end [clock clicks -milliseconds]
     report_time "EXPORT IP" $time_start $time_end
 }

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -6,6 +6,28 @@ import hls4ml
 
 
 def create_config(output_dir='my-hls-test', project_name='myproject', backend='Vivado', version='1.0.0', **kwargs):
+    """Create an initial configuration to guide the conversion process.
+
+    The resulting configuration will contain general information about the project (like project name and output directory)
+    as well as the backend-specific configuration (part numbers, clocks etc). Extra arguments of this function will be
+    passed to the backend's ``create_initial_config``. For the possible list of arguments, check the documentation of each
+    backend.
+
+    Args:
+        output_dir (str, optional): The output directory to which the generated project will be written.
+            Defaults to 'my-hls-test'.
+        project_name (str, optional): The name of the project, that will be used as a top-level function in HLS designs.
+            Defaults to 'myproject'.
+        backend (str, optional): The backend to use. Defaults to 'Vivado'.
+        version (str, optional): Optional string to version the generated project for backends that support it.
+            Defaults to '1.0.0'.
+
+    Raises:
+        Exception: Raised if unknown backend is specified.
+
+    Returns:
+        dict: The conversion configuration.
+    """
     backend_list = hls4ml.backends.get_available_backends()
     if backend.lower() not in backend_list:
         raise Exception(f'Unknown backend: {backend}')

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -5,7 +5,7 @@ import qkeras
 import hls4ml
 
 
-def create_config(output_dir='my-hls-test', project_name='myproject', backend='Vivado', **kwargs):
+def create_config(output_dir='my-hls-test', project_name='myproject', backend='Vivado', version='1.0.0', **kwargs):
     backend_list = hls4ml.backends.get_available_backends()
     if backend.lower() not in backend_list:
         raise Exception(f'Unknown backend: {backend}')
@@ -18,6 +18,7 @@ def create_config(output_dir='my-hls-test', project_name='myproject', backend='V
     config['OutputDir'] = output_dir
     config['ProjectName'] = project_name
     config['Backend'] = backend.name
+    config['Version'] = version
     config.update(backend_config)
 
     return config

--- a/hls4ml/writer/vivado_accelerator_writer.py
+++ b/hls4ml/writer/vivado_accelerator_writer.py
@@ -392,6 +392,8 @@ class VivadoAcceleratorWriter(VivadoWriter):
         f.write('set clock_period {}\n'.format(model.config.get_config_value('ClockPeriod')))
         f.write('variable clock_uncertainty\n')
         f.write('set clock_uncertainty {}\n'.format(model.config.get_config_value('ClockUncertainty', '12.5%')))
+        f.write('variable version\n')
+        f.write('set version "{}"\n'.format(model.config.get_config_value('Version', '1.0.0')))
         if self.vivado_accelerator_config.get_interface() == 'axi_stream':
             in_bit, out_bit = self.vivado_accelerator_config.get_io_bitwidth()
             f.write(f'set bit_width_hls_output {in_bit}\n')

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -588,6 +588,8 @@ class VivadoWriter(Writer):
         f.write('set clock_period {}\n'.format(model.config.get_config_value('ClockPeriod')))
         f.write('variable clock_uncertainty\n')
         f.write('set clock_uncertainty {}\n'.format(model.config.get_config_value('ClockUncertainty', '12.5%')))
+        f.write('variable version\n')
+        f.write('set version "{}"\n'.format(model.config.get_config_value('Version', '1.0.0')))
         f.close()
 
         # build_prj.tcl


### PR DESCRIPTION
A small change of adding an option to specify the IP version, defaulting to `1.0.0`.

Motivation: although it is a long time since the [Y2K22](https://support.xilinx.com/s/article/76960?language=en_US ) issue I hear people still run into it when running on systems where admins didn't install the patch. The same workaround was suggested in [here](https://support.xilinx.com/s/question/0D52E00006vDlvJSAS/export-ip-invalid-argument-revision-number-overflow-issue?language=en_US). Issue mentioned in #633.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Tests

Please suggest tests for this change.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
