### PR TITLE
Fix pre-commit warning and change '.h5' to '.keras' for written output

### DIFF
--- a/hls4ml/writer/catapult_writer.py
+++ b/hls4ml/writer/catapult_writer.py
@@ -884,7 +884,7 @@ class CatapultWriter(Writer):
         """
 
         def keras_model_representer(dumper, keras_model):
-            model_path = model.config.get_output_dir() + '/keras_model.h5'
+            model_path = model.config.get_output_dir() + '/keras_model.keras'
             keras_model.save(model_path)
             return dumper.represent_scalar('!keras_model', model_path)
 

--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -1322,7 +1322,7 @@ class QuartusWriter(Writer):
         """
 
         def keras_model_representer(dumper, keras_model):
-            model_path = model.config.get_output_dir() + '/keras_model.h5'
+            model_path = model.config.get_output_dir() + '/keras_model.keras'
             keras_model.save(model_path)
             return dumper.represent_scalar('!keras_model', model_path)
 

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -686,7 +686,7 @@ class VivadoWriter(Writer):
         """
 
         def keras_model_representer(dumper, keras_model):
-            model_path = model.config.get_output_dir() + '/keras_model.h5'
+            model_path = model.config.get_output_dir() + '/keras_model.keras'
             keras_model.save(model_path)
             return dumper.represent_scalar('!keras_model', model_path)
 

--- a/test/pytest/test_weight_writer.py
+++ b/test/pytest/test_weight_writer.py
@@ -29,5 +29,5 @@ def test_weight_writer(k, i, f):
     print(w_paths[0])
     assert len(w_paths) == 1
     w_loaded = np.loadtxt(w_paths[0], delimiter=',').reshape(1, 1)
-    print(f'{w[0,0]:.14}', f'{w_loaded[0,0]:.14}')
+    print(f'{w[0, 0]:.14}', f'{w_loaded[0, 0]:.14}')
     assert np.all(w == w_loaded)


### PR DESCRIPTION
# Description

When running pytests with the new docker image from #1005, some tests fail due to the writing of an .h5 file for reference in the output directory. It is considered depricated, and .keras is recommended. That is what this PR does.

One issue with doing this is that we would have to enforce a fairly new version of keras. But that may be fine if we move to 3.10 as our minimal python version in the near future. However, since this merits more discussion, I separated it from #1005.

The latest pre-commit flags the lack of a space after a comma, which this PR adds, though I am not convinced it better with the space. 

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Tests

The point is to fix already failing tests. Note, pytests won't actually be run till after #1005 is merged.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
