### PR TITLE
vitis backend tarball fix

### DIFF
--- a/hls4ml/writer/vitis_writer.py
+++ b/hls4ml/writer/vitis_writer.py
@@ -30,3 +30,5 @@ class VitisWriter(VivadoWriter):
         """
         super().write_hls(model)
         self.write_nnet_utils_overrides(model)
+        os.remove(model.config.get_output_dir() + '.tar.gz')
+        self.write_tar(model)


### PR DESCRIPTION
A# Description

As the current vitis writer only overwrites the headers in `nnet_utils` after calling the `vivado_writer`, the tarball produced is with vivado configurations. This PR overrides the tarball generated also.

(Though, do we need to keep the tarball?)

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
