### PR TITLE
Quartus multi out with stream fix

### DIFF
--- a/hls4ml/backends/fpga/passes/clone.py
+++ b/hls4ml/backends/fpga/passes/clone.py
@@ -20,21 +20,19 @@ clone_include_list = ['nnet_utils/nnet_stream.h']
 class CloneFunctionTemplate(FunctionCallTemplate):
     def __init__(self):
         super().__init__(Clone, include_header=clone_include_list)
-        self.template = None  # to be filled once number of clones known
 
     def format(self, node):
         params = self._default_function_params(node)
         for i, _output in enumerate(node.outputs):
             params['output' + str(i + 1)] = node.variables[node.outputs[i]].name
 
-        if self.template is None:
-            self.template = (
-                'nnet::clone_stream<{input_t}, {output_t}, {size}>({input}, '
-                + ', '.join(['{output' + str(i + 1) + '}' for i in range(len(node.outputs))])
-                + ');'
-            )
+        template = (
+            'nnet::clone_stream<{input_t}, {output_t}, {size}>({input}, '
+            + ', '.join(['{output' + str(i + 1) + '}' for i in range(len(node.outputs))])
+            + ');'
+        )
 
-        return self.template.format(**params)
+        return template.format(**params)
 
 
 def register_clone(backend):

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -471,8 +471,8 @@ class ModelGraph:
         node = layer_cls(self, name, attributes, inputs, outputs)
         for o in node.outputs:
             out_var = node.get_output_variable(output_name=o)
-            if o in self.outputs:
-                out_var.type.name = 'result_' + out_var.type.name
+            if len(self.outputs) == 1 and o in self.outputs:
+                out_var.type.name = 'result_t'
             self.output_vars[o] = out_var
         return node
 
@@ -608,8 +608,8 @@ class ModelGraph:
         return variables
 
     def register_output_variable(self, out_name, variable):
-        if out_name in self.outputs:
-            variable.type.name = 'result_' + variable.type.name
+        if len(self.outputs) == 1 and out_name in self.outputs:
+            variable.type.name = 'result_t'
         self.output_vars[out_name] = variable
 
     def get_output_variables(self):

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -472,7 +472,7 @@ class ModelGraph:
         for o in node.outputs:
             out_var = node.get_output_variable(output_name=o)
             if o in self.outputs:
-                out_var.type.name = 'result_t'
+                out_var.type.name = 'result_' + out_var.type.name
             self.output_vars[o] = out_var
         return node
 
@@ -609,7 +609,7 @@ class ModelGraph:
 
     def register_output_variable(self, out_name, variable):
         if out_name in self.outputs:
-            variable.type.name = 'result_t'
+            variable.type.name = 'result_' + variable.type.name
         self.output_vars[out_name] = variable
 
     def get_output_variables(self):

--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -172,7 +172,8 @@ class QuartusWriter(Writer):
                     for inp in model_inputs:
                         newline += indent + f'stream_in<{inp.type.name}> &{inp.name}_stream,\n'
                     for out in model_outputs:
-                        newline += indent + f'stream_out<{out.type.name}> &{out.name}_stream'
+                        newline += indent + f'stream_out<{out.type.name}> &{out.name}_stream,\n'
+                    newline = newline[:-2]  # Remove the tailing ',\n'
                     if model_brams:
                         newline += ',\n' + brams_str
                     newline += '\n) {\n'
@@ -191,7 +192,8 @@ class QuartusWriter(Writer):
                     for inp in model_inputs:
                         newline += indent + f'stream_in<{inp.type.name}> &{inp.name}_stream,\n'
                     for out in model_outputs:
-                        newline += indent + f'stream_out<{out.type.name}> &{out.name}_stream'
+                        newline += indent + f'stream_out<{out.type.name}> &{out.name}_stream,\n'
+                    newline = newline[:-2]  # Remove the tailing ',\n'\
                     if model_brams:
                         newline += ',\n' + brams_str
                     newline += '\n) {\n'
@@ -277,7 +279,7 @@ class QuartusWriter(Writer):
                         newline += indent + f'  {out.type.name} tmp = {out.name}.read();\n'
                         newline += indent + f'  {out.name}_stream.write(tmp);\n'
                         newline += indent + '}\n'
-                        newline += '}\n'
+                    newline += '}\n'
                 else:
                     newline = line
                     newline += indent + 'return outputs;\n'
@@ -330,7 +332,8 @@ class QuartusWriter(Writer):
                     for inp in model_inputs:
                         newline += indent + f'stream_in<{inp.type.name}> &{inp.name}_stream,\n'
                     for out in model_outputs:
