### PR TITLE
[DRAFT] Fix pooling accum_t autoset & avoid global override

### DIFF
--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -391,7 +391,7 @@ class VivadoBackend(FPGABackend):
         input_t = input_layer.attributes[input_layer.name].type
         accum_t = layer.attributes['accum_t']
         pool_op = layer.attributes['pool_op'].lower()
-        
+
         accum_t.name = f'{layer.name}_accum'
         # This was likely model_default
         # Avoid override parameters for other by chance


### PR DESCRIPTION
A# Description

No test at the moment - Fix a series of strange `accum_t` behaviors for pooling layers in the current version. Potential conflict with #855, would need to converge first before finalizing changes.

Strange behaviors:
- `model_default` precision overridden
- Extra integer bits were added, while the number of fp bits decreased 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Not yet available.

**Test Configuration**:

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
