### PR TITLE
Remove double transpose for Conv2DBatchnorm

### DIFF
--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -557,16 +557,8 @@ class Conv2DBatchnorm(Conv2D):
     def initialize(self):
         super().initialize()
         folded_weights, folded_bias = self._get_folded_weights()
-        if self.model.config.is_resource_strategy(self) and self.model.config.backend.name in [
-            'Vivado',
-            'VivadoAccelerator',
-        ]:
-            self.weights['weight'].data_unquantized = np.transpose(folded_weights, axes=[3, 0, 1, 2])
-            self.weights['weight'].data = self.get_attr('weight_quantizer')(self.weights['weight'].data_unquantized)
-
-        else:
-            self.weights['weight'].data_unquantized = folded_weights
-            self.weights['weight'].data = self.get_attr('weight_quantizer')(folded_weights)
+        self.weights['weight'].data_unquantized = folded_weights
+        self.weights['weight'].data = self.get_attr('weight_quantizer')(folded_weights)
         self.weights['bias'].data_unquantized = folded_bias
         bias_q = self.get_attr('bias_quantizer')
         if bias_q is not None:


### PR DESCRIPTION
# Description

In the `layers.py` `Conv2DBatchnorm` makes a transpose if it is the resource strategy, but only for `Vivado` and `VivadoAccelerator` backends. Note that `Conv2DBatchnorm` inherits from `Conv2D`, and `Conv2D` makes the same transpose in:

https://github.com/fastmachinelearning/hls4ml/blob/main/hls4ml/backends/vivado/passes/resource_strategy.py#L29-L32

I think therefore the transpose is doubly-applied. I am therefore removing the backend-specific transpose in the `layers.py`, which regardless does not belong there.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

I assume there's a `Conv2DBatchnorm` test that will catch this change, but maybe not.

**Test Configuration**:

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
