### PR TITLE
remove precision settings that make pytest for batchnorm in pytorch fail

### DIFF
--- a/test/pytest/test_batchnorm_pytorch.py
+++ b/test/pytest/test_batchnorm_pytorch.py
@@ -100,10 +100,6 @@ def test_batchnorm_fusion(fusion_data, backend, io_type):
 
     config['Model']['Strategy'] = 'Resource'
 
-    default_precision = 'ac_fixed<32, 1, true>' if backend == 'Quartus' else 'ac_fixed<32, 1>'
-
-    config['Model']['Precision'] = default_precision
-
     # conversion
     output_dir = str(test_root_path / f'hls4mlprj_block_{backend}_{io_type}')
     hls_model = hls4ml.converters.convert_from_pytorch_model(


### PR DESCRIPTION
Follow-up to https://github.com/fastmachinelearning/hls4ml/pull/1045. The new pytest for batchnorm in pytorch was using `ac_fixed<32, 1` as the precision setting for hls4ml. In some cases, this can lead to a sign flip and thus a very large difference in the results, which is why the pytest for that model failed during the PR tests. This PR simply removes this setting, running the tests with default precision. 

FYI @sei-rquartiano, this might be relevant for your future work with the tool. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Reproducing the exact pytest configuration run during the PR tests

`pytest test/pytest/test_batchnorm.py test/pytest/test_batchnorm_pytorch.py --randomly-seed=42 --randomly-dont-reorganize --randomly-dont-reset-seed`

Does reproduce the failures seen in https://github.com/fastmachinelearning/hls4ml/pull/1045. Removing the precision settings fixes this and the tests pass. 

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
