### PR TITLE
remove padding attribute

### DIFF
--- a/hls4ml/backends/catapult/passes/conv_same_pad.py
+++ b/hls4ml/backends/catapult/passes/conv_same_pad.py
@@ -6,10 +6,8 @@ class InsertZeroPaddingBeforeConv1D(OptimizerPass):
     name = 'insert_zero_padding_before_conv1d'
 
     def match(self, node):
-        is_match = (
-            isinstance(node, (Conv1D, SeparableConv1D))
-            and ((node.get_attr('padding') == 'same') or (node.get_attr('padding') == 'causal'))
-            and node.get_attr('filt_width') != 1
+        is_match = isinstance(node, (Conv1D, SeparableConv1D)) and (
+            (node.get_attr('pad_left') != 0) or (node.get_attr('pad_right') != 0)
         )
         return is_match
 
@@ -37,7 +35,6 @@ class InsertZeroPaddingBeforeConv1D(OptimizerPass):
         }
 
         # Switch Conv1D layer padding to 'valid'
-        node.set_attr('padding', 'valid')
         node.set_attr('pad_left', 0)
         node.set_attr('pad_right', 0)
         node.set_attr('in_width', out_width)
@@ -54,11 +51,11 @@ class InsertZeroPaddingBeforeConv2D(OptimizerPass):
     name = 'insert_zero_padding_before_conv2d'
 
     def match(self, node):
-        is_match = (
-            isinstance(node, (Conv2D, SeparableConv2D))
-            and node.get_attr('padding') == 'same'
-            and node.get_attr('filt_height') != 1
-            and node.get_attr('filt_width') != 1
+        is_match = isinstance(node, (Conv2D, SeparableConv2D)) and (
+            (node.get_attr('pad_left') != 0)
+            or (node.get_attr('pad_right') != 0)
+            or (node.get_attr('pad_top') != 0)
+            or (node.get_attr('pad_bottom') != 0)
         )
         return is_match
 
@@ -93,7 +90,6 @@ class InsertZeroPaddingBeforeConv2D(OptimizerPass):
         }
 
         # Switch Conv2D layer padding to 'valid'
-        node.set_attr('padding', 'valid')
         node.set_attr('pad_top', 0)
         node.set_attr('pad_bottom', 0)
         node.set_attr('pad_left', 0)

--- a/hls4ml/backends/vivado/passes/conv_same_pad.py
+++ b/hls4ml/backends/vivado/passes/conv_same_pad.py
@@ -6,10 +6,8 @@ class InsertZeroPaddingBeforeConv1D(OptimizerPass):
     name = 'insert_zero_padding_before_conv1d'
 
     def match(self, node):
-        is_match = (
-            isinstance(node, (Conv1D, SeparableConv1D))
-            and ((node.get_attr('padding') == 'same') or (node.get_attr('padding') == 'causal'))
-            and node.get_attr('filt_width') != 1
+        is_match = isinstance(node, (Conv1D, SeparableConv1D)) and (
+            (node.get_attr('pad_left') != 0) or (node.get_attr('pad_right') != 0)
         )
         return is_match
 
@@ -37,7 +35,6 @@ class InsertZeroPaddingBeforeConv1D(OptimizerPass):
         }
 
         # Switch Conv1D layer padding to 'valid'
-        node.set_attr('padding', 'valid')
         node.set_attr('pad_left', 0)
         node.set_attr('pad_right', 0)
         node.set_attr('in_width', out_width)
@@ -54,11 +51,11 @@ class InsertZeroPaddingBeforeConv2D(OptimizerPass):
     name = 'insert_zero_padding_before_conv2d'
 
     def match(self, node):
-        is_match = (
-            isinstance(node, (Conv2D, SeparableConv2D))
-            and node.get_attr('padding') == 'same'
-            and node.get_attr('filt_height') != 1
-            and node.get_attr('filt_width') != 1
+        is_match = isinstance(node, (Conv2D, SeparableConv2D)) and (
+            (node.get_attr('pad_left') != 0)
+            or (node.get_attr('pad_right') != 0)
+            or (node.get_attr('pad_top') != 0)
+            or (node.get_attr('pad_bottom') != 0)
         )
         return is_match
 
@@ -93,7 +90,6 @@ class InsertZeroPaddingBeforeConv2D(OptimizerPass):
         }
 
         # Switch Conv2D layer padding to 'valid'
