### PR TITLE
Support for quantized SeparableConv1D/2D

### DIFF
--- a/hls4ml/backends/vivado/passes/convolution_templates.py
+++ b/hls4ml/backends/vivado/passes/convolution_templates.py
@@ -244,10 +244,12 @@ sepconv_config_template = """struct config{index} {{
 }};\n"""
 
 sepconv1d_function_template = (
-    'nnet::separable_conv_1d_{data_format}<{input_t}, {output_t}, {config}>({input}, {output}, {d}, {p}, {z}, {b});'
+    'nnet::separable_conv_1d_{data_format}<{input_t}, {dw_output_t}, {output_t}, {config}>('
+    '{input}, {output}, {d}, {p}, {z}, {b});'
 )
 sepconv2d_function_template = (
-    'nnet::separable_conv_2d_{data_format}<{input_t}, {output_t}, {config}>({input}, {output}, {d}, {p}, {z}, {b});'
+    'nnet::separable_conv_2d_{data_format}<{input_t}, {dw_output_t}, {output_t}, {config}>('
+    '{input}, {output}, {d}, {p}, {z}, {b});'
 )
 
 sepconv1d_include_list = ['nnet_utils/nnet_conv1d.h', 'nnet_utils/nnet_sepconv1d_stream.h']
@@ -360,6 +362,7 @@ class SeparableConv1DFunctionTemplate(FunctionCallTemplate):
 
     def format(self, node):
         params = self._default_function_params(node)
+        params['dw_output_t'] = node.get_attr('dw_output_t').name
         params['data_format'] = 'cf' if node.get_attr('data_format') == 'channels_first' else 'cl'
         params['d'] = node.get_weights('depthwise').name
         params['p'] = node.get_weights('pointwise').name
@@ -487,6 +490,7 @@ class SeparableConv2DFunctionTemplate(FunctionCallTemplate):
 
     def format(self, node):
         params = self._default_function_params(node)
+        params['dw_output_t'] = node.get_attr('dw_output_t').name
         params['data_format'] = 'cf' if node.get_attr('data_format') == 'channels_first' else 'cl'
         params['d'] = node.get_weights('depthwise').name
         params['p'] = node.get_weights('pointwise').name

--- a/hls4ml/backends/vivado/passes/convolution_templates.py
+++ b/hls4ml/backends/vivado/passes/convolution_templates.py
@@ -275,6 +275,9 @@ class SeparableConv1DConfigTemplate(LayerConfigTemplate):
 
         # Depthwise config
         params = self._default_config_params(node)
+        # Override bias and bias_t since these are zeros in depthwise step of SepConv1D
+        params['bias'] = params['zero_bias']
+        params['bias_t'] = params['zero_bias_t']
         params['n_filt'] = params['n_chan']  # In depthwise step n_chan == n_filt
         params['dilation'] = node.get_attr('dilation', 1)
         params['nzeros'] = node.get_weights('depthwise').nzeros
@@ -282,7 +285,7 @@ class SeparableConv1DConfigTemplate(LayerConfigTemplate):
         params['weight_t'] = node.get_weights('depthwise').type
         params['fill_fn'] = 'FillConv1DBuffer'
 
-        if node.get_attr("unscaled"):
+        if node.get_attr('unscaled'):
             params['scale_index_type'] = 'scale_index_unscaled'
         else:
             params['scale_index_type'] = 'scale_index_regular'
@@ -303,14 +306,11 @@ class SeparableConv1DConfigTemplate(LayerConfigTemplate):
         depthwise_mult_config = self.depthwise_mult_template.format(**mult_params)
 
         # Pointwise config
-        params = self._default_config_params()
-        input_shape = self.get_input_variable().shape
-        if self.get_attr('data_format') == 'channels_last':
-            params['in_width'] = '*'.join([str(k) for k in input_shape[:-1]])
-            params['n_chan'] = input_shape[-1]
+        params = self._default_config_params(node)
+        if node.get_attr('data_format') == 'channels_last':
+            params['in_width'] = node.get_output_variable().shape[0]
         else:
-            params['in_width'] = '*'.join([str(k) for k in input_shape[1:]])
-            params['n_chan'] = input_shape[0]
+            params['in_width'] = node.get_output_variable().shape[1]
 
         params['filt_width'] = 1
         params['stride_width'] = 1
@@ -322,7 +322,7 @@ class SeparableConv1DConfigTemplate(LayerConfigTemplate):
         params['instructions'] = '0'
         params['fill_fn'] = 'FillConv1DBuffer'
 
-        if node.get_attr("unscaled"):
+        if node.get_attr('unscaled'):
             params['scale_index_type'] = 'scale_index_unscaled'
         else:
             params['scale_index_type'] = 'scale_index_regular'
