### PR TITLE
Make im2col default option for quartus

### DIFF
--- a/hls4ml/backends/quartus/quartus_backend.py
+++ b/hls4ml/backends/quartus/quartus_backend.py
@@ -274,7 +274,7 @@ class QuartusBackend(FPGABackend):
         # - combination - at compile-time, the decision between Winograd and im2col is made
         # - im2col - specifically use im2col
         # - Winograd - use Winograd, if possible
-        layer.set_attr('implementation', layer.model.config.get_layer_config_value(layer, 'Implementation', 'combination'))
+        layer.set_attr('implementation', layer.model.config.get_layer_config_value(layer, 'Implementation', 'im2col'))
 
         layer.set_attr(
             'n_partitions', 1
@@ -305,7 +305,7 @@ class QuartusBackend(FPGABackend):
         # - combination - at compile-time, the decision between Winograd and im2col is made
         # - im2col - specifically use im2col
         # - Winograd - use Winograd, if possible
-        layer.set_attr('implementation', layer.model.config.get_layer_config_value(layer, 'Implementation', 'combination'))
+        layer.set_attr('implementation', layer.model.config.get_layer_config_value(layer, 'Implementation', 'im2col'))
 
         layer.set_attr(
             'n_partitions', 1

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_conv1d_resource.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_conv1d_resource.h
@@ -3,6 +3,7 @@
 
 #include "nnet_common.h"
 #include "nnet_dense.h"
+#include <cstdint>
 
 namespace nnet {
 

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_conv2d_resource.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_conv2d_resource.h
@@ -4,6 +4,7 @@
 #include "nnet_common.h"
 #include "nnet_dense.h"
 #include "nnet_helpers.h"
+#include <cstdint>
 
 namespace nnet {
 

--- a/test/pytest/test_auto_precision.py
+++ b/test/pytest/test_auto_precision.py
@@ -151,12 +151,6 @@ def test_auto_precision_conv(keras_model_conv1d, keras_model_conv2d, data_2d, da
         },
     }
 
-    # Winograd is not bit-accurate, so avoid it.
-    if backend == 'Quartus' and io_type == 'io_parallel':
-        config['LayerName']['first_layer']['Implementation'] = 'im2col'
-        config['LayerName']['middle_layer']['Implementation'] = 'im2col'
-        config['LayerName']['last_layer']['Implementation'] = 'im2col'
-
     odir = str(test_root_path / f'hls4mlprj_auto_{model_type}_{backend}_{io_type}')
     hls_model = hls4ml.converters.convert_from_keras_model(
         model, hls_config=config, io_type=io_type, output_dir=odir, backend=backend


### PR DESCRIPTION
A# Description

With using the Quartus backend, with conv2d with kernel size 3x3 or conv1d with kernel size 3, the framework makes the default implementation `Winograd` instad of `im2col`. As the current `Winograd` implementation does not seem to play nicely with low bitwidth and hard to achieve bit-accuracy (e.g., with automatic precision setting), I would suggest not enable it by default.

For the Winograd impl, type `uint8_t` from `<cstdint>` is used. This header is not included by default in many environments, explicit `#include <cstdint>` is added to corresponding files. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

## Checklist

- [ ] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
