### PR TITLE
try to use new runners for gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ generator:
   stage: generate
   image: python:3.8-alpine
   tags:
-    - docker
+    - k8s-default
   before_script:
     - pip install pyyaml
   script:


### PR DESCRIPTION
# Description

Due to the decommissioning of the old default gitlab runners, try using the new shared  runners

## Type of change
- [x] Other (Specify)
testing infrastructure

## Tests

Will see how the pytests run with this changes.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.

