### PR TITLE
Pytorch upsample support

### DIFF
--- a/hls4ml/converters/pytorch/convolution.py
+++ b/hls4ml/converters/pytorch/convolution.py
@@ -47,7 +47,7 @@ def parse_conv1d_layer(operation, layer_name, input_names, input_shapes, node, c
     layer['pad_left'] = pad_left
     layer['pad_right'] = pad_right
 
-    output_shape = [input_shapes[0][0], layer['n_filt'], layer['out_width']]  # Channel first as default
+    output_shape = [layer['n_filt'], layer['out_width']]  # Channel first as default
 
     return layer, output_shape
 
@@ -102,6 +102,6 @@ def parse_conv2d_layer(operation, layer_name, input_names, input_shapes, node, c
         class_object.dilation[1],
     )
 
-    output_shape = [input_shapes[0][0], layer['n_filt'], layer['out_height'], layer['out_width']]
+    output_shape = [layer['n_filt'], layer['out_height'], layer['out_width']]
 
     return layer, output_shape

--- a/hls4ml/converters/pytorch/pooling.py
+++ b/hls4ml/converters/pytorch/pooling.py
@@ -63,6 +63,7 @@ def parse_pooling_layer(operation, layer_name, input_names, input_shapes, node, 
             output_shape = [input_shapes[0][0], layer['n_filt'], layer['n_out']]
 
     elif int(layer['class_name'][-2]) == 2:
+        print(input_shapes)
         (layer['in_height'], layer['in_width'], layer['n_filt']) = parse_data_format(input_shapes[0], layer['data_format'])
 
         if node.op == 'call_module':
@@ -129,8 +130,8 @@ def parse_pooling_layer(operation, layer_name, input_names, input_shapes, node, 
         )
 
         if layer['data_format'] == 'channels_last':
-            output_shape = [input_shapes[0][0], layer['out_height'], layer['out_width'], layer['n_filt']]
+            output_shape = [layer['out_height'], layer['out_width'], layer['n_filt']]
         elif layer['data_format'] == 'channels_first':
-            output_shape = [input_shapes[0][0], layer['n_filt'], layer['out_height'], layer['out_width']]
+            output_shape = [layer['n_filt'], layer['out_height'], layer['out_width']]
 
     return layer, output_shape

--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -138,9 +138,7 @@ def parse_flatten_layer(
         end_dim = end_dim + 1
 
     layer["target_shape"] = (
-        input_shapes[0][0:start_dim]
-        + [np.prod(input_shapes[0][start_dim:end_dim])]
-        + input_shapes[0][end_dim:]
+        input_shapes[0][0:start_dim] + [np.prod(input_shapes[0][start_dim:end_dim])] + input_shapes[0][end_dim:]
     )
     output_shape = layer["target_shape"]
 
@@ -166,9 +164,7 @@ def handle_upsample(
     layer["data_format"] = "channels_first"  # Pytorch default (can't change)
 
     # Input info
-    (layer["in_height"], layer["in_width"], layer["n_chan"]) = parse_data_format(
-        input_shapes[0], "channels_first"
-    )  # K
+    (layer["in_height"], layer["in_width"], layer["n_chan"]) = parse_data_format(input_shapes[0], "channels_first")  # K
 
     layer["height_factor"] = int(class_object.scale_factor)
     layer["width_factor"] = int(class_object.scale_factor)

--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -914,11 +914,11 @@ class Resize(Layer):
     def initialize(self):
         inp = self.get_input_variable()
         if len(inp.shape) == 2:  # 1D -> width + chan
-            shape = [self.get_attr('out_width'), self.get_attr('n_chan')]
-            dims = [f'OUT_WIDTH_{self.index}', f'N_CHAN_{self.index}']
+            shape = [self.get_attr('out_width'), self.get_attr('n_chan')] if self.get_attr('data_format') == 'channels_last' else [self.get_attr('n_chan'), self.get_attr('out_width')]
+            dims = [f'OUT_WIDTH_{self.index}', f'N_CHAN_{self.index}'] if self.get_attr('data_format') == 'channels_last' else [f'N_CHAN_{self.index}', f'OUT_WIDTH_{self.index}']
         elif len(inp.shape) == 3:  # 2D -> height + width + chan
-            shape = [self.get_attr('out_height'), self.get_attr('out_width'), self.get_attr('n_chan')]
-            dims = [f'OUT_HEIGHT_{self.index}', f'OUT_WIDTH_{self.index}', f'N_CHAN_{self.index}']
+            shape = [self.get_attr('out_height'), self.get_attr('out_width'), self.get_attr('n_chan')] if self.get_attr('data_format') == 'channels_last' else [self.get_attr('n_chan'), self.get_attr('out_height'), self.get_attr('out_width')]
+            dims = [f'OUT_HEIGHT_{self.index}', f'OUT_WIDTH_{self.index}', f'N_CHAN_{self.index}'] if self.get_attr('data_format') == 'channels_last'  else [f'N_CHAN_{self.index}', f'OUT_HEIGHT_{self.index}', f'OUT_WIDTH_{self.index}']
         self.add_output_variable(shape, dims, precision=inp.type.precision)
 
 
@@ -1366,6 +1366,7 @@ layer_map = {
     'Resize': Resize,
     'UpSampling1D': Resize,
     'UpSampling2D': Resize,
+    'Upsample': Resize,
     'Transpose': Transpose,
     'Embedding': Embedding,
     'SimpleRNN': SimpleRNN,


### PR DESCRIPTION
**Adding PyTorch Upsample Layer Support and Fixing Output Shape Batch Dimension**

Description:
This PR introduces support for PyTorch Upsample layers and addresses a bug related to output shapes in pytorch convolution and pooling handlers:

Commit 1 (bug fix):

Description: Fixing output shapes by removing the unexpected batch dimension.
Details: Resolved an issue where the batch dimension was present in output shapes for each handler, which was not expected input for [parse_data_format](https://github.com/fastmachinelearning/hls4ml/blob/eb70a61d0da77d880de055065e3837de5846cc72/hls4ml/converters/utils.py#L4).

Commit 2 (adding layer support):

Description: Adding support for PyTorch Upsample layers.
Details: Implemented PyTorch Upsample handler and revised the `Resize` layer to handle `channel_first` input (default to Pytorch).