@@ -401,12 +401,12 @@ class SeparableConv2DConfigTemplate(LayerConfigTemplate):
         params['weight_t'] = node.get_weights('depthwise').type
         params['fill_fn'] = 'FillConv2DBuffer'
 
-        if node.get_attr("unscaled_h"):
+        if node.get_attr('unscaled_h'):
             params['scale_index_height_type'] = 'scale_index_unscaled'
         else:
             params['scale_index_height_type'] = 'scale_index_regular'
 
-        if node.get_attr("unscaled_w"):
+        if node.get_attr('unscaled_w'):
             params['scale_index_width_type'] = 'scale_index_unscaled'
         else:
             params['scale_index_width_type'] = 'scale_index_regular'
@@ -446,12 +446,12 @@ class SeparableConv2DConfigTemplate(LayerConfigTemplate):
         params['instructions'] = '0'
         params['fill_fn'] = 'FillConv2DBuffer'
 
-        if node.get_attr("unscaled_h"):
+        if node.get_attr('unscaled_h'):
             params['scale_index_height_type'] = 'scale_index_unscaled'
         else:
             params['scale_index_height_type'] = 'scale_index_regular'
 
-        if node.get_attr("unscaled_w"):
+        if node.get_attr('unscaled_w'):
             params['scale_index_width_type'] = 'scale_index_unscaled'
         else:
             params['scale_index_width_type'] = 'scale_index_regular'

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -28,7 +28,7 @@ from hls4ml.model.layers import (
     Softmax,
 )
 from hls4ml.model.optimizer import get_backend_passes, layer_optimizer
-from hls4ml.model.types import FixedPrecisionType, IntegerPrecisionType, NamedType
+from hls4ml.model.types import FixedPrecisionType, IntegerPrecisionType, NamedType, PackedType
 from hls4ml.report import parse_vivado_report
 from hls4ml.utils.fixed_point_utils import ceil_log2
 
@@ -73,6 +73,12 @@ class VivadoBackend(FPGABackend):
             attrs = self.attribute_map.get(layer, [])
             # attrs.append(ConfigurableAttribute('conv_implementation', value_type=str, default='LineBuffer'))
             attrs.append(ChoiceAttribute('conv_implementation', choices=['LineBuffer', 'Encoded'], default='LineBuffer'))
+            self.attribute_map[layer] = attrs
+
+        sep_conv_layers = [SeparableConv1D, SeparableConv2D]
+        for layer in sep_conv_layers:
+            attrs = self.attribute_map.get(layer, [])
+            attrs.append(TypeAttribute('dw_output', default=FixedPrecisionType(18, 8)))
             self.attribute_map[layer] = attrs
 
     def _register_flows(self):
@@ -288,6 +294,15 @@ class VivadoBackend(FPGABackend):
         )  # TODO Once we have SeparableConv implementation for io_parallel this should be set properly
         layer.set_attr('implementation', layer.model.config.get_conv_implementation(layer).lower())
 
+        # Set the output type of the depthwise phase
+        dw_out_precision, _ = layer.model.config.get_precision(layer, 'dw_output')
+        dw_out_name = layer.name + '_dw_out_t'
+        if layer.model.config.get_config_value('IOType') == 'io_stream':
+            dw_output_t = PackedType(dw_out_name, dw_out_precision, layer.get_attr('n_chan'), n_pack=1)
+        else:
+            dw_output_t = NamedType(dw_out_name, dw_out_precision)
+        layer.set_attr('dw_output_t', dw_output_t)
+
     @layer_optimizer(Conv2D)
     def init_conv2d(self, layer):
         if len(layer.weights['weight'].data.shape) == 2:  # This can happen if we assign weights of Dense layer to 1x1 Conv2D
@@ -333,6 +348,15 @@ class VivadoBackend(FPGABackend):
             'n_partitions', 1
         )  # TODO Once we have SeparableConv implementation for io_parallel this should be set properly
         layer.set_attr('implementation', layer.model.config.get_conv_implementation(layer).lower())
+
+        # Set the output type of the depthwise phase
+        dw_out_precision, _ = layer.model.config.get_precision(layer, 'dw_output')
+        dw_out_name = layer.name + '_dw_out_t'
+        if layer.model.config.get_config_value('IOType') == 'io_stream':
+            dw_output_t = PackedType(dw_out_name, dw_out_precision, layer.get_attr('n_chan'), n_pack=1)
+        else:
+            dw_output_t = NamedType(dw_out_name, dw_out_precision)
+        layer.set_attr('dw_output_t', dw_output_t)
 
     @layer_optimizer(DepthwiseConv2D)
     def init_depconv2d(self, layer):

