### PR TITLE
Fix cleanup of synthesis tests (leftover from 927)

### DIFF
--- a/test/cleanup.sh
+++ b/test/cleanup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 failed=0
-basedir=vivado_prj
+basedir=hls_prj
 all=0
 
 function print_usage {


### PR DESCRIPTION
# Description

Synthesis tests on correlator2 fail at the last stage (cleanup) due to a incorrect base directory used in search. This was left out of the changes in #927.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Synthesis tests will pass with this change.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
