### PR TITLE
fix unwanted tested file change in #956

### DIFF
--- a/test/pytest/test_cnn_mnist.py
+++ b/test/pytest/test_cnn_mnist.py
@@ -61,7 +61,7 @@ def keras_model(mnist_data):
         ('Vitis', 'io_parallel', 'resource'),
         ('Vitis', 'io_parallel', 'latency'),
         ('Vitis', 'io_stream', 'latency'),
-        ('Vitis', 'io_stream', 'latency'),
+        ('Vitis', 'io_stream', 'resource'),
     ],
 )
 def test_mnist_cnn(keras_model, mnist_data, backend, io_type, strategy):


### PR DESCRIPTION
Revert the change (typo) made to `test/pytest/test_cnn_mnist.py` by #956, which breaks tests when using `pytest-xdist`.

- [x] Bug fix (non-breaking change that fixes an issue)