### PR TITLE
fixes for depth_multiplier in SeparableConv2d and DepthwiseConv2d

### DIFF
--- a/hls4ml/backends/catapult/passes/convolution_templates.py
+++ b/hls4ml/backends/catapult/passes/convolution_templates.py
@@ -137,11 +137,56 @@ conv2d_config_template = """struct config{index} : nnet::conv2d_config {{
     static const unsigned pad_right = {pad_right};
     static const unsigned in_height = {in_height};
     static const unsigned in_width = {in_width};
-    static const unsigned n_chan = {n_chan};
+    static const unsigned n_chan = {n_chan2};
     static const unsigned filt_height = {filt_height};
     static const unsigned filt_width = {filt_width};
     static const unsigned kernel_size = filt_height * filt_width;
     static const unsigned n_filt = {n_filt};
+    static const unsigned stride_height = {stride_height};
+    static const unsigned stride_width = {stride_width};
+    static const unsigned out_height = {out_height};
+    static const unsigned out_width = {out_width};
+    static const unsigned reuse_factor = {reuse};
+    static const unsigned n_zeros = {nzeros};
+    static const unsigned multiplier_limit =
+        DIV_ROUNDUP(kernel_size * n_chan * n_filt, reuse_factor) - n_zeros / reuse_factor;
+    static const bool store_weights_in_bram = false;
+    static const unsigned strategy = nnet::{strategy};
+    static const nnet::conv_implementation implementation = nnet::conv_implementation::{implementation};
+    static const unsigned min_height = {min_height};
+    static const unsigned min_width = {min_width};
+    static const ac_int<filt_height * filt_width,false> pixels[min_height * min_width];
+    static const unsigned n_partitions = {n_partitions};
+    static const unsigned n_pixels = out_height * out_width / n_partitions;
+    template<class data_T, class CONFIG_T>
+    using fill_buffer = nnet::{fill_fn}<data_T, CONFIG_T>;
+    typedef {accum_t.name} accum_t;
+    typedef {bias_t.name} bias_t;
+    typedef {weight_t.name} weight_t;
+    typedef {config_t} mult_config;
+    template<unsigned K, unsigned S, unsigned W>
+    using scale_index_height = nnet::{scale_index_height_type}<K, S, W>;
+    template<unsigned K, unsigned S, unsigned W>
+    using scale_index_width = nnet::{scale_index_width_type}<K, S, W>;
+}};
+// really this allocation of pixels array ought to be in a .cpp file
+#ifndef INCLUDED_MC_TESTBENCH_H
+const ac_int<config{index}::filt_height * config{index}::filt_width,false> config{index}::pixels[] = {{{instructions}}};
+#endif\n"""
+
+depthwiseconv2d_config_template = """struct config{index} : nnet::depthwiseconv2d_config {{
+    static const unsigned pad_top = {pad_top};
+    static const unsigned pad_bottom = {pad_bottom};
+    static const unsigned pad_left = {pad_left};
+    static const unsigned pad_right = {pad_right};
+    static const unsigned in_height = {in_height};
+    static const unsigned in_width = {in_width};
+    static const unsigned n_chan = {n_chan};
+    static const unsigned filt_height = {filt_height};
+    static const unsigned filt_width = {filt_width};
+    static const unsigned kernel_size = filt_height * filt_width;
+    static const unsigned d_mult = {d_mult};
+    static const unsigned n_filt = d_mult * n_chan;
     static const unsigned stride_height = {stride_height};
     static const unsigned stride_width = {stride_width};
     static const unsigned out_height = {out_height};
@@ -184,8 +229,50 @@ conv2d_include_list = ['nnet_utils/nnet_conv2d.h', 'nnet_utils/nnet_conv2d_strea
 
 class Conv2DConfigTemplate(LayerConfigTemplate):
     def __init__(self):
-        super().__init__((Conv2D, Conv2DBatchnorm, DepthwiseConv2D))
+        super().__init__((Conv2D, Conv2DBatchnorm))
         self.template = conv2d_config_template
+        self.mult_template = conv_mult_config_template
+
+    def format(self, node):
+        params = self._default_config_params(node)
+        params['dilation'] = node.get_attr('dilation', 1)
+        params['nzeros'] = node.get_weights('weight').nzeros
+
+        params['config_t'] = f'config{node.index}_mult'
+
+        if node.get_attr('in_height') == node.get_attr('min_height'):
+            params['scale_index_height_type'] = 'scale_index_unscaled'
+        else:
+            params['scale_index_height_type'] = 'scale_index_regular'
+
+        if node.get_attr('in_width') == node.get_attr('min_width'):
+            params['scale_index_width_type'] = 'scale_index_unscaled'
+        else:
+            params['scale_index_width_type'] = 'scale_index_regular'
+
+        if node.model.config.get_config_value('IOType') == 'io_parallel':
+            params['fill_fn'] = f'fill_buffer_{node.index}'
+        else:
+            params['fill_fn'] = 'FillConv2DBuffer'
+
+        conv_config = self.template.format(**params)
+
+        mult_params = self._default_config_params(node)
+        mult_params['n_in'] = node.get_attr('n_chan') * node.get_attr('filt_height') * node.get_attr('filt_width')
+        mult_params['n_out'] = node.get_attr('n_filt')
+        mult_params['nzeros'] = node.get_weights('weight').nzeros
+        mult_params['product_type'] = get_backend('catapult').product_type(
+            node.get_input_variable().type.precision, node.get_weights('weight').type.precision
+        )
+        mult_config = self.mult_template.format(**mult_params)
+
+        return mult_config + '\n' + conv_config
+
+
+class DepthwiseConv2DConfigTemplate(LayerConfigTemplate):
+    def __init__(self):
+        super().__init__(DepthwiseConv2D)
+        self.template = depthwiseconv2d_config_template
         self.mult_template = conv_mult_config_template
 
     def format(self, node):
@@ -291,6 +378,7 @@ class SeparableConv1DConfigTemplate(LayerConfigTemplate):
         params['nzeros'] = node.get_weights('depthwise').nzeros
         params['index'] = str(node.index) + '_depthwise'
         params['weight_t'] = node.get_weights('depthwise').type
+        params['bias_t'] = node.get_weights('zero_bias').type
         params['fill_fn'] = 'FillConv1DBuffer'
 
         if node.get_attr('unscaled'):
@@ -384,7 +472,7 @@ class SeparableConv2DConfigTemplate(LayerConfigTemplate):
     def __init__(self):
         super().__init__(SeparableConv2D)
         self.template = sepconv_config_template
-        self.depthwise_template = conv2d_config_template
+        self.depthwise_template = depthwiseconv2d_config_template
         self.pointwise_template = conv2d_config_template
         self.depthwise_mult_template = conv_mult_config_template
         self.pointwise_mult_template = conv_mult_config_template
@@ -469,7 +557,7 @@ class SeparableConv2DConfigTemplate(LayerConfigTemplate):
         # Pointwise mult config
         mult_params = self._default_config_params(node)
         mult_params['index'] = str(node.index) + '_pointwise'
-        mult_params['n_in'] = node.get_attr('n_chan')
+        mult_params['n_in'] = node.get_attr('n_chan2')
         mult_params['n_out'] = node.get_attr('n_filt')
         mult_params['nzeros'] = node.get_weights('pointwise').nzeros
         mult_params['weight_t'] = node.get_weights('pointwise').type

--- a/hls4ml/converters/keras/convolution.py
+++ b/hls4ml/converters/keras/convolution.py
@@ -60,10 +60,21 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader):
 
     layer['bias_data'] = get_weights_data(data_reader, layer['name'], 'bias')
 
-    if 'filters' in keras_layer['config']:
-        layer['n_filt'] = keras_layer['config']['filters']
+    layer['n_chan2'] = layer['n_chan']
+    if 'depth_multiplier' in keras_layer['config']:
+        # 'SeparableConv2D', 'DepthwiseConv2D'
+        layer['d_mult'] = keras_layer['config']['depth_multiplier']
+        if 'filters' in keras_layer['config']:
+            # 'SeparableConv2D'
+            layer['n_filt'] = keras_layer['config']['filters']
+            layer['n_chan2'] = layer['d_mult'] * layer['n_chan']
+        else:
+            # 'DepthwiseConv2D'
+            layer['n_filt'] = layer['d_mult'] * layer['n_chan']
     else:
-        layer['n_filt'] = layer['n_chan']
+        # 'Conv2D'
+        layer['n_filt'] = keras_layer['config']['filters']
+
     layer['filt_height'] = keras_layer['config']['kernel_size'][0]
     layer['filt_width'] = keras_layer['config']['kernel_size'][1]
     layer['stride_height'] = keras_layer['config']['strides'][0]

--- a/hls4ml/converters/pytorch/convolution.py
+++ b/hls4ml/converters/pytorch/convolution.py
@@ -68,11 +68,11 @@ def parse_conv2d_layer(operation, layer_name, input_names, input_shapes, node, c
         layer['bias_data'] = class_object.bias.data.numpy()
     else:
         layer['bias_data'] = None
-
     # Input info
     (layer['in_height'], layer['in_width'], layer['n_chan']) = parse_data_format(
         input_shapes[0], 'channels_first'
     )  # Keras's default is channels_last
+    layer['n_chan2'] = layer['n_chan']
 
     # Additional parameters
     layer['n_filt'] = class_object.out_channels


### PR DESCRIPTION
A# Description

The model python attached (model_asic.py) demonstrated that the shape printed by hls4ml (e.g. [None,32,32,8]) did not agree with the python model.summary() (e.g. [None,32,32,40)).
It turns out to be an incomplete handling of depth_multiplier in the SeparableConv2d and DepthwiseConv2d implementations.


## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

import os
import shutil
import sys
import hls4ml
import yaml
import pickle
import argparse
import numpy as np
import tensorflow as tf
import json
from tensorflow import keras
from tensorflow.keras.models import model_from_json
from tensorflow.keras import regularizers
from tensorflow.keras.constraints import max_norm
from qkeras import *
from sklearn.metrics import accuracy_score
 
# Usage:
#    python3 model.py
#      will build the model, perform analysis, generate HLS C++ and then synthesize it
 
## Function to create depthwise conv2d Neural Network model. For depthwiseconv2d, the kernel size will always be (1,1)
def create_model():
    model = tf.keras.Sequential()
    model.add(DepthwiseConv2D(kernel_size=(1,1), padding='valid', depth_multiplier=5, strides=1, dilation_rate=1, use_bias=True, input_shape=(32,32,8)))
    #Compiling the model
    model.compile(loss='sparse_categorical_crossentropy',
             optimizer='adam',
             metrics=['accuracy'])
    return model
 
## Function to save model architecture, weights, and configuration
def save_model(model, name=None):
    if name is None:
        name = model.name
    model.save(name + '.h5')
    model.save_weights(name + '_weights.h5')
    with open(name + '.json', 'w') as outfile:
        outfile.write(model.to_json())
    return
 
if __name__ == '__main__':
 
    print("============================================================================================")
    print("HLS4ML Version: ",hls4ml.__version__)
 
    parser = argparse.ArgumentParser(description='Configure and convert the model for Catapult HLS')
    parser.add_argument('--synth', action='store_true', help='Specify whether to perform Catapult build and synthesis')
 
    args = parser.parse_args()
 
    # Define output files/location:
    model_name = 'depthwiseconv2d'
    proj_name = 'myproject'
    out_dir = 'my-Catapult-test_asic'
 
    print("")
    print("Settings:")
    print('  model_name = '+model_name)
    print('  proj_name  = '+proj_name)
    print('  out_dir    = '+out_dir)
    print("")
 
    ## Create the model
    print("============================================================================================")
    print("Creating the model")
    model = create_model()
    model.summary()
 
    # Save model
    save_model(model, model_name)
 
    print("============================================================================================")
    print("Configuring HLS4ML")
    config_ccs = {}
    config_ccs['Backend'] = 'Catapult'
    config_ccs['ClockPeriod'] = 10
    config_ccs['HLSConfig'] = {'Model': {'Precision': 'ac_fixed<16,8>', 'ReuseFactor': 1, 'Strategy': 'Latency'}}
    config_ccs['IOType'] = 'io_stream'
    config_ccs['KerasH5'] = model_name+'_weights.h5'
    config_ccs['KerasJson'] = model_name+'.json'
    config_ccs['ProjectName'] = proj_name
    config_ccs['ASICLibs'] = 'saed32rvt_tt0p78v125c_beh'
    config_ccs['FIFO'] = 'hls4ml_lib.mgc_pipe_mem'
    config_ccs['OutputDir'] = out_dir
 
    # Create .yml file
    print("============================================================================================")
    print('Writing YAML config file: '+proj_name+'_config.yml')
    with open(proj_name+'_config.yml', 'w') as yaml_file:
        yaml.dump(config_ccs, yaml_file, explicit_start=False, default_flow_style=False)
 
    # Note: after this point the command-line hls4ml can be used to generate the C++ design and Catapult script
    #  shell%> hls4ml convert -c <project>_config.yml
    #  shell%> cd <outputdir>
    #  shell%> catapult -product ultra -file build_prj.tcl
 
    print("============================================================================================")
    print("HLS4ML converting model to HLS C++")
    hls_model_ccs = hls4ml.converters.keras_to_hls(config_ccs)
 
    print("============================================================================================")
    print("Compiling HLS C++ model")
    hls_model_ccs.compile()
 
    if args.synth:
        print("============================================================================================")
        print("Synthesizing HLS C++ model using Catapult")
        hls_model_ccs.build(csim=True, synth=True, cosim=False, validation=True, vsynth=False, sw_opt=True)
        # hls_model_ccs.build()
    else:
        print("============================================================================================")
        print("Skipping HLS - To run Catapult directly:")
        print('cd ' + out_dir + '; catapult -file build_prj.tcl')

**Test Configuration**:

## Checklist

- [x ] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
