### PR TITLE
Fix extension test for Keras v3

### DIFF
--- a/docs/advanced/extension.rst
+++ b/docs/advanced/extension.rst
@@ -35,6 +35,10 @@ For concreteness, let's say our custom layer ``KReverse`` is implemented in Kera
         def call(self, inputs):
             return tf.reverse(inputs, axis=[-1])
 
+        def get_config(self):
+            return super().get_config()
+
+Make sure you define a ``get_config()`` method for your custom layer as this is needed for correct parsing.
 We can define the equivalent layer in hls4ml ``HReverse``, which inherits from ``hls4ml.model.layers.Layer``.
 
 .. code-block:: Python

--- a/test/pytest/test_extensions.py
+++ b/test/pytest/test_extensions.py
@@ -19,6 +19,10 @@ class KReverse(tf.keras.layers.Layer):
     def call(self, inputs):
         return tf.reverse(inputs, axis=[-1])
 
+    def get_config(self):
+        # Breaks serialization and parsing in hls4ml if not defined
+        return super().get_config()
+
 
 # hls4ml layer implementation
 class HReverse(hls4ml.model.layers.Layer):


### PR DESCRIPTION
# Description

Newer versions of TF/Keras change the way serialization is handled, so one needs to define a `get_config()` to ensure the serialized json contains the information about the layer.

## Type of change

Fixes a bug observed in new testing environment, but is benign for older setups. I updated the docs to ensure this info is not hidden away in some test no user ever sees.

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Tests

I extended the test in `test_extensions.py`.

## Checklist

- [x] I did all the things required