### PR TITLE
Upsampling support for PyTorch models

### DIFF
--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -911,14 +911,34 @@ class BiasAdd(Merge):  # TensorFlow's operator that gets merged into Dense/Conv
 
 
 class Resize(Layer):
+    _expected_attributes = [
+        Attribute('in_height'),
+        Attribute('in_width'),
+        Attribute('out_height'),
+        Attribute('out_width'),
+        Attribute('n_chan'),
+        ChoiceAttribute('algorithm', ['nearest', 'bilinear'], default='nearest'),
+        Attribute('align_corners', value_type=bool, default=False),
+    ]
+
     def initialize(self):
         inp = self.get_input_variable()
-        if len(inp.shape) == 2:  # 1D -> width + chan
-            shape = [self.get_attr('out_width'), self.get_attr('n_chan')]
-            dims = [f'OUT_WIDTH_{self.index}', f'N_CHAN_{self.index}']
-        elif len(inp.shape) == 3:  # 2D -> height + width + chan
-            shape = [self.get_attr('out_height'), self.get_attr('out_width'), self.get_attr('n_chan')]
-            dims = [f'OUT_HEIGHT_{self.index}', f'OUT_WIDTH_{self.index}', f'N_CHAN_{self.index}']
+
+        if self.get_attr('data_format') == 'channels_last':
+            if len(inp.shape) == 2:  # 1D -> width + chan
+                shape = [self.get_attr('out_width'), self.get_attr('n_chan')]
+                dims = [f'OUT_WIDTH_{self.index}', f'N_CHAN_{self.index}']
+            elif len(inp.shape) == 3:  # 2D -> height + width + chan
+                shape = [self.get_attr('out_height'), self.get_attr('out_width'), self.get_attr('n_chan')]
+                dims = [f'OUT_HEIGHT_{self.index}', f'OUT_WIDTH_{self.index}', f'N_CHAN_{self.index}']
+        else:
+            if len(inp.shape) == 2:  # 1D -> width + chan
+                shape = [self.get_attr('n_chan'), self.get_attr('out_width')]
+                dims = [f'N_CHAN_{self.index}', f'OUT_WIDTH_{self.index}']
+            elif len(inp.shape) == 3:  # 2D -> height + width + chan
+                shape = [self.get_attr('n_chan'), self.get_attr('out_height'), self.get_attr('out_width')]
+                dims = [f'N_CHAN_{self.index}', f'OUT_HEIGHT_{self.index}', f'OUT_WIDTH_{self.index}']
+
         self.add_output_variable(shape, dims, precision=inp.type.precision)
 
 

--- a/test/pytest/test_upsampling_pytorch.py
+++ b/test/pytest/test_upsampling_pytorch.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+import hls4ml
+
+test_root_path = Path(__file__).parent
+
+in_height = 6
+in_width = 8
+in_feat = 4
+
+size = 2
+atol = 5e-3
+
+
+@pytest.fixture(scope='module')
+def data_1d():
+    X = np.random.rand(100, in_feat, in_width)
+    return X
+
+
+@pytest.fixture(scope='module')
+def data_2d():
+    X = np.random.rand(100, in_feat, in_height, in_width)
+    return X
+
+
+class Upsample1DModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.upsample = nn.Upsample(scale_factor=2)
+
+    def forward(self, x):
+        return self.upsample(x)
+
+
+class Upsample2DModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # this scale_factor tests proper output shape calculation with fractional scaling and parsing per-axis scales
+        self.upsample = nn.UpsamplingNearest2d(scale_factor=(1, 2.4))  # Would also work with Upsample(mode='nearest')
+
+    def forward(self, x):
+        return self.upsample(x)
+
+
+@pytest.mark.parametrize('io_type', ['io_stream', 'io_parallel'])
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus'])
+def test_pytorch_upsampling1d(data_1d, io_type, backend):
+    model = Upsample1DModel()
+
+    config = hls4ml.utils.config_from_pytorch_model(
+        model,
+        default_precision='ap_fixed<16,6>',
+        inputs_channel_last=True,  # We don't test channels_last conversion here
+        transpose_outputs=False,
+    )
+    odir = str(test_root_path / f'hls4mlprj_pytorch_upsampling_1d_{backend}_{io_type}')
+    hls_model = hls4ml.converters.convert_from_pytorch_model(
+        model, (None, in_feat, in_width), hls_config=config, io_type=io_type, output_dir=odir, backend=backend
+    )
+    hls_model.compile()
+
+    data_1d_t = np.ascontiguousarray(data_1d.transpose([0, 2, 1]))
+
+    pytorch_prediction = model(torch.Tensor(data_1d)).detach().numpy()
+    hls_prediction = hls_model.predict(data_1d_t)
+
+    pred_shape = list(pytorch_prediction.shape)
+    pred_shape.append(pred_shape.pop(1))  # Transpose shape to channels_last
+    hls_prediction = hls_prediction.reshape(pred_shape).transpose([0, 2, 1])  # Transpose back
+
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=1e-2, atol=0.01)
+
+
+@pytest.mark.parametrize('io_type', ['io_parallel'])  # Fractional scaling doesn't work with io_stream
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus'])
+def test_pytorch_upsampling2d(data_2d, io_type, backend):
+    model = Upsample2DModel()
+
+    config = hls4ml.utils.config_from_pytorch_model(
+        model,
+        default_precision='ap_fixed<16,6>',
+        inputs_channel_last=False,  # With conversion to channels_last
+        transpose_outputs=True,
+    )
+    odir = str(test_root_path / f'hls4mlprj_pytorch_upsampling_2d_{backend}_{io_type}')
+    hls_model = hls4ml.converters.convert_from_pytorch_model(
+        model, (None, in_feat, in_height, in_width), hls_config=config, io_type=io_type, output_dir=odir, backend=backend
+    )
+    hls_model.compile()
+
+    pytorch_prediction = model(torch.Tensor(data_2d)).detach().numpy().flatten()
+    hls_prediction = hls_model.predict(data_2d).flatten()
+
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=1e-2, atol=0.01)


### PR DESCRIPTION
# Description

Support for parsing `Upsample` layers that was started in #951. This one is more robust, supports 2d tensors and includes a test case.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

There's a new test in `test_upsampling_pytorch.py`.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
