### PR TITLE
Let repack_stream optimizer inheirt original precision

### DIFF
--- a/hls4ml/backends/fpga/passes/repack_stream.py
+++ b/hls4ml/backends/fpga/passes/repack_stream.py
@@ -59,6 +59,8 @@ class ReshapeStream(OptimizerPass):
 
         # Insert new Repack node instead of Reshape
         repack_layer = model.make_node(Repack, 'repack_' + node.name, attrs, node.inputs.copy())
+        # As result_t attribute is not honored by type conversion, set it manually here
+        repack_layer.attributes[repack_layer.name].type = node.attributes[node.name].type
         model.replace_node(node, repack_layer)
 
         return True

--- a/test/pytest/test_repack_precision.py
+++ b/test/pytest/test_repack_precision.py
@@ -1,0 +1,27 @@
+from tensorflow import keras
+
+from hls4ml.converters import convert_from_keras_model
+
+
+def test_repack_precision():
+    inp = keras.Input(shape=(3, 3), name='inp')
+    out = keras.layers.Reshape((3, 3), name='reshape')(inp)
+    out = keras.layers.Conv1D(2, 2, name='conv')(out)
+    model = keras.Model(inp, out)
+
+    layer_conf = {
+        'inp': {'Precision': 'fixed<20,10>'},
+        'reshape': {'Precision': 'fixed<20,10>'},
+        'conv': {'Precision': 'fixed<20,10>'},
+    }
+
+    hls_config = {'Model': {'Precision': 'fixed<2,1>', 'ReuseFactor': 1}, 'LayerName': layer_conf}
+
+    # Repack only happens in io_stream
+    model_hls = convert_from_keras_model(model, hls_config=hls_config, io_type='io_stream')
+    assert 'repack_reshape' in model_hls.graph, 'repack_reshape not found in graph'
+    repack_precision = model_hls.graph['repack_reshape'].attributes['result_t'].precision
+    assert repack_precision.integer == 10, 'Precision mismatch'
+    assert repack_precision.fractional == 10, 'Precision mismatch'
+    assert repack_precision.width == 20, 'Precision mismatch'
+    assert repack_precision.signed is True, 'Precision mismatch'


### PR DESCRIPTION
A# Description

Currently `repack_stream` is not inheriting the precision defined for the `reshape` layer. This PR fixes that.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

`test/pytest/test_repack_precision.py`

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
