### PR TITLE
add protection for when kernel_quantizer is None

### DIFF
--- a/hls4ml/converters/keras/qkeras.py
+++ b/hls4ml/converters/keras/qkeras.py
@@ -9,7 +9,9 @@ from hls4ml.model.types import FixedPrecisionType
 
 
 def get_quantizer_from_config(keras_layer, quantizer_var):
-    quantizer_config = keras_layer['config'][f'{quantizer_var}_quantizer']
+    quantizer_config = keras_layer['config'].get(f'{quantizer_var}_quantizer', None)
+    if quantizer_config is None:
+        return None  # No quantizer specified in the layer
     if keras_layer['class_name'] == 'QBatchNormalization':
         return QKerasQuantizer(quantizer_config)
     elif 'binary' in quantizer_config['class_name']:
@@ -24,15 +26,8 @@ def get_quantizer_from_config(keras_layer, quantizer_var):
 def parse_qdense_layer(keras_layer, input_names, input_shapes, data_reader):
     layer, output_shape = parse_dense_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    if keras_layer['config']['kernel_quantizer'] is not None:
-        layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
-    else:
-        layer['weight_quantizer'] = None
-
-    if keras_layer['config']['bias_quantizer'] is not None:
-        layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
-    else:
-        layer['bias_quantizer'] = None
+    layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
+    layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
 
     return layer, output_shape
 
@@ -46,15 +41,8 @@ def parse_qconv_layer(keras_layer, input_names, input_shapes, data_reader):
     elif '2D' in keras_layer['class_name']:
         layer, output_shape = parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    if keras_layer['config']['kernel_quantizer'] is not None:
-        layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
-    else:
-        layer['weight_quantizer'] = None
-
-    if keras_layer['config']['bias_quantizer'] is not None:
-        layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
-    else:
-        layer['bias_quantizer'] = None
+    layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
+    layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
 
     return layer, output_shape
 
@@ -63,14 +51,8 @@ def parse_qconv_layer(keras_layer, input_names, input_shapes, data_reader):
 def parse_qdepthwiseqconv_layer(keras_layer, input_names, input_shapes, data_reader):
     layer, output_shape = parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    if keras_layer['config']['depthwise_quantizer'] is not None:
-        layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'depthwise')
-    else:
-        layer['depthwise_quantizer'] = None
-    if keras_layer['config']['bias_quantizer'] is not None:
-        layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
-    else:
-        layer['bias_quantizer'] = None
+    layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'depthwise')
+    layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
 
     return layer, output_shape
 
@@ -84,19 +66,9 @@ def parse_qsepconv_layer(keras_layer, input_names, input_shapes, data_reader):
     elif '2D' in keras_layer['class_name']:
         layer, output_shape = parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    if keras_layer['config']['depthwise_quantizer'] is not None:
-        layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'depthwise')
-    else:
-        layer['depthwise_quantizer'] = None
-    if keras_layer['config']['pointwise_quantizer'] is not None:
-        layer['pointwise_quantizer'] = get_quantizer_from_config(keras_layer, 'pointwise')
-    else:
-        layer['pointwise_quantizer'] = None
-
-    if keras_layer['config']['bias_quantizer'] is not None:
-        layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
-    else:
-        layer['bias_quantizer'] = None
+    layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'depthwise')
+    layer['pointwise_quantizer'] = get_quantizer_from_config(keras_layer, 'pointwise')
+    layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
 
     return layer, output_shape
 
@@ -107,19 +79,9 @@ def parse_qrnn_layer(keras_layer, input_names, input_shapes, data_reader):
 
     layer, output_shape = parse_rnn_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    if keras_layer['config']['kernel_quantizer'] is not None:
-        layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
-    else:
-        layer['weight_quantizer'] = None
-    if keras_layer['config']['recurrent_quantizer'] is not None:
-        layer['recurrent_quantizer'] = get_quantizer_from_config(keras_layer, 'recurrent')
-    else:
-        layer['recurrent_quantizer'] = None
-
-    if keras_layer['config']['bias_quantizer'] is not None:
-        layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
-    else:
-        layer['bias_quantizer'] = None
+    layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
+    layer['recurrent_quantizer'] = get_quantizer_from_config(keras_layer, 'recurrent')
+    layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
 
     return layer, output_shape
 

--- a/hls4ml/converters/keras/qkeras.py
+++ b/hls4ml/converters/keras/qkeras.py
@@ -24,7 +24,11 @@ def get_quantizer_from_config(keras_layer, quantizer_var):
 def parse_qdense_layer(keras_layer, input_names, input_shapes, data_reader):
     layer, output_shape = parse_dense_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
+    if keras_layer['config']['kernel_quantizer'] is not None:
+        layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
+    else:
+        layer['weight_quantizer'] = None
+
     if keras_layer['config']['bias_quantizer'] is not None:
         layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
     else:
@@ -42,7 +46,11 @@ def parse_qconv_layer(keras_layer, input_names, input_shapes, data_reader):
     elif '2D' in keras_layer['class_name']:
         layer, output_shape = parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
+    if keras_layer['config']['kernel_quantizer'] is not None:
+        layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
+    else:
+        layer['weight_quantizer'] = None
+
     if keras_layer['config']['bias_quantizer'] is not None:
         layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
     else:
@@ -55,8 +63,10 @@ def parse_qconv_layer(keras_layer, input_names, input_shapes, data_reader):
 def parse_qdepthwiseqconv_layer(keras_layer, input_names, input_shapes, data_reader):
     layer, output_shape = parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'depthwise')
-
+    if keras_layer['config']['depthwise_quantizer'] is not None:
+        layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'depthwise')
+    else:
+        layer['depthwise_quantizer'] = None
     if keras_layer['config']['bias_quantizer'] is not None:
         layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
     else:
@@ -74,8 +84,14 @@ def parse_qsepconv_layer(keras_layer, input_names, input_shapes, data_reader):
     elif '2D' in keras_layer['class_name']:
         layer, output_shape = parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'depthwise')
-    layer['pointwise_quantizer'] = get_quantizer_from_config(keras_layer, 'pointwise')
+    if keras_layer['config']['depthwise_quantizer'] is not None:
+        layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'depthwise')
+    else:
+        layer['depthwise_quantizer'] = None
+    if keras_layer['config']['pointwise_quantizer'] is not None:
+        layer['pointwise_quantizer'] = get_quantizer_from_config(keras_layer, 'pointwise')
+    else:
+        layer['pointwise_quantizer'] = None
 
     if keras_layer['config']['bias_quantizer'] is not None:
         layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
@@ -91,8 +107,14 @@ def parse_qrnn_layer(keras_layer, input_names, input_shapes, data_reader):
 
     layer, output_shape = parse_rnn_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
-    layer['recurrent_quantizer'] = get_quantizer_from_config(keras_layer, 'recurrent')
+    if keras_layer['config']['kernel_quantizer'] is not None:
+        layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
+    else:
+        layer['weight_quantizer'] = None
+    if keras_layer['config']['recurrent_quantizer'] is not None:
+        layer['recurrent_quantizer'] = get_quantizer_from_config(keras_layer, 'recurrent')
+    else:
+        layer['recurrent_quantizer'] = None
 
     if keras_layer['config']['bias_quantizer'] is not None:
         layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')


### PR DESCRIPTION
# Description

The hls4ml software assumes that in QKeras, QDense, QConv, etc, will always have kernel_quantizer or similar defined. This fixes the case when they are not, as found in issue #990.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Must first check that this doesn't break other tests. Whether we want to add a test for this particular situation I am not sure.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
