### PR TITLE
add blank line to make rst format correct

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -90,6 +90,7 @@ Acknowledgments
 ===============
 If you benefited from participating in our community, we ask that you please acknowledge the Fast Machine Learning collaboration, and particular individuals who helped you, in any publications.
 Please use the following text for this acknowledgment:
+
   We acknowledge the Fast Machine Learning collective as an open community of multi-domain experts and collaborators. This community and \<names of individuals\>, in particular, were important for the development of this project.
 
 


### PR DESCRIPTION
# Description

Building the documentation locally indicated a need for an extra line to be legal [reStructuredText](https://docutils.sourceforge.io/rst.html).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Tests

Ran `make html` in the docs directory

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
