### PR TITLE
Add support for flattening to the pytorch parser

### DIFF
--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -38,7 +38,16 @@ def parse_flatten_layer(operation, layer_name, input_names, input_shapes, node, 
     layer['name'] = layer_name
     layer['inputs'] = input_names
 
-    layer['target_shape'] = [input_shapes[0][0], np.prod(input_shapes[0][1:])]
+    start_dim = class_object.start_dim
+    end_dim = class_object.end_dim
+    if end_dim + 1 == 0 or end_dim + 1 > len(input_shapes[0]):
+        end_dim = len(input_shapes[0])
+    else:
+        end_dim = end_dim + 1
+
+    layer['target_shape'] = (
+        input_shapes[0][0:start_dim] + [np.prod(input_shapes[0][start_dim:end_dim])] + input_shapes[0][end_dim:]
+    )
     output_shape = layer['target_shape']
 
     return layer, output_shape

--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -27,3 +27,17 @@ def parse_reshape_layer(operation, layer_name, input_names, input_shapes, node, 
     output_shape = input_shapes[0][:1] + layer['target_shape']
 
     return layer, output_shape
+
+@pytorch_handler('Flatten')
+def parse_flatten_layer(operation, layer_name, input_names, input_shapes, node, class_object, data_reader, config):
+    assert operation == 'Flatten'
+
+    layer = {}
+    layer['class_name'] = 'Reshape'
+    layer['name'] = layer_name
+    layer['inputs'] = input_names
+
+    layer['target_shape'] = [input_shapes[0][0], np.prod(input_shapes[0][1:])]
+    output_shape = layer['target_shape']
+
+    return layer, output_shape

--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -28,6 +28,7 @@ def parse_reshape_layer(operation, layer_name, input_names, input_shapes, node, 
 
     return layer, output_shape
 
+
 @pytorch_handler('Flatten')
 def parse_flatten_layer(operation, layer_name, input_names, input_shapes, node, class_object, data_reader, config):
     assert operation == 'Flatten'

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -104,7 +104,7 @@ layer_name_map = {
     'max_pool2d': 'MaxPool2d',
     'avg_pool1d': 'AvgPool1d',
     'avg_pool2d': 'AvgPool2d',
-    'flatten': "Flatten",
+    'flatten': 'Flatten',
 }
 
 

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -105,6 +105,7 @@ layer_name_map = {
     'max_pool2d': 'MaxPool2d',
     'avg_pool1d': 'AvgPool1d',
     'avg_pool2d': 'AvgPool2d',
+    'flatten': "Flatten"
 }
 
 
@@ -144,7 +145,7 @@ def pytorch_to_hls(config):
 
     traced_model = symbolic_trace(model)
     # Define layers to skip for conversion to HLS
-    skip_layers = ['Dropout', 'Flatten', 'Sequential']
+    skip_layers = ['Dropout', 'Sequential']
 
     # All supported layers
     supported_layers = get_supported_pytorch_layers() + skip_layers
@@ -189,10 +190,8 @@ def pytorch_to_hls(config):
                 if pytorch_class == 'Sequential':  # Ignore the mother module's class name
                     continue
 
-                if pytorch_class == 'Flatten':
-                    output_shapes[layer_name] = [input_shapes[0][0], np.prod(input_shapes[0][1:])]
-                else:
-                    output_shapes[layer_name] = input_shapes[0]
+                output_shapes[layer_name] = input_shapes[0]
+
                 continue
 
             # Increment the layer counter after initial screenings

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -1,4 +1,3 @@
-import numpy as np
 import torch
 
 from hls4ml.model import ModelGraph
@@ -105,7 +104,7 @@ layer_name_map = {
     'max_pool2d': 'MaxPool2d',
     'avg_pool1d': 'AvgPool1d',
     'avg_pool2d': 'AvgPool2d',
-    'flatten': "Flatten"
+    'flatten': "Flatten",
 }
 
 

--- a/hls4ml/model/optimizer/passes/convert_to_channels_last.py
+++ b/hls4ml/model/optimizer/passes/convert_to_channels_last.py
@@ -93,7 +93,7 @@ class ChannelsLastConverter(OptimizerPass):
                 node.add_output_variable(shape, dims)
 
             # Have to transpose back before flattening to get correct order of elements in the flattened tensor
-            if isinstance(node, Reshape) and len(node.attributes["target_shape"]) == 1:
+            if isinstance(node, Reshape) and len(node.attributes['target_shape']) == 1:
                 previous_node = node.get_input_node(node.inputs[0])
                 input = previous_node.name
                 outshape = previous_node.get_output_variable().shape
@@ -112,7 +112,7 @@ class ChannelsLastConverter(OptimizerPass):
 
             # Add transpose for output layer
             elif (
-                node.get_attr("name") in model.outputs
+                node.get_attr('name') in model.outputs
                 and len(outshape) > 1
                 and model.config.config['HLSConfig']['Model']['TransposeOutputs']
             ):

--- a/hls4ml/model/optimizer/passes/convert_to_channels_last.py
+++ b/hls4ml/model/optimizer/passes/convert_to_channels_last.py
@@ -92,9 +92,8 @@ class ChannelsLastConverter(OptimizerPass):
                 dims = [outdims[1], outdims[2], outdims[0]]
                 node.add_output_variable(shape, dims)
 
-            #Have to transpose back before flattening to get correct order of elements in the flattened tensor
+            # Have to transpose back before flattening to get correct order of elements in the flattened tensor
             if isinstance(node, Reshape) and len(node.attributes["target_shape"]) == 1:
-
                 previous_node = node.get_input_node(node.inputs[0])
                 input = previous_node.name
                 outshape = previous_node.get_output_variable().shape

--- a/test/pytest/test_pytorch_api.py
+++ b/test/pytest/test_pytorch_api.py
@@ -576,22 +576,14 @@ def test_pooling(pooling, padds, backend):
 
 @pytest.mark.parametrize('backend', ['Vivado', 'Quartus'])
 def test_flatten(backend):
-
     input = torch.randn(1, 1, 5, 5)
-    model = nn.Sequential(
-    nn.Conv2d(1, 32, 5, 1, 1),
-    nn.Flatten(),
-    nn.ReLU()   
-    )
+    model = nn.Sequential(nn.Conv2d(1, 32, 5, 1, 1), nn.Flatten(), nn.ReLU())
     pytorch_prediction = model(input).detach().numpy()
     input_shape = (None, 1, 5, 5)
 
- 
     config = config_from_pytorch_model(model)
     output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_flatten_backend_{backend}')
-    hls_model = convert_from_pytorch_model(
-        model, input_shape, hls_config=config, output_dir=output_dir, backend=backend
-    )
+    hls_model = convert_from_pytorch_model(model, input_shape, hls_config=config, output_dir=output_dir, backend=backend)
     hls_model.compile()
 
     pred = hls_model.predict(input.detach().numpy())


### PR DESCRIPTION
Currently, `Flatten` layers are skipped in the pytorch parser. Additionally, this operation is not flagged as unsupported, so the model will parse, but exhibit incorrect behavior. This PR adds support for these layers by adding them to the parser. The optimizer pass that converts the operations to `channels_last` for pytorch models is adapted to transpose the input to the flattener so the output elements are in the correct order. 

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Tests

Verified that a simple model with a Conv2D and a `Flatten` operation give correct results, both for the `torch.nn.Flatten` and `torch.flatten()` interfaces to this operation in pytorch. Pytest has been added to verify this. 

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
