### PR TITLE
prevent test directory overwrites for activation

### DIFF
--- a/test/pytest/test_keras_api.py
+++ b/test/pytest/test_keras_api.py
@@ -80,13 +80,13 @@ def test_dense(backend, io_type):
 @pytest.mark.parametrize(
     "activation_function",
     [
-        Activation(activation='relu', name='Activation'),
+        Activation(activation='relu', name='relu'),
         LeakyReLU(alpha=1.0),
         ELU(alpha=1.0),
         PReLU(
             alpha_initializer="zeros",
         ),
-        Activation(activation='sigmoid', name='Activation'),
+        Activation(activation='sigmoid', name='sigmoid'),
     ],
 )
 # ThresholdedReLU(theta=1.0)])
@@ -101,9 +101,7 @@ def test_activations(activation_function, backend, io_type):
     X_input = np.random.rand(100, 1)
     keras_prediction = model.predict(X_input)
     config = hls4ml.utils.config_from_keras_model(model)
-    output_dir = str(
-        test_root_path / f'hls4mlprj_keras_api_activations_{activation_function.__class__.__name__}_{backend}_{io_type}'
-    )
+    output_dir = str(test_root_path / f'hls4mlprj_keras_api_activations_{activation_function.name}_{backend}_{io_type}')
     hls_model = hls4ml.converters.convert_from_keras_model(
         model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
     )


### PR DESCRIPTION
# Description

The `test_activations` test in `test_keras_api.py` currently does not always produce unique directory names for different parametrizations. In particular, the two parametrizations of the Activation type wind up with clashing directory names. This change makes unique names. There are alternate ways to have unique names, so please comment if you would prefer a different solution. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

This change fixes random `test_keras_api.py::test_activations` errors one sometimes gets when running `test_keras_api.py`

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