-        node.set_attr('padding', 'valid')
         node.set_attr('pad_top', 0)
         node.set_attr('pad_bottom', 0)
         node.set_attr('pad_left', 0)

--- a/hls4ml/converters/keras/convolution.py
+++ b/hls4ml/converters/keras/convolution.py
@@ -30,10 +30,9 @@ def parse_conv1d_layer(keras_layer, input_names, input_shapes, data_reader):
         layer['n_filt'] = layer['n_chan'] * layer.get('depth_multiplier')
     layer['filt_width'] = keras_layer['config']['kernel_size'][0]
     layer['stride_width'] = keras_layer['config']['strides'][0]
-    layer['padding'] = keras_layer['config']['padding']
 
     (layer['out_width'], layer['pad_left'], layer['pad_right']) = compute_padding_1d(
-        layer['padding'], layer['in_width'], layer['stride_width'], layer['filt_width']
+        keras_layer['config']['padding'], layer['in_width'], layer['stride_width'], layer['filt_width']
     )
 
     if layer['data_format'] == 'channels_last':
@@ -74,7 +73,6 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader):
     layer['filt_width'] = keras_layer['config']['kernel_size'][1]
     layer['stride_height'] = keras_layer['config']['strides'][0]
     layer['stride_width'] = keras_layer['config']['strides'][1]
