### PR TITLE
Update pooling logic for Vivado, Vitis, and Catapult backends

### DIFF
--- a/hls4ml/templates/vitis/nnet_utils/nnet_pooling.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_pooling.h
@@ -70,6 +70,7 @@ struct pooling1d_config {
     static const unsigned n_out = (n_in - pool_width) / stride_width + 1;
     static const unsigned pad_left = 0;
     static const unsigned pad_right = 0;
+    static const bool count_pad = false;
     // Pooling function
     static const Pool_Op pool_op = Max;
 };
@@ -130,6 +131,7 @@ void global_pooling1d_cl(data_T data[CONFIG_T::n_in * CONFIG_T::n_filt], res_T r
 
     for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
         data_T pool[CONFIG_T::n_in];
+        #pragma HLS ARRAY_PARTITION variable=pool complete dim=0
         for (int jj = 0; jj < CONFIG_T::n_in; jj++) {
             pool[jj] = data[jj * CONFIG_T::n_filt + ff];
         }
@@ -154,6 +156,7 @@ struct pooling2d_config {
     static const unsigned pad_bottom = 0;
     static const unsigned pad_left = 0;
     static const unsigned pad_right = 0;
+    static const bool count_pad = false;
     // Pooling function
     static const Pool_Op pool_op = Max;
     // Reuse factor
@@ -245,6 +248,7 @@ void pooling2d_cf(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
             // Loop over input image x in steps of stride
             for (int jj = 0; jj < padded_width; jj += CONFIG_T::stride_width) {
                 data_T pool[CONFIG_T::pool_height * CONFIG_T::pool_width];
+                #pragma HLS ARRAY_PARTITION variable=pool complete dim=0
                 // Keep track of number of pixels in image vs padding region
                 unsigned img_overlap = 0;
                 // Loop over pool window y
@@ -255,10 +259,12 @@ void pooling2d_cf(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
                             jj + ll < CONFIG_T::pad_left || jj + ll >= (padded_width - CONFIG_T::pad_right)) {
                             // Add padding
                             pool[kk * CONFIG_T::stride_width + ll] = pad_val<data_T, CONFIG_T::pool_op>();
+                            if (CONFIG_T::count_pad)
+                                img_overlap++;
                         } else {
                             pool[kk * CONFIG_T::stride_width + ll] =
-                                data[(ii + kk) * CONFIG_T::in_width + ff * CONFIG_T::in_width * CONFIG_T::in_height + ll +
-                                     jj];
+                                data[(ii + kk - CONFIG_T::pad_top) * CONFIG_T::in_width +
+                                     ff * CONFIG_T::in_width * CONFIG_T::in_height + ll + jj - CONFIG_T::pad_left];
                             img_overlap++;
                         }
                     }

--- a/hls4ml/templates/vitis/nnet_utils/nnet_pooling.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_pooling.h
@@ -89,14 +89,13 @@ void pooling1d_cl(data_T data[CONFIG_T::n_in * CONFIG_T::n_filt], res_T res[CONF
         CONFIG_T::pool_op, typename CONFIG_T::accum_t> limit=limit
     // Add any necessary padding
 
-    unsigned padded_width = CONFIG_T::n_in + CONFIG_T::pad_left + CONFIG_T::pad_right;
-    if (CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
-        padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
-    }
+    // Add padding and reduce input width to area covered by pooling function
+    static constexpr int full_padded_width = CONFIG_T::n_in + CONFIG_T::pad_left + CONFIG_T::pad_right;
+    static constexpr int restricted_padded_width = full_padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width;
 
     for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
         // Loop over input image x in steps of stride
-        for (int ii = 0; ii < padded_width; ii += CONFIG_T::stride_width) {
+        for (int ii = 0; ii < restricted_padded_width; ii += CONFIG_T::stride_width) {
             unsigned overlap_pixel = 0;
             data_T pool[CONFIG_T::pool_width];
             #pragma HLS ARRAY_PARTITION variable=pool complete dim=0
@@ -179,18 +178,17 @@ void pooling2d_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
     const int limit = pool_op_limit<CONFIG_T>();
     #pragma HLS ALLOCATION function instances=pool_op<data_T, CONFIG_T::pool_height*CONFIG_T::pool_width, \
         CONFIG_T::pool_op, typename CONFIG_T::accum_t> limit=limit
-    unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
-    unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
-    if (CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
-        padded_height -= padded_height - (padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height);
-        padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
-    }
+    // Add padding and reduce input width to area covered by pooling function
+    static constexpr int full_padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
+    static constexpr int full_padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
+    static constexpr int restricted_padded_width = full_padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width;
+    static constexpr int restricted_padded_height = full_padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height;
 
     for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
         // Loop over input image y in steps of stride
-        for (int ii = 0; ii < padded_height; ii += CONFIG_T::stride_height) {
+        for (int ii = 0; ii < restricted_padded_height; ii += CONFIG_T::stride_height) {
             // Loop over input image x in steps of stride
-            for (int jj = 0; jj < padded_width; jj += CONFIG_T::stride_width) {
+            for (int jj = 0; jj < restricted_padded_width; jj += CONFIG_T::stride_width) {
                 data_T pool[CONFIG_T::pool_height * CONFIG_T::pool_width];
                 #pragma HLS ARRAY_PARTITION variable=pool complete dim=0
 
@@ -234,19 +232,17 @@ void pooling2d_cf(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
     const int limit = pool_op_limit<CONFIG_T>();
     #pragma HLS ALLOCATION function instances=pool_op<data_T, CONFIG_T::pool_height*CONFIG_T::pool_width, \
         CONFIG_T::pool_op, typename CONFIG_T::accum_t> limit=limit
-    // Add any necessary padding
-    unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
-    unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
-    if (CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
-        padded_height -= padded_height - (padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height);
-        padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
-    }
+    // Add padding and reduce input width to area covered by pooling function
+    static constexpr int full_padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
+    static constexpr int full_padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
+    static constexpr int restricted_padded_width = full_padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width;
+    static constexpr int restricted_padded_height = full_padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height;
 
     for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
         // Loop over input image y in steps of stride
-        for (int ii = 0; ii < padded_height; ii += CONFIG_T::stride_height) {
+        for (int ii = 0; ii < restricted_padded_height; ii += CONFIG_T::stride_height) {
             // Loop over input image x in steps of stride
-            for (int jj = 0; jj < padded_width; jj += CONFIG_T::stride_width) {
+            for (int jj = 0; jj < restricted_padded_width; jj += CONFIG_T::stride_width) {
                 data_T pool[CONFIG_T::pool_height * CONFIG_T::pool_width];
                 #pragma HLS ARRAY_PARTITION variable=pool complete dim=0
                 // Keep track of number of pixels in image vs padding region
@@ -255,8 +251,8 @@ void pooling2d_cf(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
                 for (int kk = 0; kk < CONFIG_T::stride_height; kk++) {
                     // Loop over pool window x
                     for (int ll = 0; ll < CONFIG_T::stride_width; ll++) {
-                        if (ii + kk < CONFIG_T::pad_top || ii + kk >= (padded_height - CONFIG_T::pad_bottom) ||
-                            jj + ll < CONFIG_T::pad_left || jj + ll >= (padded_width - CONFIG_T::pad_right)) {
+                        if (ii + kk < CONFIG_T::pad_top || ii + kk >= (full_padded_height - CONFIG_T::pad_bottom) ||
+                            jj + ll < CONFIG_T::pad_left || jj + ll >= (full_padded_width - CONFIG_T::pad_right)) {
                             // Add padding
                             pool[kk * CONFIG_T::stride_width + ll] = pad_val<data_T, CONFIG_T::pool_op>();
                             if (CONFIG_T::count_pad)

--- a/hls4ml/templates/vivado/nnet_utils/nnet_pooling.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_pooling.h
@@ -87,14 +87,13 @@ void pooling1d_cl(data_T data[CONFIG_T::n_in * CONFIG_T::n_filt], res_T res[CONF
     #pragma HLS ALLOCATION function instances=CONFIG_T::pool_op limit=limit
     // Add any necessary padding
 
-    unsigned padded_width = CONFIG_T::n_in + CONFIG_T::pad_left + CONFIG_T::pad_right;
-    if (CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
-        padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
-    }
+    // Add padding and reduce input width to area covered by pooling function
+    static constexpr int full_padded_width = CONFIG_T::n_in + CONFIG_T::pad_left + CONFIG_T::pad_right;
+    static constexpr int restricted_padded_width = full_padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width;
 
     for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
         // Loop over input image x in steps of stride
-        for (int ii = 0; ii < padded_width; ii += CONFIG_T::stride_width) {
+        for (int ii = 0; ii < restricted_padded_width; ii += CONFIG_T::stride_width) {
             unsigned overlap_pixel = 0;
             data_T pool[CONFIG_T::pool_width];
             #pragma HLS ARRAY_PARTITION variable=pool complete dim=0
@@ -176,12 +175,11 @@ void pooling2d_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
     const int limit = pool_op_limit<CONFIG_T>();
     #pragma HLS ALLOCATION function instances=CONFIG_T::pool_op limit=limit
 
-    unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
-    unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
-    if (CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
-        padded_height -= padded_height - (padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height);
-        padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
-    }
+        // Add padding and reduce input width to area covered by pooling function
+    static constexpr int full_padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
+    static constexpr int full_padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
+    static constexpr int restricted_padded_width = full_padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width;
+    static constexpr int restricted_padded_height = full_padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height;
 
     for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
 

--- a/hls4ml/templates/vivado/nnet_utils/nnet_pooling.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_pooling.h
@@ -184,9 +184,9 @@ void pooling2d_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
     for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
 
         // Loop over input image y in steps of stride
-        for (int ii = 0; ii < padded_height; ii += CONFIG_T::stride_height) {
+        for (int ii = 0; ii < restricted_padded_height; ii += CONFIG_T::stride_height) {
             // Loop over input image x in steps of stride
-            for (int jj = 0; jj < padded_width; jj += CONFIG_T::stride_width) {
+            for (int jj = 0; jj < restricted_padded_width; jj += CONFIG_T::stride_width) {
                 data_T pool[CONFIG_T::pool_height * CONFIG_T::pool_width];
                 #pragma HLS ARRAY_PARTITION variable=pool complete dim=0
 
@@ -229,19 +229,17 @@ void pooling2d_cf(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
     // TODO partition the arrays according to the reuse factor
     const int limit = pool_op_limit<CONFIG_T>();
     #pragma HLS ALLOCATION function instances=CONFIG_T::pool_op limit=limit
-    // Add any necessary padding
-    unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
-    unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
-    if (CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
-        padded_height -= padded_height - (padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height);
-        padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
-    }
+    // Add padding and reduce input width to area covered by pooling function
+    static constexpr int full_padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
+    static constexpr int full_padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
+    static constexpr int restricted_padded_width = full_padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width;
+    static constexpr int restricted_padded_height = full_padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height;
 
     for (int ff = 0; ff < CONFIG_T::n_filt; ff++) {
         // Loop over input image y in steps of stride
-        for (int ii = 0; ii < padded_height; ii += CONFIG_T::stride_height) {
+        for (int ii = 0; ii < restricted_padded_height; ii += CONFIG_T::stride_height) {
             // Loop over input image x in steps of stride
-            for (int jj = 0; jj < padded_width; jj += CONFIG_T::stride_width) {
+            for (int jj = 0; jj < restricted_padded_width; jj += CONFIG_T::stride_width) {
                 data_T pool[CONFIG_T::pool_height * CONFIG_T::pool_width];
                 #pragma HLS ARRAY_PARTITION variable=pool complete dim=0
                 // Keep track of number of pixels in image vs padding region
@@ -250,8 +248,8 @@ void pooling2d_cf(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
                 for (int kk = 0; kk < CONFIG_T::stride_height; kk++) {
                     // Loop over pool window x
                     for (int ll = 0; ll < CONFIG_T::stride_width; ll++) {
-                        if (ii + kk < CONFIG_T::pad_top || ii + kk >= (padded_height - CONFIG_T::pad_bottom) ||
-                            jj + ll < CONFIG_T::pad_left || jj + ll >= (padded_width - CONFIG_T::pad_right)) {
+                        if (ii + kk < CONFIG_T::pad_top || ii + kk >= (full_padded_height - CONFIG_T::pad_bottom) ||
+                            jj + ll < CONFIG_T::pad_left || jj + ll >= (full_padded_width - CONFIG_T::pad_right)) {
                             // Add padding
                             pool[kk * CONFIG_T::stride_width + ll] = pad_val<data_T, CONFIG_T::pool_op>();
                             if (CONFIG_T::count_pad)

--- a/hls4ml/templates/vivado/nnet_utils/nnet_pooling.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_pooling.h
@@ -175,7 +175,7 @@ void pooling2d_cl(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_
     const int limit = pool_op_limit<CONFIG_T>();
     #pragma HLS ALLOCATION function instances=CONFIG_T::pool_op limit=limit
 
-        // Add padding and reduce input width to area covered by pooling function
+    // Add padding and reduce input width to area covered by pooling function
     static constexpr int full_padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
     static constexpr int full_padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
     static constexpr int restricted_padded_width = full_padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width;


### PR DESCRIPTION
# Description

When testing the oneAPI backend, we found an issue with general padding (i.e. not "valid" of "same") using `test_pytorch_api.py::test_pooling`, in particular for the 1D case with padding. The oneAPI test hung. The culprit was writing past the result array. This copies the logic changes from the oneAPI backend (and the related Quartus backend) in #955 to the Vivado, Vitis, and Catapult backends. Somehow only the oneAPI backend was sensitive to that overwrite, but the problem existed everywhere. Some partial fixes were already made in #973.

The Vivado and Vitis template files were also made more similar, with a few missing pragmas copied, and a bug fix for padding copied to the Vitis backend for the channels-first 2D implementation, which may well be unused currently.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

The existing pytests and synthesis tests should show that this works. 

**Test Configuration**:

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
