### PR TITLE
Fix sphinx by pinning tensorflow<=2.15

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,15 +1,8 @@
 .
-h5py
-matplotlib
-numpy
-onnx>=1.4.0
-pandas
-pyyaml
-seaborn
 setuptools_scm[toml]>=5
 sphinx>=3.2.1
 sphinx_contributors
 sphinx_github_changelog
 sphinx_rtd_theme
-tensorflow
+tensorflow<=2.15
 toposort>=1.5.0


### PR DESCRIPTION
As discussed in the hls4ml meeting today, this PR attempts to fix the sphinx environment by pinning tensorflow<=2.15 temporarily until related dependencies are fixed.