### PR TITLE
Fix weight precision format string

### DIFF
--- a/hls4ml/model/types.py
+++ b/hls4ml/model/types.py
@@ -564,7 +564,7 @@ class WeightVariable(Variable):
                 # to right of decimal point
                 lsb = 2**-new_precision.fractional
                 decimal_spaces = len(str(lsb).split('.')[1])
-                self.precision_fmt = f'{{:{decimal_spaces}f}}'
+                self.precision_fmt = f'{{:.{decimal_spaces}f}}'
             else:
                 self.precision_fmt = '{:.0f}'
         else:


### PR DESCRIPTION
# Description

Observed in #874 but not limited to zero-integer quantizers, the generated HLS doesn't achieve bit-perfect matching with the QKeras model. This turns out to be due to the initialization of the weights from literals. We print literals with `{:#f}` (where `#` is the number of digits required), but this doesn't work correctly and we should instead use `{:.#f}` (with the leading `.`). For example:
```
Python 3.8.5 (default, Sep  4 2020, 07:30:14) 
[GCC 7.3.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> x = 0.3203125
>>> '{:7f}'.format(x)
'0.320312'
>>> '{:.7f}'.format(x)
'0.3203125'
>>>
```
`ap_fixed<8,1>` would interpret the literal `0.320312` as a value `0.3125`, messing up the result. This one-liner (in fact one-character) fixes #874 (and alike).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Existing QKeras tests should suffice, we should eventually aim for a stricter agreement, ideally bit-perfect one, but that's a separate change.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