-                        newline += indent + f'stream_out<{out.type.name}> &{out.name}_stream'
+                        newline += indent + f'stream_out<{out.type.name}> &{out.name}_stream,\n'
+                    newline = newline[:-2]  # Remove the tailing ',\n'
                     if model_brams:
                         newline += ',\n' + brams_str
                     newline += '\n);\n'
@@ -350,7 +353,8 @@ class QuartusWriter(Writer):
                     for inp in model_inputs:
                         newline += indent + f'stream_in<{inp.type.name}> &{inp.name}_stream,\n'
                     for out in model_outputs:
-                        newline += indent + f'stream_out<{out.type.name}> &{out.name}_stream'
+                        newline += indent + f'stream_out<{out.type.name}> &{out.name}_stream,\n'
+                    newline = newline[:-2]  # Remove the tailing ',\n'
                     if model_brams:
                         newline += ',\n' + brams_str
                     newline += '\n);\n'

--- a/test/pytest/test_multiout_network.py
+++ b/test/pytest/test_multiout_network.py
@@ -1,0 +1,53 @@
+import os
+import random
+from pathlib import Path
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from keras.layers import Dense
+from tensorflow import keras
+
+from hls4ml.converters import convert_from_keras_model
+
+test_root_path = Path(__file__).parent
+
+
+@pytest.fixture(scope='module')
+def model():
+    seed = 42
+    os.environ['RANDOM_SEED'] = f'{seed}'
+    np.random.seed(seed)
+    tf.random.set_seed(seed)
+    tf.get_logger().setLevel('ERROR')
+    random.seed(seed)
+
+    inp = keras.Input(shape=(10,))
+    x = Dense(10)(inp)
+    y = Dense(10)(inp)
+    model = keras.Model(inp, [x, y])
+    return model
+
+
+@pytest.fixture(scope='module')
+def data():
+    rng = np.random.RandomState(42)
+    X = rng.normal(0, 1, (1000, 10))
+    X = np.clip(X, -16, 15)
+    return X
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Quartus', 'Vitis'])
+@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
+def test_multi_clone(model, data, backend: str, io_type: str):
+    output_dir = str(test_root_path / f'hls4mlprj_multiout_network_{backend}_{io_type}')
+    hls_config = {'Model': {'Precision': 'fixed<32,5>', 'ReuseFactor': 1}}
+    model_hls = convert_from_keras_model(
+        model, backend=backend, output_dir=output_dir, hls_config=hls_config, io_type=io_type
+    )
+    model_hls.compile()
+    r_hls = model_hls.predict(data)
+    r_keras = [x.numpy() for x in model(data)]
+
+    assert np.allclose(r_hls[0], r_keras[0], atol=1e-5, rtol=0)
+    assert np.allclose(r_hls[1], r_keras[1], atol=1e-5, rtol=0)

--- a/test/pytest/test_multiout_network.py
+++ b/test/pytest/test_multiout_network.py
@@ -8,7 +8,6 @@ from tensorflow import keras
 from hls4ml.converters import convert_from_keras_model
 
 test_root_path = Path(__file__).parent
-test_root_path = Path('/tmp/hls4mlprj_multiout_network')
 
 
 @pytest.fixture(scope='module')

--- a/test/pytest/test_multiout_network.py
+++ b/test/pytest/test_multiout_network.py
@@ -8,13 +8,14 @@ from tensorflow import keras
 from hls4ml.converters import convert_from_keras_model
 
 test_root_path = Path(__file__).parent
+test_root_path = Path('/tmp/hls4mlprj_multiout_network')
 
 
 @pytest.fixture(scope='module')
 def model():
     inp = keras.Input(shape=(10,))
-    x = Dense(10)(inp)
-    y = Dense(10)(inp)
+    x = Dense(10, name='dense1')(inp)
+    y = Dense(10, name='dense2')(inp)
     model = keras.Model(inp, [x, y])
     return model
 
@@ -31,9 +32,19 @@ def data():
 def test_multi_clone(model, data, backend: str, io_type: str):
     output_dir = str(test_root_path / f'hls4mlprj_multiout_network_{backend}_{io_type}')
     hls_config = {'Model': {'Precision': 'fixed<32,5>', 'ReuseFactor': 1}}
+    layer_config = {
+        'dense1': {'Precision': {'result': 'fixed<35,5>'}},
+        'dense2': {'Precision': {'result': 'fixed<40,5>'}},
+        'dense1_linear': {'Precision': {'result': 'fixed<35,5>'}},
+        'dense2_linear': {'Precision': {'result': 'fixed<40,5>'}},
+    }
+    hls_config['LayerName'] = layer_config
     model_hls = convert_from_keras_model(
         model, backend=backend, output_dir=output_dir, hls_config=hls_config, io_type=io_type
     )
+
+    assert model_hls.graph['dense1'].attributes['result_t'] != model_hls.graph['dense2'].attributes['result_t']
+
     model_hls.compile()
     r_hls = model_hls.predict(data)
     r_keras = [x.numpy() for x in model(data)]

