### PR TITLE
Fix profiling SeparableConv1D and SeparableConv2D

### DIFF
--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -350,6 +350,7 @@ def activations_keras(model, X, fmt='longform', plot='boxplot'):
     outputs = _get_outputs(
         [layer for layer in model.layers if not isinstance(layer, keras.layers.InputLayer)], X, model.input
     )
+    outputs = dict(zip([layer.name for layer in model.layers if not isinstance(layer, keras.layers.InputLayer)], outputs))
     for layer_name, y in outputs.items():
         print(f"   {layer_name}")
         y = y.flatten()

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -10,7 +10,7 @@ import pandas
 import seaborn as sb
 
 from hls4ml.model.graph import ModelGraph
-from hls4ml.model.layers import GRU, LSTM
+from hls4ml.model.layers import GRU, LSTM, SeparableConv1D, SeparableConv2D
 
 try:
     import qkeras
@@ -184,6 +184,8 @@ def types_hlsmodel(model):
     for layer in model.get_layers():
         if isinstance(layer, GRU) or isinstance(layer, LSTM):
             suffix = ['w', 'rw', 'b', 'rb']
+        elif isinstance(layer, SeparableConv1D) or isinstance(layer, SeparableConv2D):
+            suffix = ['dw', 'pw', 'db', 'pb']
         else:
             suffix = ['w', 'b']
         for iw, weight in enumerate(layer.get_weights()):
@@ -225,6 +227,8 @@ def weights_hlsmodel(model, fmt='longform', plot='boxplot'):
     for layer in model.get_layers():
         if isinstance(layer, GRU) or isinstance(layer, LSTM):
             suffix = ['w', 'rw', 'b', 'rb']
+        elif isinstance(layer, SeparableConv1D) or isinstance(layer, SeparableConv2D):
+            suffix = ['dw', 'pw', 'db', 'pb']
         else:
             suffix = ['w', 'b']
         name = layer.name


### PR DESCRIPTION
# Description

As described in #890, profiling model using SeparableConv1D or SeparableConv2D fail.
The application of theses two commit fix the test cases decribed in the issue.

* The base issue is similar to #829, which have been fixed by #833. The first commit of this PR contains very similar changes.
* The second commit fixes a subsequent issue where a list is used where a dict is expected. I am less sure about this one, maybe it hides something more deep, or it fixes another bug not yet reported. Experienced eyes required here.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Tests explaining how to reproduce the problem have been provided in the original issue #890.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
