### PR TITLE
Fix profiling for Keras LSTM layers. 

### DIFF
--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -272,9 +272,11 @@ def _keras_batchnorm(layer):
 def _keras_layer(layer):
     return layer.get_weights(), ['w', 'b']
 
+def _keras_lstm(layer):
+    return layer.get_weights(), ['w', 'u', 'b']
 
 keras_process_layer_map = defaultdict(
-    lambda: _keras_layer, {'BatchNormalization': _keras_batchnorm, 'QBatchNormalization': _keras_batchnorm}
+    lambda: _keras_layer, {'BatchNormalization': _keras_batchnorm, 'QBatchNormalization': _keras_batchnorm, 'LSTM': _keras_lstm, 'QLSTM': _keras_lstm}
 )
 
 

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -272,11 +272,19 @@ def _keras_batchnorm(layer):
 def _keras_layer(layer):
     return layer.get_weights(), ['w', 'b']
 
+
 def _keras_lstm(layer):
     return layer.get_weights(), ['w', 'u', 'b']
 
+
 keras_process_layer_map = defaultdict(
-    lambda: _keras_layer, {'BatchNormalization': _keras_batchnorm, 'QBatchNormalization': _keras_batchnorm, 'LSTM': _keras_lstm, 'QLSTM': _keras_lstm}
+    lambda: _keras_layer,
+    {
+        'BatchNormalization': _keras_batchnorm,
+        'QBatchNormalization': _keras_batchnorm,
+        'LSTM': _keras_lstm,
+        'QLSTM': _keras_lstm,
+    },
 )
 
 


### PR DESCRIPTION
# Description

Before it for Keras LSTM it throws IndexError: list index out of range.
I know, that there is a low chance that it will be run without the HLS model, but still would be good to set properly. 

## Type of change


- [X] Bug fix (non-breaking change that fixes an issue)

## Tests

```
import hls4ml
from tensorflow.keras.models import Model
from tensorflow.keras.layers import Conv1D, Activation, MaxPooling1D, LSTM, Dense, Input

input = Input(shape = (600, 10 ), name = 'input')
    
x = Conv1D(
    filters = 4,
    kernel_size = 3,
    strides = 1,
    padding = 'valid',
    name = 'conv_1',
)(input)

x = Activation(
    'relu',
    name = 'conv_act_1'
)(x)
x = MaxPooling1D(
    pool_size = 3,
    padding = 'valid',
    name = 'pool_1'
)(x)
x = LSTM(16, name = 'lstm')(x)
x = Dense(10, name = 'dense')(x)

model = Model(inputs = input, outputs = x)
hls4ml.model.profiling.numerical(model = model, hls_model = None)
```



## Checklist

- [X] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