--- a/test/pytest/test_multiout_network.py
+++ b/test/pytest/test_multiout_network.py
@@ -1,10 +1,7 @@
-import os
-import random
 from pathlib import Path
 
 import numpy as np
 import pytest
-import tensorflow as tf
 from keras.layers import Dense
 from tensorflow import keras
 
@@ -15,13 +12,6 @@ test_root_path = Path(__file__).parent
 
 @pytest.fixture(scope='module')
 def model():
-    seed = 42
-    os.environ['RANDOM_SEED'] = f'{seed}'
-    np.random.seed(seed)
-    tf.random.set_seed(seed)
-    tf.get_logger().setLevel('ERROR')
-    random.seed(seed)
-
     inp = keras.Input(shape=(10,))
     x = Dense(10)(inp)
     y = Dense(10)(inp)
@@ -31,8 +21,7 @@ def model():
 
 @pytest.fixture(scope='module')
 def data():
-    rng = np.random.RandomState(42)
-    X = rng.normal(0, 1, (1000, 10))
+    X = np.random.normal(0, 1, (1000, 10))
     X = np.clip(X, -16, 15)
     return X
 

--- a/test/pytest/test_stream_multi_clone.py
+++ b/test/pytest/test_stream_multi_clone.py
@@ -1,0 +1,62 @@
+import os
+import random
+from pathlib import Path
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from keras.layers import Add, Dense
+from tensorflow import keras
+
+from hls4ml.converters import convert_from_keras_model
+
+test_root_path = Path(__file__).parent
+
+
+# @pytest.fixture(scope='module')
+def model():
+    seed = 42
+    os.environ['RANDOM_SEED'] = f'{seed}'
+    np.random.seed(seed)
+    tf.random.set_seed(seed)
+    tf.get_logger().setLevel('ERROR')
+    random.seed(seed)
+
+    inp = keras.Input(shape=(10,))
+    x = Dense(10)(inp)
+    y = Dense(10)(inp)
+    z = Dense(10)(inp)
+    xy = Add()([x, y])  # 5
+    xy = Add()([xy, y])  # 5
+    model = keras.Model(inp, [xy, z])
+    return model
+
+
+# @pytest.fixture(scope='module')
+def data():
+    rng = np.random.RandomState(42)
+    X = rng.normal(0, 1, (1000, 10))
+    return X
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Quartus', 'Vitis'])
+def test_multi_clone(model, data, backend: str):
+    output_dir = str(test_root_path / f'hls4mlprj_stream_multi_clone_{backend}')
+    hls_config = {'Model': {'Precision': 'fixed<32,10>', 'ReuseFactor': 1}}
+    model_hls = convert_from_keras_model(
+        model,
+        backend=backend,
+        output_dir=output_dir,
+        hls_config=hls_config,
+        io_type='io_stream',  # clone only happens with stream io.
+    )
+    model_hls.compile()
+    r_hls = model_hls.predict(data)
+    r_keras = [x.numpy() for x in model(data)]
+
+    assert np.allclose(r_hls[0], r_keras[0], atol=5e-5, rtol=0)
+    assert np.allclose(r_hls[1], r_keras[1], atol=5e-5, rtol=0)
+
+
+if __name__ == '__main__':
+    test_multi_clone(model(), data(), 'Vivado')

--- a/test/pytest/test_stream_multi_clone.py
+++ b/test/pytest/test_stream_multi_clone.py
@@ -1,10 +1,7 @@
-import os
-import random
 from pathlib import Path
 
 import numpy as np
 import pytest
-import tensorflow as tf
 from keras.layers import Add, Dense
 from tensorflow import keras
 
@@ -15,13 +12,6 @@ test_root_path = Path(__file__).parent
 
 @pytest.fixture(scope='module')
 def model():
-    seed = 42
-    os.environ['RANDOM_SEED'] = f'{seed}'
-    np.random.seed(seed)
-    tf.random.set_seed(seed)
-    tf.get_logger().setLevel('ERROR')
-    random.seed(seed)
-
     inp = keras.Input(shape=(10,))
     x = Dense(10)(inp)
     y = Dense(10)(inp)
@@ -35,8 +25,7 @@ def model():
 
 @pytest.fixture(scope='module')
 def data():
-    rng = np.random.RandomState(42)
-    X = rng.normal(0, 1, (1000, 10))
+    X = np.random.normal(0, 1, (1000, 10))
     X = np.clip(X, -16, 15)
     return X
 


### PR DESCRIPTION
A# Description

Quartus writer writes uncompilable programs when there are multiple outputs with io_stream. This PR fixes that.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

`test/pytest/test_multiout_network.py`

**Test Configuration**:

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
