### PR TITLE
Update pytest docker image to 0.5.4

### DIFF
--- a/test/pytest/ci-template.yml
+++ b/test/pytest/ci-template.yml
@@ -1,10 +1,11 @@
 .pytest:
   stage: test
-  image: gitlab-registry.cern.ch/fastmachinelearning/hls4ml-testing:0.4.base
+  image: gitlab-registry.cern.ch/fastmachinelearning/hls4ml-testing:0.5.4.base
   tags:
     - k8s-default
   before_script:
     - source ~/.bashrc
+    - git config --global --add safe.directory /builds/fastmachinelearning/hls4ml
     - git submodule update --init --recursive hls4ml/templates/catapult/
     - if [ $EXAMPLEMODEL == 1 ]; then git submodule update --init example-models; fi
     - conda activate hls4ml-testing


### PR DESCRIPTION
# Description

Currently the pytest image is broken. This updates it to one based on RockyLinux9, python 3.10, and tensorflow 3.14. It should also enable qonnx and oneAPI tests. There are a few pytest failures, but those can be covered by other PRs, since they may merit more discussion, and currently our pytest environment is broken.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [x] Other (Specify)  -  Infrastructure

## Tests

This updates the test environment. There are some failures, but currently we have only failures for pytests.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