--- a/hls4ml/converters/keras/qkeras.py
+++ b/hls4ml/converters/keras/qkeras.py
@@ -54,6 +54,27 @@ def parse_qdepthwiseqconv_layer(keras_layer, input_names, input_shapes, data_rea
     layer, output_shape = parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader)
 
     layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'depthwise')
+
+    if keras_layer['config']['bias_quantizer'] is not None:
+        layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
+    else:
+        layer['bias_quantizer'] = None
+
+    return layer, output_shape
+
+
+@keras_handler('QSeparableConv1D', 'QSeparableConv2D')
+def parse_qsepconv_layer(keras_layer, input_names, input_shapes, data_reader):
+    assert 'QSeparableConv' in keras_layer['class_name']
+
+    if '1D' in keras_layer['class_name']:
+        layer, output_shape = parse_conv1d_layer(keras_layer, input_names, input_shapes, data_reader)
+    elif '2D' in keras_layer['class_name']:
+        layer, output_shape = parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader)
+
+    layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'depthwise')
+    layer['pointwise_quantizer'] = get_quantizer_from_config(keras_layer, 'pointwise')
+
     if keras_layer['config']['bias_quantizer'] is not None:
         layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
     else:

--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -56,7 +56,6 @@ class Layer:
         ConfigurableAttribute('trace', default=False),
         TypeAttribute('result'),
     ]
-    """"""
 
     @classproperty
     def expected_attributes(cls):
@@ -1331,8 +1330,10 @@ layer_map = {
     'QConv2D': Conv2D,
     'QConv2DBatchnorm': Conv2DBatchnorm,
     'SeparableConv1D': SeparableConv1D,
+    'QSeparableConv1D': SeparableConv1D,
     'DepthwiseConv1D': DepthwiseConv1D,
     'SeparableConv2D': SeparableConv2D,
+    'QSeparableConv2D': SeparableConv2D,
     'DepthwiseConv2D': DepthwiseConv2D,
     'QDepthwiseConv2D': DepthwiseConv2D,
     'BatchNormalization': BatchNormalization,

--- a/hls4ml/templates/vitis/nnet_utils/nnet_sepconv1d_stream.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_sepconv1d_stream.h
@@ -70,7 +70,7 @@ void pointwise_conv_1d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
     }
 }
 
-template <class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class dw_res_T, class res_T, typename CONFIG_T>
 void separable_conv_1d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
                           typename CONFIG_T::depthwise_config::weight_t
                               depthwise_weights[CONFIG_T::depthwise_config::filt_width * CONFIG_T::depthwise_config::n_chan],
@@ -85,14 +85,14 @@ void separable_conv_1d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
 
     #pragma HLS DATAFLOW
 
-    hls::stream<data_T> depthwise_res;
+    hls::stream<dw_res_T> depthwise_res;
     unsigned res_depth = CONFIG_T::depthwise_config::out_width;
     #pragma HLS STREAM variable=depthwise_res depth=res_depth
 
-    depthwise_conv_1d_buffer_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(data, depthwise_res, depthwise_weights,
-                                                                                     depthwise_biases);
-    pointwise_conv_1d_cl<data_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights,
-                                                                             pointwise_biases);
+    depthwise_conv_1d_buffer_cl<data_T, dw_res_T, typename CONFIG_T::depthwise_config>(data, depthwise_res,
+                                                                                       depthwise_weights, depthwise_biases);
+    pointwise_conv_1d_cl<dw_res_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights,
+                                                                               pointwise_biases);
 }
 
 } // namespace nnet

--- a/hls4ml/templates/vitis/nnet_utils/nnet_sepconv2d_stream.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_sepconv2d_stream.h
@@ -103,7 +103,7 @@ void depthwise_conv_2d_cl(
     depthwise_conv_2d_buffer_cl<data_T, res_T, CONFIG_T>(data, res, weights, biases);
 }
 
-template <class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class dw_res_T, class res_T, typename CONFIG_T>
 void separable_conv_2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
                           typename CONFIG_T::depthwise_config::weight_t
                               depthwise_weights[CONFIG_T::depthwise_config::filt_height *
@@ -119,14 +119,14 @@ void separable_conv_2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
 
     #pragma HLS DATAFLOW
 
-    hls::stream<data_T> depthwise_res;
+    hls::stream<dw_res_T> depthwise_res;
     unsigned res_depth = CONFIG_T::depthwise_config::out_height * CONFIG_T::depthwise_config::out_width;
     #pragma HLS STREAM variable=depthwise_res depth=res_depth
 
-    depthwise_conv_2d_buffer_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(data, depthwise_res, depthwise_weights,
-                                                                                     depthwise_biases);
-    pointwise_conv_2d_cl<data_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights,
-                                                                             pointwise_biases);
+    depthwise_conv_2d_buffer_cl<data_T, dw_res_T, typename CONFIG_T::depthwise_config>(data, depthwise_res,
+                                                                                       depthwise_weights, depthwise_biases);
+    pointwise_conv_2d_cl<dw_res_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights,
+                                                                               pointwise_biases);
 }
 
 } // namespace nnet

