### PR TITLE
Add support for filt_height==1 for streaming quartus conv2d

### DIFF
--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_conv2d_stream.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_conv2d_stream.h
@@ -69,7 +69,7 @@ template <class data_T, typename CONFIG_T>
 void shift_line_buffer_2d(
     const data_T &in_elem,
     nnet::shift_reg<typename data_T::value_type, CONFIG_T::pad_left + CONFIG_T::in_width + CONFIG_T::pad_right>
-        line_buffer[CONFIG_T::filt_height - 1][CONFIG_T::n_chan],
+        line_buffer[MAX(CONFIG_T::filt_height - 1, 1)][CONFIG_T::n_chan],
     typename data_T::value_type shift_buffer[CONFIG_T::filt_height][CONFIG_T::n_chan]) {
 // For every channel, insert the incoming pixel at end of the shift buffer
 UpdateBuffer:


### PR DESCRIPTION
# Description

The streaming Conv2D implementation in the quartus backend doesn't handle the `filt_height==1` case, as discovered in #878 and #855. We currently do not have a special pointwise streaming implementation for quartus, but nevertheless the default implementation should be able to handle the case, even if a bit less efficiently. This PR adds some C++ fixes for issues that clang and i++ complained about (but not g++).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

I just enabled streaming with the Quartus backend to the `test_pointwiseconv.py` test. As mentioned, there is no special pointwise implementation in this case, but the results should nevertheless be correct

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
