### PR TITLE
Fix for multiple inputs that may get out of order

### DIFF
--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -343,7 +343,7 @@ class ModelGraph:
         input_layers = inputs if inputs is not None else [layer_list[0]['name']]
         output_layers = outputs if outputs is not None else [layer_list[-1]['name']]
         self.inputs = self._find_output_variable_names(layer_list, input_layers)
-        if self.inputs != input_layers:
+        if sorted(self.inputs) != sorted(input_layers):
             raise RuntimeError(
                 "Currently only support the case when input variables and input layer names match\n"
                 + f"Input layers = {input_layers}, input_vars = {self.inputs}"

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -343,7 +343,7 @@ class ModelGraph:
         input_layers = inputs if inputs is not None else [layer_list[0]['name']]
         output_layers = outputs if outputs is not None else [layer_list[-1]['name']]
         self.inputs = self._find_output_variable_names(layer_list, input_layers)
-        if sorted(self.inputs) != sorted(input_layers):
+        if self.inputs != input_layers:
             raise RuntimeError(
                 "Currently only support the case when input variables and input layer names match\n"
                 + f"Input layers = {input_layers}, input_vars = {self.inputs}"
@@ -362,9 +362,12 @@ class ModelGraph:
             self.apply_flow(flow)
 
     def _find_output_variable_names(self, layer_list, layer_names):
-        """Given a list of all layers, and a list input/output names, find the names of the their outputs that will be used
+        """Given a list of all layers, and a list input/output names, find the names of their outputs that will be used
         as the name of the output variables."""
-        inout_nodes = [node for node in layer_list if node['name'] in layer_names]
+        inout_nodes = []
+        for layer_name in layer_names:
+            for node in layer_list:
+                if node['name'] == layer_name: inout_nodes.append(node)
         all_node_output_names = [node['outputs'] if 'outputs' in node else [node['name']] for node in inout_nodes]
         return [output for node_output_names in all_node_output_names for output in node_output_names]  # to flatten
 

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -367,7 +367,8 @@ class ModelGraph:
         inout_nodes = []
         for layer_name in layer_names:
             for node in layer_list:
-                if node['name'] == layer_name: inout_nodes.append(node)
+                if node['name'] == layer_name:
+                    inout_nodes.append(node)
         all_node_output_names = [node['outputs'] if 'outputs' in node else [node['name']] for node in inout_nodes]
         return [output for node_output_names in all_node_output_names for output in node_output_names]  # to flatten
 

--- a/test/pytest/test_merge.py
+++ b/test/pytest/test_merge.py
@@ -28,7 +28,10 @@ def test_merge(merge_layer, io_type, backend, swap_inputs):
     model.compile()
 
     config = hls4ml.utils.config_from_keras_model(model, default_precision='ap_fixed<32,16>')
-    output_dir = str(test_root_path / f'hls4mlprj_merge_{"swap_inputs_" if swap_inputs else ""}{merge_layer.__name__.lower()}_{backend}_{io_type}')
+    output_dir = str(
+        test_root_path
+        / f'hls4mlprj_merge_{"swap_inputs_" if swap_inputs else ""}{merge_layer.__name__.lower()}_{backend}_{io_type}'
+    )
     hls_model = hls4ml.converters.convert_from_keras_model(
         model, hls_config=config, output_dir=output_dir, io_type=io_type, backend=backend
     )

--- a/test/pytest/test_merge.py
+++ b/test/pytest/test_merge.py
@@ -13,18 +13,22 @@ test_root_path = Path(__file__).parent
 @pytest.mark.parametrize('merge_layer', [Add, Average, Maximum, Minimum, Multiply, Subtract])
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
 @pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus'])
-def test_merge(merge_layer, io_type, backend):
+@pytest.mark.parametrize('swap_inputs', [True, False])
+def test_merge(merge_layer, io_type, backend, swap_inputs):
     input_shape = (10, 10, 3)
 
     in1 = Input(shape=input_shape)
     in2 = Input(shape=input_shape)
-    out = merge_layer()([in1, in2])
+    if swap_inputs:
+        out = merge_layer()([in2, in1])
+    else:
+        out = merge_layer()([in1, in2])
 
     model = tf.keras.models.Model(inputs=[in1, in2], outputs=out)
     model.compile()
 
     config = hls4ml.utils.config_from_keras_model(model, default_precision='ap_fixed<32,16>')
-    output_dir = str(test_root_path / f'hls4mlprj_merge_{merge_layer.__name__.lower()}_{backend}_{io_type}')
+    output_dir = str(test_root_path / f'hls4mlprj_merge_{"swap_inputs_" if swap_inputs else ""}{merge_layer.__name__.lower()}_{backend}_{io_type}')
     hls_model = hls4ml.converters.convert_from_keras_model(
         model, hls_config=config, output_dir=output_dir, io_type=io_type, backend=backend
     )


### PR DESCRIPTION
Fix for multiple inputs that may be in a different order than the order in which the model uses them. Should I add a specific test for this?

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

This breaks in the current main
```python
import hls4ml
from tensorflow.keras.models import Model
from tensorflow.keras.layers import Dense, Input, Add

input_1 = Input(shape=(10), name='input_1')
input_2 = Input(shape=(10), name='input_2')
x = Dense(10, name='dense_1')(input_2)
outputs = Add(name='add_1')([x, input_1])
model = Model(inputs=[input_1, input_2], outputs=outputs, name='model_1')
model.summary()

config = hls4ml.utils.config_from_keras_model(model, granularity='model')
hls_model = hls4ml.converters.convert_from_keras_model(model,
                                                       hls_config=config,
                                                       io_type='io_parallel',
                                                       output_dir='test_fix',
                                                       part='xcvu13p-flga2577-2-e',
                                                       clock_period=5)
hls_model.compile()
```

with the error message:

```
RuntimeError: Currently only support the case when input variables and input layer names match
Input layers = ['input_1', 'input_2'], input_vars = ['input_2', 'input_1']
```

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
