### PR TITLE
Raise exception on compile errors

### DIFF
--- a/hls4ml/backends/fpga/fpga_backend.py
+++ b/hls4ml/backends/fpga/fpga_backend.py
@@ -1,6 +1,7 @@
 import math
 import os
 import re
+import subprocess
 from bisect import bisect_left
 from collections.abc import Iterable
 
@@ -131,19 +132,22 @@ class FPGABackend(Backend):
         Returns:
             string: Returns the name of the compiled library.
         """
-        curr_dir = os.getcwd()
-        os.chdir(model.config.get_output_dir())
 
         lib_name = None
-        try:
-            ret_val = os.system('bash build_lib.sh')
-            if ret_val != 0:
-                raise Exception(f'Failed to compile project "{model.config.get_project_name()}"')
-            lib_name = '{}/firmware/{}-{}.so'.format(
-                model.config.get_output_dir(), model.config.get_project_name(), model.config.get_config_value('Stamp')
-            )
-        finally:
-            os.chdir(curr_dir)
+        ret_val = subprocess.run(
+            ['./build_lib.sh'],
+            shell=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=model.config.get_output_dir()
+        )
+        if ret_val.returncode != 0:
+            print(ret_val.stdout)
+            raise Exception(f'Failed to compile project "{model.config.get_project_name()}"')
+        lib_name = '{}/firmware/{}-{}.so'.format(
+            model.config.get_output_dir(), model.config.get_project_name(), model.config.get_config_value('Stamp')
+        )
 
         return lib_name
 

--- a/hls4ml/templates/vivado/build_lib.sh
+++ b/hls4ml/templates/vivado/build_lib.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 CC=g++
 if [[ "$OSTYPE" == "linux-gnu" ]]; then

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -1,7 +1,9 @@
 import glob
 import os
+import stat
 import tarfile
 from collections import OrderedDict
+from pathlib import Path
 from shutil import copyfile, copytree, rmtree
 
 import numpy as np
@@ -692,45 +694,44 @@ class VivadoWriter(Writer):
             model (ModelGraph): the hls4ml model.
         """
 
-        filedir = os.path.dirname(os.path.abspath(__file__))
+        filedir = Path(__file__).parent
 
         # project.tcl
-        f = open(f'{model.config.get_output_dir()}/project.tcl', 'w')
-        f.write('variable project_name\n')
-        f.write(f'set project_name "{model.config.get_project_name()}"\n')
-        f.write('variable backend\n')
-        f.write('set backend "vivado"\n')
-        f.write('variable part\n')
-        f.write('set part "{}"\n'.format(model.config.get_config_value('Part')))
-        f.write('variable clock_period\n')
-        f.write('set clock_period {}\n'.format(model.config.get_config_value('ClockPeriod')))
-        f.write('variable clock_uncertainty\n')
-        f.write('set clock_uncertainty {}\n'.format(model.config.get_config_value('ClockUncertainty', '12.5%')))
-        f.write('variable version\n')
-        f.write('set version "{}"\n'.format(model.config.get_config_value('Version', '1.0.0')))
-        f.close()
+        prj_tcl_dst = Path(f'{model.config.get_output_dir()}/project.tcl')
+        with open(prj_tcl_dst, 'w') as f:
+            f.write('variable project_name\n')
+            f.write(f'set project_name "{model.config.get_project_name()}"\n')
+            f.write('variable backend\n')
+            f.write('set backend "vivado"\n')
+            f.write('variable part\n')
+            f.write('set part "{}"\n'.format(model.config.get_config_value('Part')))
+            f.write('variable clock_period\n')
+            f.write('set clock_period {}\n'.format(model.config.get_config_value('ClockPeriod')))
+            f.write('variable clock_uncertainty\n')
+            f.write('set clock_uncertainty {}\n'.format(model.config.get_config_value('ClockUncertainty', '12.5%')))
+            f.write('variable version\n')
+            f.write('set version "{}"\n'.format(model.config.get_config_value('Version', '1.0.0')))
 
         # build_prj.tcl
-        srcpath = os.path.join(filedir, '../templates/vivado/build_prj.tcl')
+        srcpath = (filedir / '../templates/vivado/build_prj.tcl').resolve()
         dstpath = f'{model.config.get_output_dir()}/build_prj.tcl'
         copyfile(srcpath, dstpath)
 
         # vivado_synth.tcl
-        srcpath = os.path.join(filedir, '../templates/vivado/vivado_synth.tcl')
+        srcpath = (filedir / '../templates/vivado/vivado_synth.tcl').resolve()
         dstpath = f'{model.config.get_output_dir()}/vivado_synth.tcl'
         copyfile(srcpath, dstpath)
 
         # build_lib.sh
-        f = open(os.path.join(filedir, '../templates/vivado/build_lib.sh'))
-        fout = open(f'{model.config.get_output_dir()}/build_lib.sh', 'w')
+        build_lib_src = (filedir / '../templates/vivado/build_lib.sh').resolve()
+        build_lib_dst = Path(f'{model.config.get_output_dir()}/build_lib.sh').resolve()
+        with open(build_lib_src) as src, open(build_lib_dst, 'w') as dst:
+            for line in src.readlines():
+                line = line.replace('myproject', model.config.get_project_name())
+                line = line.replace('mystamp', model.config.get_config_value('Stamp'))
 
-        for line in f.readlines():
-            line = line.replace('myproject', model.config.get_project_name())
-            line = line.replace('mystamp', model.config.get_config_value('Stamp'))
-
-            fout.write(line)
-        f.close()
-        fout.close()
+                dst.write(line)
+        build_lib_dst.chmod(build_lib_dst.stat().st_mode | stat.S_IEXEC)
 
     def write_nnet_utils(self, model):
         """Copy the nnet_utils, AP types headers and any custom source to the project output directory


### PR DESCRIPTION
# Description

In some cases when the compilation fails, the `build_lib.sh` script still returns 0 and the actual error is "lost" (as in, not visible in all environments, like Jupyter). We can force the script to fail on any error with `set -e` command, as done in first commit. The other two commits are to improve the code path that is touched by this. `build_lib.sh` should be executable and this prompted a change in writer. While there, I updated the code to use the `pathlib` library instead of os.path for a cleaner code. We should do a separate PR to change the rest of the writer (also in other backends eventually). Finally there's a change to use `subprocess` instead of `os.system` since this is the recommended way for newer Python.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue) - sort of.

## Tests

Existing tests are enough, they all call `compile()` in some way.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
