### PR TITLE
Update default FPGA part number from KU115 to VU13P

### DIFF
--- a/docs/api/configuration.rst
+++ b/docs/api/configuration.rst
@@ -70,7 +70,7 @@ It looks like this:
    OutputPredictions: keras/KERAS_3layer_predictions.dat
 
    # Backend section (Vivado backend)
-   Part: xcku115-flvb2104-2-i
+   Part: xcvu13p-flga2577-2-e
    ClockPeriod: 5
    IOType: io_parallel # options: io_parallel/io_stream
 
@@ -97,7 +97,7 @@ There are a number of configuration options that you have.  Let's go through the
 The backend-specific section of the configuration depends on the backend. You can get a starting point for the necessary settings using, for example `hls4ml.templates.get_backend('Vivado').create_initial_config()`.
 For Vivado backend the options are:
 
-* **Part**\ : the particular FPGA part number that you are considering, here it's a Xilinx Virtex-7 FPGA
+* **Part**\ : the particular FPGA part number that you are considering, here it's a Xilinx Virtex UltraScale+ VU13P FPGA
 * **ClockPeriod**\ : the clock period, in ns, at which your algorithm runs
   Then you have some optimization parameters for how your algorithm runs:
 * **IOType**\ : your options are ``io_parallel`` or ``io_stream`` which defines the type of data structure used for inputs, intermediate activations between layers, and outputs. For ``io_parallel``, arrays are used that, in principle, can be fully unrolled and are typically implemented in RAMs. For ``io_stream``, HLS streams are used, which are a more efficient/scalable mechanism to represent data that are produced and consumed in a sequential manner. Typically, HLS streams are implemented with FIFOs instead of RAMs. For more information see `here <https://docs.xilinx.com/r/en-US/ug1399-vitis-hls/pragma-HLS-stream>`__.

--- a/hls4ml/backends/quartus/quartus_backend.py
+++ b/hls4ml/backends/quartus/quartus_backend.py
@@ -127,7 +127,7 @@ class QuartusBackend(FPGABackend):
     def create_initial_config(self, part='Arria10', clock_period=5, io_type='io_parallel'):
         config = {}
 
-        config['Part'] = part
+        config['Part'] = part if part is not None else 'Arria10'
         config['ClockPeriod'] = clock_period
         config['IOType'] = io_type
         config['HLSConfig'] = {}

--- a/hls4ml/backends/quartus/quartus_backend.py
+++ b/hls4ml/backends/quartus/quartus_backend.py
@@ -127,7 +127,7 @@ class QuartusBackend(FPGABackend):
     def create_initial_config(self, part='Arria10', clock_period=5, io_type='io_parallel'):
         config = {}
 
-        config['Part'] = part if part is not None else 'Arria10'
+        config['Part'] = part
         config['ClockPeriod'] = clock_period
         config['IOType'] = io_type
         config['HLSConfig'] = {}

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -178,7 +178,7 @@ class VivadoBackend(FPGABackend):
     def create_initial_config(self, part='xcvu13p-flga2577-2-e', clock_period=5, io_type='io_parallel'):
         config = {}
 
-        config['Part'] = part
+        config['Part'] = part if part is not None else 'xcku115-flvb2104-2-i'
         config['ClockPeriod'] = clock_period
         config['IOType'] = io_type
         config['HLSConfig'] = {}

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -175,10 +175,10 @@ class VivadoBackend(FPGABackend):
     def get_writer_flow(self):
         return self._writer_flow
 
-    def create_initial_config(self, part='xcku115-flvb2104-2-i', clock_period=5, io_type='io_parallel'):
+    def create_initial_config(self, part='xcvu13p-flga2577-2-e', clock_period=5, io_type='io_parallel'):
         config = {}
 
-        config['Part'] = part if part is not None else 'xcku115-flvb2104-2-i'
+        config['Part'] = part if part is not None else 'xcvu13p-flga2577-2-e'
         config['ClockPeriod'] = clock_period
         config['IOType'] = io_type
         config['HLSConfig'] = {}

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -178,7 +178,7 @@ class VivadoBackend(FPGABackend):
     def create_initial_config(self, part='xcvu13p-flga2577-2-e', clock_period=5, io_type='io_parallel'):
         config = {}
 
-        config['Part'] = part if part is not None else 'xcvu13p-flga2577-2-e'
+        config['Part'] = part
         config['ClockPeriod'] = clock_period
         config['IOType'] = io_type
         config['HLSConfig'] = {}

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -178,7 +178,7 @@ class VivadoBackend(FPGABackend):
     def create_initial_config(self, part='xcvu13p-flga2577-2-e', clock_period=5, io_type='io_parallel'):
         config = {}
 
-        config['Part'] = part if part is not None else 'xcku115-flvb2104-2-i'
+        config['Part'] = part if part is not None else 'xcvu13p-flga2577-2-e'
         config['ClockPeriod'] = clock_period
         config['IOType'] = io_type
         config['HLSConfig'] = {}

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -74,7 +74,7 @@ def parse_yaml_config(config_file):
         KerasH5: my_keras_model.h5
         OutputDir: my-hls-test
         ProjectName: myproject
-        Part: xcku115-flvb2104-2-i
+        Part: xcvu13p-flga2577-2-e
         ClockPeriod: 5
         IOType: io_stream
         HLSConfig:

--- a/scripts/hls4ml
+++ b/scripts/hls4ml
@@ -40,7 +40,7 @@ def main():
     )
     config_parser.add_argument('-p', '--project', help='Project name', default='myproject')
     config_parser.add_argument('-d', '--dir', help='Project output directory', default='my-hls-test')
-    config_parser.add_argument('-f', '--fpga', help='FPGA part', default='xcku115-flvb2104-2-i')
+    config_parser.add_argument('-f', '--fpga', help='FPGA part', default='xcvu13p-flga2577-2-e')
     config_parser.add_argument('-bo', '--board', help='Board used.', default='pynq-z2')
     config_parser.add_argument(
         '-ba', '--backend', help='Backend to use (Vivado, VivadoAccelerator, Quartus)', default='Vivado'


### PR DESCRIPTION
# Description

- Update default FPGA part number from KU115 to VU13P, as more commonly used by hls4ml users (e.g., for CMS Phase-2 Level-1 Trigger)

## Type of change

- [x] Documentation update
- [x] Other: Default configuration change

## Tests

- Checking in CI

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
