### PR TITLE
Update Jenkinsfile to use new Docker image and Python 3.10 environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,8 @@ pipeline {
         dir(path: 'test') {
           sh '''#!/bin/bash --login
               conda activate hls4ml-py310
-              pip install tensorflow pyparsing
+              conda install -y jupyterhub pydot graphviz pytest pytest-cov
+              pip install pytest-randomly jupyter onnx>=1.4.0 matplotlib pandas seaborn pydigitalwavetools==1.1 pyyaml tensorflow==2.14 qonnx torch git+https://github.com/google/qkeras.git pyparsing
               pip install -U ../ --user
               ./convert-keras-models.sh -x -f keras-models.txt
               pip uninstall hls4ml -y'''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     docker {
-      image 'vivado-el7:3'
+      image 'vivado-alma9:1'
       args  '-v /data/Xilinx:/data/Xilinx'
     }
   }
@@ -14,7 +14,7 @@ pipeline {
       steps {
         dir(path: 'test') {
           sh '''#!/bin/bash --login
-              conda activate hls4ml-py38
+              conda activate hls4ml-py310
               pip install tensorflow pyparsing
               pip install -U ../ --user
               ./convert-keras-models.sh -x -f keras-models.txt


### PR DESCRIPTION
# Description

Update Jenkinsfile (which drives the synthesis tests) to use the new Alma9-based image and the new environment based on Python 3.10 that the main branch now requires. The new image/environment will enable future Vitis synthesis tests but may not work for Vivado 2020.1 anymore, we'll see :crossed_fingers: 

This may not work on first attempt and may require several attempts.

## Type of change

- [x] Other - Infrastructure update

## Tests

The synthesis tests should be triggered and run without issues. The pytests are not affected.