--- a/hls4ml/templates/vivado/nnet_utils/nnet_sepconv1d_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_sepconv1d_stream.h
@@ -95,7 +95,7 @@ ReadInputWidth:
     }
 }
 
-template <class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class dw_res_T, class res_T, typename CONFIG_T>
 void separable_conv_1d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
                           typename CONFIG_T::depthwise_config::weight_t
                               depthwise_weights[CONFIG_T::depthwise_config::filt_width * CONFIG_T::depthwise_config::n_chan],
@@ -105,14 +105,14 @@ void separable_conv_1d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
                           typename CONFIG_T::pointwise_config::bias_t pointwise_biases[CONFIG_T::pointwise_config::n_filt]) {
     #pragma HLS DATAFLOW
 
-    hls::stream<data_T> depthwise_res;
+    hls::stream<dw_res_T> depthwise_res;
     unsigned res_depth = CONFIG_T::depthwise_config::out_width;
     #pragma HLS STREAM variable=depthwise_res depth=res_depth
 
-    depthwise_conv_1d_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(data, depthwise_res, depthwise_weights,
-                                                                              depthwise_biases);
-    pointwise_conv_1d_cl<data_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights,
-                                                                             pointwise_biases);
+    depthwise_conv_1d_cl<data_T, dw_res_T, typename CONFIG_T::depthwise_config>(data, depthwise_res, depthwise_weights,
+                                                                                depthwise_biases);
+    pointwise_conv_1d_cl<dw_res_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights,
+                                                                               pointwise_biases);
 }
 
 } // namespace nnet

--- a/hls4ml/templates/vivado/nnet_utils/nnet_sepconv2d_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_sepconv2d_stream.h
@@ -5,6 +5,7 @@
 #include "nnet_common.h"
 #include "nnet_conv2d_stream.h"
 #include "nnet_sepconv_stream.h"
+#include "nnet_types.h"
 
 namespace nnet {
 
@@ -117,7 +118,7 @@ ReadInputHeight:
     }
 }
 
-template <class data_T, class res_T, typename CONFIG_T>
+template <class data_T, class dw_res_T, class res_T, typename CONFIG_T>
 void separable_conv_2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
                           typename CONFIG_T::depthwise_config::weight_t
                               depthwise_weights[CONFIG_T::depthwise_config::filt_height *
@@ -128,14 +129,14 @@ void separable_conv_2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res,
                           typename CONFIG_T::pointwise_config::bias_t pointwise_biases[CONFIG_T::pointwise_config::n_filt]) {
     #pragma HLS DATAFLOW
 
-    hls::stream<data_T> depthwise_res;
+    hls::stream<dw_res_T> depthwise_res;
     unsigned res_depth = CONFIG_T::depthwise_config::out_height * CONFIG_T::depthwise_config::out_width;
     #pragma HLS STREAM variable=depthwise_res depth=res_depth
 
-    depthwise_conv_2d_cl<data_T, data_T, typename CONFIG_T::depthwise_config>(data, depthwise_res, depthwise_weights,
-                                                                              depthwise_biases);
-    pointwise_conv_2d_cl<data_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights,
-                                                                             pointwise_biases);
+    depthwise_conv_2d_cl<data_T, dw_res_T, typename CONFIG_T::depthwise_config>(data, depthwise_res, depthwise_weights,
+                                                                                depthwise_biases);
+    pointwise_conv_2d_cl<dw_res_T, res_T, typename CONFIG_T::pointwise_config>(depthwise_res, res, pointwise_weights,
+                                                                               pointwise_biases);
 }
 
 } // namespace nnet

