### PR TITLE
Split fpga_types into separate files

### DIFF
--- a/hls4ml/backends/catapult/catapult_backend.py
+++ b/hls4ml/backends/catapult/catapult_backend.py
@@ -4,7 +4,8 @@ import sys
 import numpy as np
 
 from hls4ml.backends import FPGABackend
-from hls4ml.backends.fpga.fpga_types import ACTypeConverter, CatapultArrayVariableConverter, HLSTypeConverter
+from hls4ml.backends.catapult.catapult_types import CatapultArrayVariableConverter
+from hls4ml.backends.fpga.fpga_types import ACTypeConverter, HLSTypeConverter
 from hls4ml.model.attributes import ChoiceAttribute, ConfigurableAttribute, TypeAttribute
 from hls4ml.model.flow import register_flow
 from hls4ml.model.layers import (

--- a/hls4ml/backends/catapult/catapult_types.py
+++ b/hls4ml/backends/catapult/catapult_types.py
@@ -1,0 +1,92 @@
+from hls4ml.backends.fpga.fpga_types import (
+    ArrayVariableConverter,
+    InplaceStreamVariableConverter,
+    StreamVariableConverter,
+    StructMemberVariableConverter,
+    VariableDefinition,
+)
+
+# region ArrayVariable
+
+
+class CatapultArrayVariableDefinition(VariableDefinition):
+    def definition_cpp(self, name_suffix='', as_reference=False):
+        return '{type} {name}{suffix}[{shape}] /* {pragma} */'.format(
+            type=self.type.name, name=self.name, suffix=name_suffix, shape=self.size_cpp(), pragma=self.pragma
+        )
+
+
+class CatapultInplaceArrayVariableDefinition(VariableDefinition):
+    def definition_cpp(self):
+        return f'auto& {self.name} = {self.input_var.name}'
+
+
+class CatapultArrayVariableConverter(ArrayVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(type_converter=type_converter, prefix='Catapult', definition_cls=CatapultArrayVariableDefinition)
+
+
+class CatapultInplaceArrayVariableConverter(ArrayVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(
+            type_converter=type_converter, prefix='Catapult', definition_cls=CatapultInplaceArrayVariableDefinition
+        )
+
+
+# endregion
+
+# region StructMemberVariable
+
+
+class CatapultStructMemberVariableDefinition(VariableDefinition):
+    def definition_cpp(self, name_suffix='', as_reference=False):
+        return '{type} {name}{suffix}[{shape}]'.format(
+            type=self.type.name, name=self.member_name, suffix=name_suffix, shape=self.size_cpp()
+        )
+
+
+class CatapultStructMemberVariableConverter(StructMemberVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(
+            type_converter=type_converter, prefix='Catapult', definition_cls=CatapultStructMemberVariableDefinition
+        )
+
+
+# endregion
+
+# region StreamVariable
+
+
+class CatapultStreamVariableDefinition(VariableDefinition):
+    def definition_cpp(self, name_suffix='', as_reference=False):
+        if as_reference:  # Function parameter
+            return f'ac_channel<{self.type.name}> &{self.name}{name_suffix}'
+        else:  # Declaration (string name arg not implemented in ac_channel)
+            return 'ac_channel<{type}> {name}{suffix}/*("{name}")*/'.format(
+                type=self.type.name, name=self.name, suffix=name_suffix
+            )
+
+
+class CatapultStreamVariableConverter(StreamVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(type_converter=type_converter, prefix='Catapult', definition_cls=CatapultStreamVariableDefinition)
+
+
+# endregion
+
+# region InplaceStreamVariable
+
+
+class CatapultInplaceStreamVariableDefinition(VariableDefinition):
+    def definition_cpp(self):
+        return f'auto& {self.name} = {self.input_var.name}'
+
+
+class CatapultInplaceStreamVariableConverter(InplaceStreamVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(
+            type_converter=type_converter, prefix='Catapult', definition_cls=CatapultInplaceStreamVariableDefinition
+        )
+
+
+# endregion

--- a/hls4ml/backends/catapult/passes/transform_types.py
+++ b/hls4ml/backends/catapult/passes/transform_types.py
@@ -1,12 +1,10 @@
-from hls4ml.backends.fpga.fpga_types import (
-    ACTypeConverter,
+from hls4ml.backends.catapult.catapult_types import (
     CatapultArrayVariableConverter,
     CatapultInplaceArrayVariableConverter,
     CatapultInplaceStreamVariableConverter,
     CatapultStreamVariableConverter,
-    HLSTypeConverter,
-    StaticWeightVariableConverter,
 )
+from hls4ml.backends.fpga.fpga_types import ACTypeConverter, HLSTypeConverter, StaticWeightVariableConverter
 from hls4ml.model.optimizer import GlobalOptimizerPass
 from hls4ml.model.types import InplaceTensorVariable
 

--- a/hls4ml/backends/fpga/fpga_types.py
+++ b/hls4ml/backends/fpga/fpga_types.py
@@ -248,24 +248,12 @@ class QuartusArrayVariableDefinition(VariableDefinition):
         )
 
 
-class CatapultArrayVariableDefinition(VariableDefinition):
-    def definition_cpp(self, name_suffix='', as_reference=False):
-        return '{type} {name}{suffix}[{shape}] /* {pragma} */'.format(
-            type=self.type.name, name=self.name, suffix=name_suffix, shape=self.size_cpp(), pragma=self.pragma
-        )
-
-
 class VivadoInplaceArrayVariableDefinition(VariableDefinition):
     def definition_cpp(self):
         return f'auto& {self.name} = {self.input_var.name}'
 
 
 class QuartusInplaceArrayVariableDefinition(VariableDefinition):
-    def definition_cpp(self):
-        return f'auto& {self.name} = {self.input_var.name}'
-
-
-class CatapultInplaceArrayVariableDefinition(VariableDefinition):
     def definition_cpp(self):
         return f'auto& {self.name} = {self.input_var.name}'
 
@@ -297,11 +285,6 @@ class QuartusArrayVariableConverter(ArrayVariableConverter):
         super().__init__(type_converter=type_converter, prefix='Quartus', definition_cls=QuartusArrayVariableDefinition)
 
 
-class CatapultArrayVariableConverter(ArrayVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(type_converter=type_converter, prefix='Catapult', definition_cls=CatapultArrayVariableDefinition)
-
-
 class VivadoInplaceArrayVariableConverter(ArrayVariableConverter):
     def __init__(self, type_converter):
         super().__init__(type_converter=type_converter, prefix='Vivado', definition_cls=VivadoInplaceArrayVariableDefinition)
@@ -314,26 +297,12 @@ class QuartusInplaceArrayVariableConverter(ArrayVariableConverter):
         )
 
 
-class CatapultInplaceArrayVariableConverter(ArrayVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(
-            type_converter=type_converter, prefix='Catapult', definition_cls=CatapultInplaceArrayVariableDefinition
-        )
-
-
 # endregion
 
 # region StructMemberVariable
 
 
 class QuartusStructMemberVariableDefinition(VariableDefinition):
-    def definition_cpp(self, name_suffix='', as_reference=False):
-        return '{type} {name}{suffix}[{shape}]'.format(
-            type=self.type.name, name=self.member_name, suffix=name_suffix, shape=self.size_cpp()
-        )
-
-
-class CatapultStructMemberVariableDefinition(VariableDefinition):
     def definition_cpp(self, name_suffix='', as_reference=False):
         return '{type} {name}{suffix}[{shape}]'.format(
             type=self.type.name, name=self.member_name, suffix=name_suffix, shape=self.size_cpp()
@@ -366,13 +335,6 @@ class QuartusStructMemberVariableConverter(StructMemberVariableConverter):
     def __init__(self, type_converter):
         super().__init__(
             type_converter=type_converter, prefix='Quartus', definition_cls=QuartusStructMemberVariableDefinition
-        )
-
-
-class CatapultStructMemberVariableConverter(StructMemberVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(
-            type_converter=type_converter, prefix='Catapult', definition_cls=CatapultStructMemberVariableDefinition
         )
 
 
@@ -409,21 +371,6 @@ class QuartusInplaceStreamVariableDefinition(VariableDefinition):
         return f'auto& {self.name} = {self.input_var.name}'
 
 
-class CatapultStreamVariableDefinition(VariableDefinition):
-    def definition_cpp(self, name_suffix='', as_reference=False):
-        if as_reference:  # Function parameter
-            return f'ac_channel<{self.type.name}> &{self.name}{name_suffix}'
-        else:  # Declaration (string name arg not implemented in ac_channel)
-            return 'ac_channel<{type}> {name}{suffix}/*("{name}")*/'.format(
-                type=self.type.name, name=self.name, suffix=name_suffix
-            )
-
-
-class CatapultInplaceStreamVariableDefinition(VariableDefinition):
-    def definition_cpp(self):
-        return f'auto& {self.name} = {self.input_var.name}'
-
-
 class StreamVariableConverter:
     def __init__(self, type_converter, prefix, definition_cls):
         self.type_converter = type_converter
@@ -453,11 +400,6 @@ class VivadoStreamVariableConverter(StreamVariableConverter):
 class QuartusStreamVariableConverter(StreamVariableConverter):
     def __init__(self, type_converter):
         super().__init__(type_converter=type_converter, prefix='Quartus', definition_cls=QuartusStreamVariableDefinition)
-
-
-class CatapultStreamVariableConverter(StreamVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(type_converter=type_converter, prefix='Catapult', definition_cls=CatapultStreamVariableDefinition)
 
 
 # endregion
@@ -490,13 +432,6 @@ class QuartusInplaceStreamVariableConverter(InplaceStreamVariableConverter):
     def __init__(self, type_converter):
         super().__init__(
             type_converter=type_converter, prefix='Quartus', definition_cls=QuartusInplaceStreamVariableDefinition
-        )
-
-
-class CatapultInplaceStreamVariableConverter(InplaceStreamVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(
-            type_converter=type_converter, prefix='Catapult', definition_cls=CatapultInplaceStreamVariableDefinition
         )
 
 

--- a/hls4ml/backends/fpga/fpga_types.py
+++ b/hls4ml/backends/fpga/fpga_types.py
@@ -241,19 +241,7 @@ class VivadoArrayVariableDefinition(VariableDefinition):
         )
 
 
-class QuartusArrayVariableDefinition(VariableDefinition):
-    def definition_cpp(self, name_suffix='', as_reference=False):
-        return '{type} {name}{suffix}[{shape}] {pragma}'.format(
-            type=self.type.name, name=self.name, suffix=name_suffix, shape=self.size_cpp(), pragma=self.pragma
-        )
-
-
 class VivadoInplaceArrayVariableDefinition(VariableDefinition):
-    def definition_cpp(self):
-        return f'auto& {self.name} = {self.input_var.name}'
-
-
-class QuartusInplaceArrayVariableDefinition(VariableDefinition):
     def definition_cpp(self):
         return f'auto& {self.name} = {self.input_var.name}'
 
@@ -280,33 +268,14 @@ class VivadoArrayVariableConverter(ArrayVariableConverter):
         super().__init__(type_converter=type_converter, prefix='Vivado', definition_cls=VivadoArrayVariableDefinition)
 
 
-class QuartusArrayVariableConverter(ArrayVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(type_converter=type_converter, prefix='Quartus', definition_cls=QuartusArrayVariableDefinition)
-
-
 class VivadoInplaceArrayVariableConverter(ArrayVariableConverter):
     def __init__(self, type_converter):
         super().__init__(type_converter=type_converter, prefix='Vivado', definition_cls=VivadoInplaceArrayVariableDefinition)
 
 
-class QuartusInplaceArrayVariableConverter(ArrayVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(
-            type_converter=type_converter, prefix='Quartus', definition_cls=QuartusInplaceArrayVariableDefinition
-        )
-
-
 # endregion
 
 # region StructMemberVariable
-
-
-class QuartusStructMemberVariableDefinition(VariableDefinition):
-    def definition_cpp(self, name_suffix='', as_reference=False):
-        return '{type} {name}{suffix}[{shape}]'.format(
-            type=self.type.name, name=self.member_name, suffix=name_suffix, shape=self.size_cpp()
-        )
 
 
 class StructMemberVariableConverter:
@@ -331,13 +300,6 @@ class StructMemberVariableConverter:
         return tensor_var
 
 
-class QuartusStructMemberVariableConverter(StructMemberVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(
-            type_converter=type_converter, prefix='Quartus', definition_cls=QuartusStructMemberVariableDefinition
-        )
-
-
 # endregion
 
 # region StreamVariable
@@ -354,19 +316,6 @@ class VivadoStreamVariableDefinition(VariableDefinition):
 
 
 class VivadoInplaceStreamVariableDefinition(VariableDefinition):
-    def definition_cpp(self):
-        return f'auto& {self.name} = {self.input_var.name}'
-
-
-class QuartusStreamVariableDefinition(VariableDefinition):
-    def definition_cpp(self, name_suffix='', as_reference=False):
-        if as_reference:  # Function parameter
-            return f'stream<{self.type.name}> &{self.name}{name_suffix}'
-        else:  # Declaration
-            return f'stream<{self.type.name}> {self.name}{name_suffix}'
-
-
-class QuartusInplaceStreamVariableDefinition(VariableDefinition):
     def definition_cpp(self):
         return f'auto& {self.name} = {self.input_var.name}'
 
@@ -397,11 +346,6 @@ class VivadoStreamVariableConverter(StreamVariableConverter):
         super().__init__(type_converter=type_converter, prefix='Vivado', definition_cls=VivadoStreamVariableDefinition)
 
 
-class QuartusStreamVariableConverter(StreamVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(type_converter=type_converter, prefix='Quartus', definition_cls=QuartusStreamVariableDefinition)
-
-
 # endregion
 
 # region InplaceStreamVariable
@@ -425,13 +369,6 @@ class VivadoInplaceStreamVariableConverter(InplaceStreamVariableConverter):
     def __init__(self, type_converter):
         super().__init__(
             type_converter=type_converter, prefix='Vivado', definition_cls=VivadoInplaceStreamVariableDefinition
-        )
-
-
-class QuartusInplaceStreamVariableConverter(InplaceStreamVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(
-            type_converter=type_converter, prefix='Quartus', definition_cls=QuartusInplaceStreamVariableDefinition
         )
 
 

--- a/hls4ml/backends/fpga/fpga_types.py
+++ b/hls4ml/backends/fpga/fpga_types.py
@@ -234,18 +234,6 @@ class VariableDefinition:
 # region ArrayVariable
 
 
-class VivadoArrayVariableDefinition(VariableDefinition):
-    def definition_cpp(self, name_suffix='', as_reference=False):
-        return '{type} {name}{suffix}[{shape}]'.format(
-            type=self.type.name, name=self.name, suffix=name_suffix, shape=self.size_cpp()
-        )
-
-
-class VivadoInplaceArrayVariableDefinition(VariableDefinition):
-    def definition_cpp(self):
-        return f'auto& {self.name} = {self.input_var.name}'
-
-
 class ArrayVariableConverter:
     def __init__(self, type_converter, prefix, definition_cls):
         self.type_converter = type_converter
@@ -261,16 +249,6 @@ class ArrayVariableConverter:
 
         tensor_var.__class__ = type(self.prefix + 'ArrayVariable', (type(tensor_var), self.definition_cls), {})
         return tensor_var
-
-
-class VivadoArrayVariableConverter(ArrayVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(type_converter=type_converter, prefix='Vivado', definition_cls=VivadoArrayVariableDefinition)
-
-
-class VivadoInplaceArrayVariableConverter(ArrayVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(type_converter=type_converter, prefix='Vivado', definition_cls=VivadoInplaceArrayVariableDefinition)
 
 
 # endregion
@@ -305,21 +283,6 @@ class StructMemberVariableConverter:
 # region StreamVariable
 
 
-class VivadoStreamVariableDefinition(VariableDefinition):
-    def definition_cpp(self, name_suffix='', as_reference=False):
-        if as_reference:  # Function parameter
-            return f'hls::stream<{self.type.name}> &{self.name}{name_suffix}'
-        else:  # Declaration
-            return 'hls::stream<{type}> {name}{suffix}("{name}")'.format(
-                type=self.type.name, name=self.name, suffix=name_suffix
-            )
-
-
-class VivadoInplaceStreamVariableDefinition(VariableDefinition):
-    def definition_cpp(self):
-        return f'auto& {self.name} = {self.input_var.name}'
-
-
 class StreamVariableConverter:
     def __init__(self, type_converter, prefix, definition_cls):
         self.type_converter = type_converter
@@ -341,11 +304,6 @@ class StreamVariableConverter:
         return tensor_var
 
 
-class VivadoStreamVariableConverter(StreamVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(type_converter=type_converter, prefix='Vivado', definition_cls=VivadoStreamVariableDefinition)
-
-
 # endregion
 
 # region InplaceStreamVariable
@@ -363,13 +321,6 @@ class InplaceStreamVariableConverter(StreamVariableConverter):
 
         tensor_var.__class__ = type(self.prefix + 'StreamVariable', (type(tensor_var), self.definition_cls), {})
         return tensor_var
-
-
-class VivadoInplaceStreamVariableConverter(InplaceStreamVariableConverter):
-    def __init__(self, type_converter):
-        super().__init__(
-            type_converter=type_converter, prefix='Vivado', definition_cls=VivadoInplaceStreamVariableDefinition
-        )
 
 
 # endregion

--- a/hls4ml/backends/quartus/passes/transform_types.py
+++ b/hls4ml/backends/quartus/passes/transform_types.py
@@ -1,12 +1,10 @@
-from hls4ml.backends.fpga.fpga_types import (
-    ACTypeConverter,
-    HLSTypeConverter,
+from hls4ml.backends.fpga.fpga_types import ACTypeConverter, HLSTypeConverter, StaticWeightVariableConverter
+from hls4ml.backends.quartus.quartus_types import (
     QuartusArrayVariableConverter,
     QuartusInplaceArrayVariableConverter,
     QuartusInplaceStreamVariableConverter,
     QuartusStreamVariableConverter,
     QuartusStructMemberVariableConverter,
-    StaticWeightVariableConverter,
 )
 from hls4ml.model.optimizer import GlobalOptimizerPass
 from hls4ml.model.types import InplaceTensorVariable

--- a/hls4ml/backends/quartus/quartus_types.py
+++ b/hls4ml/backends/quartus/quartus_types.py
@@ -1,0 +1,90 @@
+from hls4ml.backends.fpga.fpga_types import (
+    ArrayVariableConverter,
+    InplaceStreamVariableConverter,
+    StreamVariableConverter,
+    StructMemberVariableConverter,
+    VariableDefinition,
+)
+
+# region ArrayVariable
+
+
+class QuartusArrayVariableDefinition(VariableDefinition):
+    def definition_cpp(self, name_suffix='', as_reference=False):
+        return '{type} {name}{suffix}[{shape}] {pragma}'.format(
+            type=self.type.name, name=self.name, suffix=name_suffix, shape=self.size_cpp(), pragma=self.pragma
+        )
+
+
+class QuartusInplaceArrayVariableDefinition(VariableDefinition):
+    def definition_cpp(self):
+        return f'auto& {self.name} = {self.input_var.name}'
+
+
+class QuartusArrayVariableConverter(ArrayVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(type_converter=type_converter, prefix='Quartus', definition_cls=QuartusArrayVariableDefinition)
+
+
+class QuartusInplaceArrayVariableConverter(ArrayVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(
+            type_converter=type_converter, prefix='Quartus', definition_cls=QuartusInplaceArrayVariableDefinition
+        )
+
+
+# endregion
+
+# region StructMemberVariable
+
+
+class QuartusStructMemberVariableDefinition(VariableDefinition):
+    def definition_cpp(self, name_suffix='', as_reference=False):
+        return '{type} {name}{suffix}[{shape}]'.format(
+            type=self.type.name, name=self.member_name, suffix=name_suffix, shape=self.size_cpp()
+        )
+
+
+class QuartusStructMemberVariableConverter(StructMemberVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(
+            type_converter=type_converter, prefix='Quartus', definition_cls=QuartusStructMemberVariableDefinition
+        )
+
+
+# endregion
+
+# region StreamVariable
+
+
+class QuartusStreamVariableDefinition(VariableDefinition):
+    def definition_cpp(self, name_suffix='', as_reference=False):
+        if as_reference:  # Function parameter
+            return f'stream<{self.type.name}> &{self.name}{name_suffix}'
+        else:  # Declaration
+            return f'stream<{self.type.name}> {self.name}{name_suffix}'
+
+
+class QuartusInplaceStreamVariableDefinition(VariableDefinition):
+    def definition_cpp(self):
+        return f'auto& {self.name} = {self.input_var.name}'
+
+
+class QuartusStreamVariableConverter(StreamVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(type_converter=type_converter, prefix='Quartus', definition_cls=QuartusStreamVariableDefinition)
+
+
+# endregion
+
+# region InplaceStreamVariable
+
+
+class QuartusInplaceStreamVariableConverter(InplaceStreamVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(
+            type_converter=type_converter, prefix='Quartus', definition_cls=QuartusInplaceStreamVariableDefinition
+        )
+
+
+# endregion

--- a/hls4ml/backends/vivado/passes/transform_types.py
+++ b/hls4ml/backends/vivado/passes/transform_types.py
@@ -1,7 +1,5 @@
-from hls4ml.backends.fpga.fpga_types import (
-    APTypeConverter,
-    HLSTypeConverter,
-    StaticWeightVariableConverter,
+from hls4ml.backends.fpga.fpga_types import APTypeConverter, HLSTypeConverter, StaticWeightVariableConverter
+from hls4ml.backends.vivado.vivado_types import (
     VivadoArrayVariableConverter,
     VivadoInplaceArrayVariableConverter,
     VivadoInplaceStreamVariableConverter,

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -4,7 +4,8 @@ import sys
 import numpy as np
 
 from hls4ml.backends import FPGABackend
-from hls4ml.backends.fpga.fpga_types import APTypeConverter, HLSTypeConverter, VivadoArrayVariableConverter
+from hls4ml.backends.fpga.fpga_types import APTypeConverter, HLSTypeConverter
+from hls4ml.backends.vivado.vivado_types import VivadoArrayVariableConverter
 from hls4ml.model.attributes import ChoiceAttribute, ConfigurableAttribute, TypeAttribute
 from hls4ml.model.flow import register_flow
 from hls4ml.model.layers import (

--- a/hls4ml/backends/vivado/vivado_types.py
+++ b/hls4ml/backends/vivado/vivado_types.py
@@ -1,0 +1,70 @@
+from hls4ml.backends.fpga.fpga_types import (
+    ArrayVariableConverter,
+    InplaceStreamVariableConverter,
+    StreamVariableConverter,
+    VariableDefinition,
+)
+
+# region ArrayVariable
+
+
+class VivadoArrayVariableDefinition(VariableDefinition):
+    def definition_cpp(self, name_suffix='', as_reference=False):
+        return '{type} {name}{suffix}[{shape}]'.format(
+            type=self.type.name, name=self.name, suffix=name_suffix, shape=self.size_cpp()
+        )
+
+
+class VivadoInplaceArrayVariableDefinition(VariableDefinition):
+    def definition_cpp(self):
+        return f'auto& {self.name} = {self.input_var.name}'
+
+
+class VivadoArrayVariableConverter(ArrayVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(type_converter=type_converter, prefix='Vivado', definition_cls=VivadoArrayVariableDefinition)
+
+
+class VivadoInplaceArrayVariableConverter(ArrayVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(type_converter=type_converter, prefix='Vivado', definition_cls=VivadoInplaceArrayVariableDefinition)
+
+
+# endregion
+
+# region StreamVariable
+
+
+class VivadoStreamVariableDefinition(VariableDefinition):
+    def definition_cpp(self, name_suffix='', as_reference=False):
+        if as_reference:  # Function parameter
+            return f'hls::stream<{self.type.name}> &{self.name}{name_suffix}'
+        else:  # Declaration
+            return 'hls::stream<{type}> {name}{suffix}("{name}")'.format(
+                type=self.type.name, name=self.name, suffix=name_suffix
+            )
+
+
+class VivadoInplaceStreamVariableDefinition(VariableDefinition):
+    def definition_cpp(self):
+        return f'auto& {self.name} = {self.input_var.name}'
+
+
+class VivadoStreamVariableConverter(StreamVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(type_converter=type_converter, prefix='Vivado', definition_cls=VivadoStreamVariableDefinition)
+
+
+# endregion
+
+# region InplaceStreamVariable
+
+
+class VivadoInplaceStreamVariableConverter(InplaceStreamVariableConverter):
+    def __init__(self, type_converter):
+        super().__init__(
+            type_converter=type_converter, prefix='Vivado', definition_cls=VivadoInplaceStreamVariableDefinition
+        )
+
+
+# endregion


### PR DESCRIPTION
# Description

`fpga_types.py` became unwieldy due to all the types from various backends being stored there. To simplify things, we should split them into backend-specific files. This was observed in Catapult PR but agreed to be done afterwards

## Type of change

- [x] Other (Specify) - Code aesthetic improvement

## Tests

Nothing to test specifically. If the existing tests work, we're fine. Errors in this refactor would cause import issues so they would be obvious immediately.