-    layer['padding'] = keras_layer['config']['padding']
 
     (
         layer['out_height'],
@@ -84,7 +82,7 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader):
         layer['pad_left'],
         layer['pad_right'],
     ) = compute_padding_2d(
-        layer['padding'],
+        keras_layer['config']['padding'],
         layer['in_height'],
         layer['in_width'],
         layer['stride_height'],

--- a/hls4ml/converters/keras/pooling.py
+++ b/hls4ml/converters/keras/pooling.py
@@ -15,10 +15,9 @@ def parse_pooling_layer(keras_layer, input_names, input_shapes, data_reader):
 
         layer['pool_width'] = keras_layer['config']['pool_size'][0]
         layer['stride_width'] = keras_layer['config']['strides'][0]
-        layer['padding'] = keras_layer['config']['padding']
 
         (layer['n_out'], layer['pad_left'], layer['pad_right']) = compute_padding_1d(
-            layer['padding'], layer['n_in'], layer['stride_width'], layer['pool_width']
+            keras_layer['config']['padding'], layer['n_in'], layer['stride_width'], layer['pool_width']
         )
 
         if layer['data_format'] == 'channels_last':
@@ -32,7 +31,6 @@ def parse_pooling_layer(keras_layer, input_names, input_shapes, data_reader):
         layer['stride_width'] = keras_layer['config']['strides'][1]
         layer['pool_height'] = keras_layer['config']['pool_size'][0]
         layer['pool_width'] = keras_layer['config']['pool_size'][1]
-        layer['padding'] = keras_layer['config']['padding']
 
         (
             layer['out_height'],
@@ -42,7 +40,7 @@ def parse_pooling_layer(keras_layer, input_names, input_shapes, data_reader):
             layer['pad_left'],
             layer['pad_right'],
         ) = compute_padding_2d(
-            layer['padding'],
+            keras_layer['config']['padding'],
             layer['in_height'],
             layer['in_width'],
             layer['stride_height'],

--- a/hls4ml/converters/pytorch/convolution.py
+++ b/hls4ml/converters/pytorch/convolution.py
@@ -35,11 +35,6 @@ def parse_conv1d_layer(operation, layer_name, input_names, input_shapes, node, c
     else:
         padding = class_object.padding
 
-    if padding == 0:  # No padding, i.e., 'VALID' padding in Keras/Tensorflow
-        layer['padding'] = 'valid'
-    else:  # Only 'valid' and 'same' padding are available in Keras
-        layer['padding'] = 'same'
-
     # Ouput info
     (layer['out_width'], pad_left, pad_right) = compute_padding_1d_pytorch(
         padding, layer['in_width'], layer['stride_width'], layer['filt_width'], layer['dilation']
@@ -83,11 +78,6 @@ def parse_conv2d_layer(operation, layer_name, input_names, input_shapes, node, c
     layer['dilation'] = class_object.dilation[0]
     layer['pad_top'] = layer['pad_bottom'] = class_object.padding[0]
     layer['pad_left'] = layer['pad_right'] = class_object.padding[1]
-
-    if all(x == 0 for x in class_object.padding):  # No padding, i.e., 'VALID' padding in Keras/Tensorflow
-        layer['padding'] = 'valid'
-    else:  # Only 'valid' and 'same' padding are available in Keras
-        layer['padding'] = 'same'
 
     # Ouput info
     (layer['out_height'], layer['out_width'], _, _, _, _) = compute_padding_2d_pytorch(

--- a/hls4ml/model/optimizer/passes/multi_dense.py
+++ b/hls4ml/model/optimizer/passes/multi_dense.py
@@ -20,7 +20,6 @@ class ReplaceMultidimensionalDenseWithConv(OptimizerPass):
 
         conv_attrs = {
             'data_format': 'channels_last',
-            'padding': 'valid',
             'n_chan': input_shape[-1],
             'n_filt': node.get_attr('n_out'),
             'weight_data': np.expand_dims(node.get_attr('weight_data'), axis=tuple(range(dim))),

--- a/hls4ml/model/optimizer/passes/seperable_to_dw_conv.py
+++ b/hls4ml/model/optimizer/passes/seperable_to_dw_conv.py
@@ -33,7 +33,6 @@ class SeperableToDepthwiseAndConv(OptimizerPass):
         'data_format',
         'depthwise_data',
         'depthwise_quantizer',
-        'padding',
     )
 
     _pw_attributes = ('out_width', 'n_filt', 'dilation_width', 'out_height', 'dilation_height', 'data_format', 'use_bias')

--- a/test/pytest/test_pytorch_api.py
+++ b/test/pytest/test_pytorch_api.py
@@ -277,10 +277,7 @@ def test_conv1d(padds, backend, io_type):
     assert list(hls_model.get_layers())[conv_index].attributes['n_chan'] == class_object_conv.in_channels
     assert list(hls_model.get_layers())[conv_index].attributes['n_filt'] == class_object_conv.out_channels
     assert list(hls_model.get_layers())[conv_index].attributes['stride_width'] == class_object_conv.stride[0]
-    if list(hls_model.get_layers())[conv_index].attributes['padding'] == 'valid':
-        padding = 0
-    else:
-        padding = 1
+    padding = padds
     if io_type == "io_stream" and (backend == "Vivado" or backend == "Vitis") and padds == 1:
         padding = 1
         padds = 0
@@ -424,10 +421,7 @@ def test_conv2d(padds, backend, io_type):
         assert list(hls_model.get_layers())[conv_index].attributes['n_filt'] == class_object_conv.out_channels
         assert list(hls_model.get_layers())[conv_index].attributes['stride_width'] == class_object_conv.stride[1]
         assert list(hls_model.get_layers())[conv_index].attributes['stride_height'] == class_object_conv.stride[0]
-        if list(hls_model.get_layers())[conv_index].attributes['padding'] == 'valid':
-            padding = 0
-        else:
-            padding = 1
+        padding = padds
         assert padding == class_object_conv.padding[0]
         assert list(hls_model.get_layers())[conv_index].attributes['data_format'] == 'channels_last'
 


### PR DESCRIPTION
# Description

This PR removes the "padding" attribute from hls4ml's IR. Given that it we specify the actual pad values in the IR, this is redundant, and it is also keras-specific, so it becomes unnatural to set in pytorch and onnx, since you can get paddings that do not map exactly.

## Type of change

- [x] Other (Specify):  remove keras-specific redundant feature

## Tests

This is supposed to produce no changes, so original tests should continue working. That functions as a test.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
