### PR TITLE
Remove extras flow

### DIFF
--- a/hls4ml/backends/catapult/catapult_backend.py
+++ b/hls4ml/backends/catapult/catapult_backend.py
@@ -153,9 +153,8 @@ class CatapultBackend(FPGABackend):
         ]
 
         if len(extras) > 0:
-            extras_flow = register_flow('extras', extras, requires=[init_flow], backend=self.name)
-        else:
-            extras_flow = None
+            for opt in extras:
+                print(f'WARNING: Optimizer "{opt}" is not part of any flow and will not be executed.')
 
         ip_flow_requirements = [
             'optimize',
@@ -164,10 +163,8 @@ class CatapultBackend(FPGABackend):
             quantization_flow,
             optimization_flow,
             catapult_types_flow,
-            extras_flow,
             template_flow,
         ]
-        ip_flow_requirements = list(filter(None, ip_flow_requirements))
 
         self._default_flow = register_flow('ip', None, requires=ip_flow_requirements, backend=self.name)
 

--- a/hls4ml/backends/catapult/catapult_backend.py
+++ b/hls4ml/backends/catapult/catapult_backend.py
@@ -111,6 +111,7 @@ class CatapultBackend(FPGABackend):
             'catapult:inplace_stream_flatten',
             'catapult:skip_softmax',
             'catapult:fix_softmax_table_size',
+            'catapult:process_fixed_point_quantizer_layer',
             'infer_precision_types',
         ]
         optimization_flow = register_flow('optimize', optimization_passes, requires=[init_flow], backend=self.name)
@@ -121,6 +122,7 @@ class CatapultBackend(FPGABackend):
             'catapult:generate_conv_streaming_instructions',
             'catapult:apply_resource_strategy',
             'catapult:generate_conv_im2col',
+            'catapult:apply_winograd_kernel_transformation',
         ]
         catapult_types_flow = register_flow('specific_types', catapult_types, requires=[init_flow], backend=self.name)
 

--- a/hls4ml/backends/catapult/catapult_backend.py
+++ b/hls4ml/backends/catapult/catapult_backend.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from warnings import warn
 
 import numpy as np
 
@@ -154,7 +155,7 @@ class CatapultBackend(FPGABackend):
 
         if len(extras) > 0:
             for opt in extras:
-                print(f'WARNING: Optimizer "{opt}" is not part of any flow and will not be executed.')
+                warn(f'WARNING: Optimizer "{opt}" is not part of any flow and will not be executed.')
 
         ip_flow_requirements = [
             'optimize',

--- a/hls4ml/backends/quartus/quartus_backend.py
+++ b/hls4ml/backends/quartus/quartus_backend.py
@@ -104,7 +104,7 @@ class QuartusBackend(FPGABackend):
 
         if len(extras) > 0:
             for opt in extras:
-                print(f'WARNING: Optimizer "{opt}" is not part of any flow and will not be executed.')
+                warn(f'WARNING: Optimizer "{opt}" is not part of any flow and will not be executed.')
 
         ip_flow_requirements = [
             'optimize',

--- a/hls4ml/backends/quartus/quartus_backend.py
+++ b/hls4ml/backends/quartus/quartus_backend.py
@@ -103,9 +103,8 @@ class QuartusBackend(FPGABackend):
         ]
 
         if len(extras) > 0:
-            extras_flow = register_flow('extras', extras, requires=[init_flow], backend=self.name)
-        else:
-            extras_flow = None
+            for opt in extras:
+                print(f'WARNING: Optimizer "{opt}" is not part of any flow and will not be executed.')
 
         ip_flow_requirements = [
             'optimize',
@@ -114,10 +113,8 @@ class QuartusBackend(FPGABackend):
             quantization_flow,
             optimization_flow,
             quartus_types_flow,
-            extras_flow,
             template_flow,
         ]
-        ip_flow_requirements = list(filter(None, ip_flow_requirements))
 
         self._default_flow = register_flow('ip', None, requires=ip_flow_requirements, backend=self.name)
 

--- a/hls4ml/backends/quartus/quartus_backend.py
+++ b/hls4ml/backends/quartus/quartus_backend.py
@@ -55,6 +55,7 @@ class QuartusBackend(FPGABackend):
             'quartus:transform_types',
             'quartus:register_bram_weights',
             'quartus:apply_resource_strategy',
+            'quartus:generate_conv_im2col',
             'quartus:apply_winograd_kernel_transformation',
         ]
         quartus_types_flow = register_flow('specific_types', quartus_types, requires=[init_flow], backend=self.name)

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -147,9 +147,8 @@ class VivadoBackend(FPGABackend):
         ]
 
         if len(extras) > 0:
-            extras_flow = register_flow('extras', extras, requires=[init_flow], backend=self.name)
-        else:
-            extras_flow = None
+            for opt in extras:
+                print(f'WARNING: Optimizer "{opt}" is not part of any flow and will not be executed.')
 
         ip_flow_requirements = [
             'optimize',
@@ -158,10 +157,8 @@ class VivadoBackend(FPGABackend):
             quantization_flow,
             optimization_flow,
             vivado_types_flow,
-            extras_flow,
             template_flow,
         ]
-        ip_flow_requirements = list(filter(None, ip_flow_requirements))
 
         self._default_flow = register_flow('ip', None, requires=ip_flow_requirements, backend=self.name)
 

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -148,7 +148,7 @@ class VivadoBackend(FPGABackend):
 
         if len(extras) > 0:
             for opt in extras:
-                print(f'WARNING: Optimizer "{opt}" is not part of any flow and will not be executed.')
+                warn(f'WARNING: Optimizer "{opt}" is not part of any flow and will not be executed.')
 
         ip_flow_requirements = [
             'optimize',


### PR DESCRIPTION
# Description

Vivado, Quartus and Catapult backends have an "extras" flow that is used for all optimizers that are not part of existing flows and should be empty in normal operation. It is only intended as a development/debug feature and was created before the flows become so granular. Meanwhile it became a hinderance and can trip up genuine development/debug effort. This PR removes the `extras` flow and replaces it with a warning.

## Type of change
- [x] Other (Specify) - Change in internal behavior, invisible to users

## Tests

There are numerous ways to test this, as a developer one can just ensure one optimizer is not registered to a backend flow to see the warning. This can be done by commenting out any of the existing optimizers in any backend flows or creating a new optimizer in `passes` directory.

Creating a test-case for this is not really useful and is very hacky, as it requires "reloading" a backend, first by removing the registered optimizers and flows, then registering the new dummy optmizer and finally reloading the backend in the `backend_map`. I suggest we don't do this.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