--- a/test/pytest/test_qkeras.py
+++ b/test/pytest/test_qkeras.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from qkeras.qconv2d_batchnorm import QConv2DBatchnorm
-from qkeras.qconvolutional import QDepthwiseConv2D
+from qkeras.qconvolutional import QDepthwiseConv2D, QSeparableConv1D, QSeparableConv2D
 from qkeras.qlayers import QActivation, QDense
 from qkeras.quantizers import (
     binary,
@@ -478,3 +478,95 @@ def test_quantised_po2_bit_width(backend, io_type, strategy):
     y_hls = hls_model.predict(np.ascontiguousarray(X))
 
     np.testing.assert_allclose(y_hls.flatten(), y_keras.flatten(), rtol=2e-2)
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis'])
+@pytest.mark.parametrize('io_type', ['io_stream'])
+def test_qseparableconv1d(backend, io_type):
+    '''
+    Test proper handling of QSeparableConv1D.
+    '''
+    x_in = Input((13, 20), name='input_layer')
+    x = QSeparableConv1D(
+        5,
+        3,
+        depthwise_quantizer=quantized_bits(8, 3, alpha=1),
+        pointwise_quantizer=quantized_bits(8, 3, alpha=1),
+        bias_quantizer=quantized_bits(8, 3, alpha=1),
+        name='qsepconv_1',
+    )(x_in)
+    model = Model(inputs=x_in, outputs=x)
+
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', backend=backend, default_precision='fixed<23,7>'
+    )
+
+    # Use 8 bits for input
+    config['LayerName']['input_layer']['Precision']['result'] = 'fixed<8,1>'
+    # default_precision is will be used for accum_t and result_t of the conv layer, so we don't need to set them here
+    # We need <15,4> for the result of depthwise step
+    config['LayerName']['qsepconv_1']['Precision']['dw_output'] = 'fixed<15,4>'
+
+    output_dir = str(test_root_path / f'hls4mlprj_qsepconv1d_{backend}_{io_type}')
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model,
+        hls_config=config,
+        output_dir=output_dir,
+        io_type=io_type,
+    )
+    hls_model.compile()
+
+    data = np.random.rand(100, 13, 20)
+    input_quantizer = quantized_bits(8, 0, alpha=1)
+    dataq = input_quantizer(data).numpy()
+
+    y_qkeras = model.predict(dataq)
+    y_hls4ml = hls_model.predict(dataq)
+
+    np.testing.assert_allclose(y_qkeras, y_hls4ml.reshape(y_qkeras.shape), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis'])
+@pytest.mark.parametrize('io_type', ['io_stream'])
+def test_qseparableconv2d(backend, io_type):
+    '''
+    Test proper handling of QSeparableConv2D.
+    '''
+    x_in = Input((13, 21, 20), name='input_layer')
+    x = QSeparableConv2D(
+        5,
+        3,
+        depthwise_quantizer=quantized_bits(8, 3, alpha=1),
+        pointwise_quantizer=quantized_bits(8, 3, alpha=1),
+        bias_quantizer=quantized_bits(8, 3, alpha=1),
+        name='qsepconv_1',
+    )(x_in)
+    model = Model(inputs=x_in, outputs=x)
+
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', backend=backend, default_precision='fixed<23,7>'
+    )
+
+    # Use 8 bits for input
+    config['LayerName']['input_layer']['Precision']['result'] = 'fixed<8,1>'
+    # default_precision is will be used for accum_t and result_t of the conv layer, so we don't need to set them here
+    # We need <15,4> for the result of depthwise step
+    config['LayerName']['qsepconv_1']['Precision']['dw_output'] = 'fixed<15,4>'
+
+    output_dir = str(test_root_path / f'hls4mlprj_qsepconv2d_{backend}_{io_type}')
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model,
+        hls_config=config,
+        output_dir=output_dir,
+        io_type=io_type,
+    )
+    hls_model.compile()
+
+    data = np.random.rand(100, 13, 21, 20)
+    input_quantizer = quantized_bits(8, 0, alpha=1)
+    dataq = input_quantizer(data).numpy()
+
+    y_qkeras = model.predict(dataq)
+    y_hls4ml = hls_model.predict(dataq)
+
+    np.testing.assert_allclose(y_qkeras, y_hls4ml.reshape(y_qkeras.shape), rtol=0, atol=0)


### PR DESCRIPTION
# Description

This PR adds support for parsing `QSeparableConv1D/2D` and exxtends the existing implementation to allow specifying the intermediate result of the depthwise step. Otherwise it is tricky to get bit accurate matching. This is mostly motivated by issues observed in Lindsey's model. I've added the tests for 1D and 2D. Supersedes #849. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

A "bug fix" in a sense that it fixes the issues observed in conversion of SeparableConv1D (whether Q or not). A "new feature" as it adds support for separable layers from QKeras. "Breaking change" in a sense that the HLS function call is changed to include the type of the intermediate result of depthwise step (implemented in both Vivado and Vitis for `io_stream`, no other implementations exist ATM).

## Tests

There are two tests appended to `test_qkeras.py`.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
