### PR TITLE
Expose alpha and theta type for parametrized activations

### DIFF
--- a/hls4ml/backends/quartus/passes/core_templates.py
+++ b/hls4ml/backends/quartus/passes/core_templates.py
@@ -125,6 +125,15 @@ activ_config_template = """struct {type}_config{index} : nnet::activ_config {{
     typedef {table_t.name} table_t;
 }};\n"""
 
+param_activ_config_template = """struct {type}_config{index} : nnet::activ_config {{
+    static const unsigned n_in = {n_in};
+    static const unsigned table_size = {table_size};
+    static const unsigned io_type = nnet::{iotype};
+    static const unsigned reuse_factor = {reuse};
+    typedef {table_t.name} table_t;
+    typedef {param_t.name} param_t;
+}};\n"""
+
 hard_activ_config_template = """struct {type}_config{index} {{
     static const unsigned n_in = {n_in};
     static const {slope_t.name} slope;
@@ -146,15 +155,29 @@ softmax_config_template = """struct {type}_config{index} : nnet::activ_config {{
 }};\n"""
 
 activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {config}>({input}, {output});'
-param_activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {config}>({input}, {param}, {output});'
+param_activ_function_template = (
+    'nnet::{activation}<{input_t}, {param_t.name}, {output_t}, {config}>({input}, {param}, {output});'
+)
 
 activ_include_list = ['nnet_utils/nnet_activation.h', 'nnet_utils/nnet_activation_stream.h']
 
 
 class ActivationConfigTemplate(LayerConfigTemplate):
     def __init__(self):
-        super().__init__((Activation, ParametrizedActivation, PReLU, UnaryLUT))
+        super().__init__((Activation, UnaryLUT))
         self.template = activ_config_template
+
+    def format(self, node):
+        params = self._default_config_params(node)
+        params['type'] = node.get_attr('activation')
+
+        return self.template.format(**params)
+
+
+class ParamActivationConfigTemplate(LayerConfigTemplate):
+    def __init__(self):
+        super().__init__((ParametrizedActivation, PReLU))
+        self.template = param_activ_config_template
 
     def format(self, node):
         params = self._default_config_params(node)
@@ -216,7 +239,7 @@ class PReLUFunctionTemplate(FunctionCallTemplate):
     def format(self, node):
         params = self._default_function_params(node)
         params['activation'] = node.get_attr('activation').lower()
-        params['param'] = node.get_weights('alpha').name
+        params['param'] = node.get_weights('param').name
         params['config'] = '{}_config{}'.format(node.get_attr('activation'), node.index)
 
         return self.template.format(**params)

--- a/hls4ml/backends/vivado/passes/core_templates.py
+++ b/hls4ml/backends/vivado/passes/core_templates.py
@@ -116,6 +116,15 @@ activ_config_template = """struct {type}_config{index} : nnet::activ_config {{
     typedef {table_t.name} table_t;
 }};\n"""
 
+param_activ_config_template = """struct {type}_config{index} : nnet::activ_config {{
+    static const unsigned n_in = {n_in};
+    static const unsigned table_size = {table_size};
+    static const unsigned io_type = nnet::{iotype};
+    static const unsigned reuse_factor = {reuse};
+    typedef {table_t.name} table_t;
+    typedef {param_t.name} param_t;
+}};\n"""
+
 hard_activ_config_template = """struct {type}_config{index} {{
     static const unsigned n_in = {n_in};
     static const {slope_t.name} slope;
@@ -138,15 +147,29 @@ softmax_config_template = """struct {type}_config{index} : nnet::activ_config {{
 }};\n"""
 
 activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {config}>({input}, {output});'
-param_activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {config}>({input}, {param}, {output});'
+param_activ_function_template = (
+    'nnet::{activation}<{input_t}, {param_t.name}, {output_t}, {config}>({input}, {param}, {output});'
+)
 
 activ_include_list = ['nnet_utils/nnet_activation.h', 'nnet_utils/nnet_activation_stream.h']
 
 
 class ActivationConfigTemplate(LayerConfigTemplate):
     def __init__(self):
-        super().__init__((Activation, ParametrizedActivation, PReLU, UnaryLUT))
+        super().__init__((Activation, UnaryLUT))
         self.template = activ_config_template
+
+    def format(self, node):
+        params = self._default_config_params(node)
+        params['type'] = node.get_attr('activation')
+
+        return self.template.format(**params)
+
+
+class ParamActivationConfigTemplate(LayerConfigTemplate):
+    def __init__(self):
+        super().__init__((ParametrizedActivation, PReLU))
+        self.template = param_activ_config_template
 
     def format(self, node):
         params = self._default_config_params(node)
@@ -208,7 +231,7 @@ class PReLUFunctionTemplate(FunctionCallTemplate):
     def format(self, node):
         params = self._default_function_params(node)
         params['activation'] = node.get_attr('activation').lower()
-        params['param'] = node.get_weights('alpha').name
+        params['param'] = node.get_weights('param').name
         params['config'] = '{}_config{}'.format(node.get_attr('activation'), node.index)
 
         return self.template.format(**params)

--- a/hls4ml/converters/keras/core.py
+++ b/hls4ml/converters/keras/core.py
@@ -71,7 +71,7 @@ def parse_activation_layer(keras_layer, input_names, input_shapes, data_reader):
     elif layer['class_name'] == 'ReLU':
         layer['class_name'] = 'Activation'
     elif layer['class_name'] == 'PReLU':
-        layer['alpha_data'] = get_weights_data(data_reader, layer['name'], 'alpha')
+        layer['param_data'] = get_weights_data(data_reader, layer['name'], 'alpha')
 
     if layer['class_name'] == 'Activation' and layer['activation'] == 'softmax':
         layer['class_name'] = 'Softmax'

--- a/hls4ml/converters/pytorch/core.py
+++ b/hls4ml/converters/pytorch/core.py
@@ -55,7 +55,7 @@ def parse_activation_layer(operation, layer_name, input_names, input_shapes, nod
         if layer['class_name'] == 'ELU':
             layer['activ_param'] = class_object.alpha
         if layer['class_name'] == 'PReLU':
-            layer['alpha_data'] = class_object.weight.data.numpy()
+            layer['param_data'] = class_object.weight.data.numpy()
         if layer['class_name'] == 'Threshold':
             layer['activ_param'] = class_object.threshold
             layer['class_name'] = 'ThresholdedReLU'

--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -845,6 +845,17 @@ class Activation(Layer):
 
 
 class ParametrizedActivation(Activation):
+    _expected_attributes = [
+        Attribute('n_in'),
+        Attribute('activation', value_type=str),
+        TypeAttribute('param'),
+    ]
+
+    def initialize(self):
+        super().initialize()
+        param_t = NamedType(*reversed(self.model.config.get_precision(self, 'param')))
+        self.set_attr('param_t', param_t)
+
     def _get_act_function_name(self):
         act = self.get_attr('activation').lower()
         if act == 'leakyrelu':
@@ -882,9 +893,16 @@ class HardActivation(Activation):
 
 
 class PReLU(Activation):
+    _expected_attributes = [
+        Attribute('n_in'),
+        Attribute('activation', value_type=str),
+        WeightAttribute('param'),
+        TypeAttribute('param'),
+    ]
+
     def initialize(self):
         super().initialize()
-        self.add_weights_variable(name='alpha', var_name='a{index}')
+        self.add_weights_variable(name='param', var_name='a{index}')
 
 
 class Softmax(Activation):

--- a/hls4ml/model/optimizer/passes/infer_precision.py
+++ b/hls4ml/model/optimizer/passes/infer_precision.py
@@ -84,6 +84,9 @@ class InferPrecisionTypes(ConfigurableOptimizerPass):
         if node_class in ['SimpleRNN', 'LSTM', 'GRU']:
             return self._infer_rnn_precision(node, types_to_infer)
 
+        if node_class in ['ParametrizedActivation']:
+            return self._infer_par_act_precision(node, types_to_infer)
+
         # What about quantized activation layer? Setting it to 'auto' manually will break it here. We should prevent
         # this in config_from_* functions
 
@@ -555,5 +558,16 @@ class InferPrecisionTypes(ConfigurableOptimizerPass):
                 self._infer_default_type(node, f'{weightvar}_t')
                 node.weights[weightvar].update_precision(node.types[f'{weightvar}_t'].precision)
                 inferred_types.append(f'{weightvar}_t')
+
+        return inferred_types
+
+    def _infer_par_act_precision(self, node, types_to_infer):
+        inferred_types = []
+
+        # for now, only set if for threshold relu
+        if 'param_t' in inferred_types and self.get_attr('activation').lower() == 'thresholdedrelu':
+            in_type = node.get_input_variable().type.precision
+            node.attributes['param_t'].type = in_type
+            inferred_types.append('param_t')
 
         return inferred_types

--- a/hls4ml/model/optimizer/passes/infer_precision.py
+++ b/hls4ml/model/optimizer/passes/infer_precision.py
@@ -564,7 +564,9 @@ class InferPrecisionTypes(ConfigurableOptimizerPass):
     def _infer_par_act_precision(self, node, types_to_infer):
         inferred_types = []
 
-        # for now, only set if for threshold relu
+        # For threshold relu, set the parameter precision to be the input precision by default;
+        # for other parametrized activations, just allow the default precision to be used.
+        # Can override these values in the configuration by explicitly setting them.
         if 'param_t' in inferred_types and self.get_attr('activation').lower() == 'thresholdedrelu':
             in_type = node.get_input_variable().type.precision
             node.attributes['param_t'].type = in_type

--- a/hls4ml/templates/catapult/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/catapult/nnet_utils/nnet_activation.h
@@ -686,8 +686,8 @@ void hard_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
 // *************************************************
 //       Leaky RELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void leaky_relu(data_T data[CONFIG_T::n_in], data_T alpha, res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void leaky_relu(data_T data[CONFIG_T::n_in], param_T alpha, res_T res[CONFIG_T::n_in]) {
     //#pragma HLS PIPELINE
 
     data_T datareg;
@@ -703,8 +703,8 @@ void leaky_relu(data_T data[CONFIG_T::n_in], data_T alpha, res_T res[CONFIG_T::n
 // *************************************************
 //       Thresholded RELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void thresholded_relu(data_T data[CONFIG_T::n_in], data_T theta, res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void thresholded_relu(data_T data[CONFIG_T::n_in], param_T theta, res_T res[CONFIG_T::n_in]) {
     //#pragma HLS PIPELINE
 
     data_T datareg;
@@ -917,8 +917,8 @@ template <typename CONFIG_T, int N_TABLE> void init_elu_table(typename CONFIG_T:
 
 #ifndef USE_AC_MATH
 
-template <class data_T, class res_T, typename CONFIG_T>
-void elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(data_T data[CONFIG_T::n_in], const param_T alpha, res_T res[CONFIG_T::n_in]) {
     // Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
@@ -953,8 +953,8 @@ void elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_i
 
 #else
 
-template <class data_T, class res_T, typename CONFIG_T>
-void elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(data_T data[CONFIG_T::n_in], const param_T alpha, res_T res[CONFIG_T::n_in]) {
     for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
         ac_math::ac_elu_pwl(data[ii], res[ii], alpha);
     }
@@ -1045,8 +1045,8 @@ template <class data_T, class res_T, typename CONFIG_T> void selu(data_T data[CO
 // *************************************************
 //       PReLU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void prelu(data_T data[CONFIG_T::n_in], data_T alpha[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void prelu(data_T data[CONFIG_T::n_in], param_T alpha[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
     //#pragma HLS PIPELINE
 
     data_T datareg;

--- a/hls4ml/templates/catapult/nnet_utils/nnet_activation_stream.h
+++ b/hls4ml/templates/catapult/nnet_utils/nnet_activation_stream.h
@@ -545,8 +545,8 @@ HardTanhActLoop:
 // *************************************************
 //       Leaky RELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void leaky_relu(ac_channel<data_T> &data, typename data_T::value_type alpha, ac_channel<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void leaky_relu(ac_channel<data_T> &data, param_T alpha, ac_channel<res_T> &res) {
 LeakyReLUActLoop:
     for (int i = 0; i < CONFIG_T::n_in / res_T::size; i++) {
         //#pragma HLS PIPELINE
@@ -571,8 +571,8 @@ LeakyReLUActLoop:
 //       Thresholded RELU Activation
 // *************************************************
 
-template <class data_T, class res_T, typename CONFIG_T>
-void thresholded_relu(ac_channel<data_T> &data, typename data_T::value_type theta, ac_channel<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void thresholded_relu(ac_channel<data_T> &data, param_T theta, ac_channel<res_T> &res) {
 ThresholdedReLUActLoop:
     for (int i = 0; i < CONFIG_T::n_in / res_T::size; i++) {
         //#pragma HLS PIPELINE
@@ -720,8 +720,8 @@ SoftsignActLoop:
 
 #ifndef USE_AC_MATH
 
-template <class data_T, class res_T, typename CONFIG_T>
-void elu(ac_channel<data_T> &data, typename data_T::value_type alpha, ac_channel<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(ac_channel<data_T> &data, param_T alpha, ac_channel<res_T> &res) {
     // Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
@@ -763,8 +763,8 @@ EluActLoop:
 }
 
 #else
-template <class data_T, class res_T, typename CONFIG_T>
-void elu(ac_channel<data_T> &data, typename data_T::value_type alpha, ac_channel<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(ac_channel<data_T> &data, param_T alpha, ac_channel<res_T> &res) {
 EluActLoop:
     for (int i = 0; i < CONFIG_T::n_in / res_T::size; i++) {
         data_T in_data = data.read();
@@ -845,8 +845,8 @@ SeluActLoop:
 // *************************************************
 //       PReLU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void prelu(ac_channel<data_T> &data, typename data_T::value_type alpha[CONFIG_T::n_in], ac_channel<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void prelu(ac_channel<data_T> &data, const param_T alpha[CONFIG_T::n_in], ac_channel<res_T> &res) {
 PReLUActLoop:
     for (int i = 0; i < CONFIG_T::n_in / res_T::size; i++) {
         //#pragma HLS PIPELINE

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_activation.h
@@ -433,7 +433,8 @@ void elu(data_T data[CONFIG_T::n_in], const param_T alpha, res_T res[CONFIG_T::n
     }
 }
 
-template <class data_T, class param_T, class res_T, typename CONFIG_T> void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
     elu<data_T, param_T, res_T, CONFIG_T>(data, 1.0, res);
 }
 

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_activation.h
@@ -333,8 +333,8 @@ void hard_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
 // *************************************************
 //       Leaky RELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void leaky_relu(data_T data[CONFIG_T::n_in], data_T alpha, res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void leaky_relu(data_T data[CONFIG_T::n_in], param_T alpha, res_T res[CONFIG_T::n_in]) {
     #pragma unroll
     for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
         data_T datareg = data[ii];
@@ -348,8 +348,8 @@ void leaky_relu(data_T data[CONFIG_T::n_in], data_T alpha, res_T res[CONFIG_T::n
 // *************************************************
 //       Thresholded RELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void thresholded_relu(data_T data[CONFIG_T::n_in], data_T theta, res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void thresholded_relu(data_T data[CONFIG_T::n_in], param_T theta, res_T res[CONFIG_T::n_in]) {
     #pragma unroll
     for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
         data_T datareg = data[ii];
@@ -414,8 +414,8 @@ void softsign(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
 // *************************************************
 //       ELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(data_T data[CONFIG_T::n_in], const param_T alpha, res_T res[CONFIG_T::n_in]) {
 // Initialize the lookup table
 #include "activation_tables/elu_table.tb"
     // Index into the lookup table based on data
@@ -433,8 +433,8 @@ void elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_i
     }
 }
 
-template <class data_T, class res_T, typename CONFIG_T> void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
-    elu<data_T, res_T, CONFIG_T>(data, 1.0, res);
+template <class data_T, class param_T, class res_T, typename CONFIG_T> void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
+    elu<data_T, param_T, res_T, CONFIG_T>(data, 1.0, res);
 }
 
 // *************************************************
@@ -461,8 +461,8 @@ template <class data_T, class res_T, typename CONFIG_T> void selu(data_T data[CO
 // *************************************************
 //       PReLU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void prelu(data_T data[CONFIG_T::n_in], const data_T alpha[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void prelu(data_T data[CONFIG_T::n_in], const param_T alpha[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
     #pragma unroll
     for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
         data_T datareg = data[ii];

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_activation.h
@@ -433,9 +433,8 @@ void elu(data_T data[CONFIG_T::n_in], const param_T alpha, res_T res[CONFIG_T::n
     }
 }
 
-template <class data_T, class param_T, class res_T, typename CONFIG_T>
-void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
-    elu<data_T, param_T, res_T, CONFIG_T>(data, 1.0, res);
+template <class data_T, class res_T, typename CONFIG_T> void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
+    elu<data_T, ac_int<1, false>, res_T, CONFIG_T>(data, 1.0, res);
 }
 
 // *************************************************

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_activation_stream.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_activation_stream.h
@@ -134,8 +134,8 @@ EluActLoop:
     }
 }
 
-template <class data_T, class res_T, class param_T, typename CONFIG_T> void elu(stream<data_T> &data, stream<res_T> &res) {
-    elu<data_T, param_T, res_T, CONFIG_T>(data, 1.0, res);
+template <class data_T, class res_T, typename CONFIG_T> void elu(stream<data_T> &data, stream<res_T> &res) {
+    elu<data_T, ac_int<1, false>, res_T, CONFIG_T>(data, 1.0, res);
 }
 
 // *************************************************

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_activation_stream.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_activation_stream.h
@@ -52,8 +52,8 @@ ReLUActLoop:
 // *************************************************
 //       Leaky RELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void leaky_relu(stream<data_T> &data, const typename data_T::value_type alpha, stream<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void leaky_relu(stream<data_T> &data, param_T alpha, stream<res_T> &res) {
     constexpr unsigned multiplier_limit = DIV_ROUNDUP(data_T::size, CONFIG_T::reuse_factor);
     constexpr unsigned pipeline = data_T::size / multiplier_limit;
 
@@ -79,8 +79,8 @@ LeakyReLUActLoop:
 // *************************************************
 //       Thresholded RELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void thresholded_relu(stream<data_T> &data, const typename data_T::value_type theta, stream<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void thresholded_relu(stream<data_T> &data, param_T theta, stream<res_T> &res) {
 ThresholdedReLUActLoop:
     #pragma ii 1
     for (int i = 0; i < CONFIG_T::n_in / res_T::size; i++) {
@@ -103,8 +103,8 @@ ThresholdedReLUActLoop:
 // *************************************************
 //       ELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void elu(stream<data_T> &data, const typename data_T::value_type alpha, stream<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(stream<data_T> &data, param_T alpha, stream<res_T> &res) {
 #include "activation_tables/elu_table.tb"
 
     constexpr unsigned multiplier_limit = DIV_ROUNDUP(data_T::size, CONFIG_T::reuse_factor);
@@ -134,8 +134,8 @@ EluActLoop:
     }
 }
 
-template <class data_T, class res_T, typename CONFIG_T> void elu(stream<data_T> &data, stream<res_T> &res) {
-    elu<data_T, res_T, CONFIG_T>(data, 1.0, res);
+template <class data_T, class res_T, class param_T, typename CONFIG_T> void elu(stream<data_T> &data, stream<res_T> &res) {
+    elu<data_T, param_T, res_T, CONFIG_T>(data, 1.0, res);
 }
 
 // *************************************************
@@ -171,8 +171,8 @@ SeluActLoop:
 // *************************************************
 //       PReLU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void prelu(stream<data_T> &data, const typename data_T::value_type alpha[CONFIG_T::n_in], stream<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void prelu(stream<data_T> &data, const param_T alpha[CONFIG_T::n_in], stream<res_T> &res) {
     constexpr unsigned multiplier_limit = DIV_ROUNDUP(data_T::size, CONFIG_T::reuse_factor);
     constexpr unsigned pipeline = data_T::size / multiplier_limit;
 

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -679,9 +679,8 @@ void elu(data_T data[CONFIG_T::n_in], const param_T alpha, res_T res[CONFIG_T::n
     }
 }
 
-template <class data_T, class param_T, class res_T, typename CONFIG_T>
-void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
-    elu<data_T, param_T, res_T, CONFIG_T>(data, 1.0, res);
+template <class data_T, class res_T, typename CONFIG_T> void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
+    elu<data_T, ap_uint<1>, res_T, CONFIG_T>(data, 1.0, res);
 }
 
 // *************************************************

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -499,8 +499,8 @@ void hard_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
 // *************************************************
 //       Leaky RELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void leaky_relu(data_T data[CONFIG_T::n_in], data_T alpha, res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void leaky_relu(data_T data[CONFIG_T::n_in], param_T alpha, res_T res[CONFIG_T::n_in]) {
     #pragma HLS PIPELINE
 
     data_T datareg;
@@ -516,8 +516,8 @@ void leaky_relu(data_T data[CONFIG_T::n_in], data_T alpha, res_T res[CONFIG_T::n
 // *************************************************
 //       Thresholded RELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void thresholded_relu(data_T data[CONFIG_T::n_in], data_T theta, res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void thresholded_relu(data_T data[CONFIG_T::n_in], param_T theta, res_T res[CONFIG_T::n_in]) {
     #pragma HLS PIPELINE
 
     data_T datareg;
@@ -646,8 +646,8 @@ template <typename CONFIG_T, int N_TABLE> void init_elu_table(typename CONFIG_T:
     }
 }
 
-template <class data_T, class res_T, typename CONFIG_T>
-void elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(data_T data[CONFIG_T::n_in], const param_T alpha, res_T res[CONFIG_T::n_in]) {
     // Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
@@ -679,8 +679,9 @@ void elu(data_T data[CONFIG_T::n_in], const res_T alpha, res_T res[CONFIG_T::n_i
     }
 }
 
-template <class data_T, class res_T, typename CONFIG_T> void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
-    elu<data_T, res_T, CONFIG_T>(data, 1.0, res);
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
+    elu<data_T, param_T, res_T, CONFIG_T>(data, 1.0, res);
 }
 
 // *************************************************
@@ -738,8 +739,8 @@ template <class data_T, class res_T, typename CONFIG_T> void selu(data_T data[CO
 // *************************************************
 //       PReLU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void prelu(data_T data[CONFIG_T::n_in], data_T alpha[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void prelu(data_T data[CONFIG_T::n_in], param_T alpha[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
     #pragma HLS PIPELINE
 
     data_T datareg;

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation_stream.h
@@ -728,7 +728,7 @@ SeluActLoop:
 // *************************************************
 
 template <class data_T, class param_T, class res_T, typename CONFIG_T>
-void prelu(hls::stream<data_T> &data, param_T alpha[CONFIG_T::n_in], hls::stream<res_T> &res) {
+void prelu(hls::stream<data_T> &data, const param_T alpha[CONFIG_T::n_in], hls::stream<res_T> &res) {
 PReLUActLoop:
     for (int i = 0; i < CONFIG_T::n_in / res_T::size; i++) {
         #pragma HLS PIPELINE

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation_stream.h
@@ -499,8 +499,8 @@ HardSigmoidActLoop:
 //       Leaky RELU Activation
 // *************************************************
 
-template <class data_T, class res_T, typename CONFIG_T>
-void leaky_relu(hls::stream<data_T> &data, typename data_T::value_type alpha, hls::stream<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void leaky_relu(hls::stream<data_T> &data, param_T alpha, hls::stream<res_T> &res) {
 LeakyReLUActLoop:
     for (int i = 0; i < CONFIG_T::n_in / res_T::size; i++) {
         #pragma HLS PIPELINE
@@ -525,8 +525,8 @@ LeakyReLUActLoop:
 //       Thresholded RELU Activation
 // *************************************************
 
-template <class data_T, class res_T, typename CONFIG_T>
-void thresholded_relu(hls::stream<data_T> &data, typename data_T::value_type theta, hls::stream<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void thresholded_relu(hls::stream<data_T> &data, param_T theta, hls::stream<res_T> &res) {
 ThresholdedReLUActLoop:
     for (int i = 0; i < CONFIG_T::n_in / res_T::size; i++) {
         #pragma HLS PIPELINE
@@ -633,8 +633,8 @@ SoftsignActLoop:
 // *************************************************
 //       ELU Activation
 // *************************************************
-template <class data_T, class res_T, typename CONFIG_T>
-void elu(hls::stream<data_T> &data, typename data_T::value_type alpha, hls::stream<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(hls::stream<data_T> &data, param_T alpha, hls::stream<res_T> &res) {
     // Initialize the lookup table
 #ifdef __HLS_SYN__
     bool initialized = false;
@@ -674,8 +674,9 @@ EluActLoop:
     }
 }
 
-template <class data_T, class res_T, typename CONFIG_T> void elu(hls::stream<data_T> &data, hls::stream<res_T> &res) {
-    elu<data_T, res_T, CONFIG_T>(data, 1.0, res);
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void elu(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+    elu<data_T, param_T, res_T, CONFIG_T>(data, 1.0, res);
 }
 
 // *************************************************
@@ -726,8 +727,8 @@ SeluActLoop:
 //       PReLU Activation
 // *************************************************
 
-template <class data_T, class res_T, typename CONFIG_T>
-void prelu(hls::stream<data_T> &data, typename data_T::value_type alpha[CONFIG_T::n_in], hls::stream<res_T> &res) {
+template <class data_T, class param_T, class res_T, typename CONFIG_T>
+void prelu(hls::stream<data_T> &data, param_T alpha[CONFIG_T::n_in], hls::stream<res_T> &res) {
 PReLUActLoop:
     for (int i = 0; i < CONFIG_T::n_in / res_T::size; i++) {
         #pragma HLS PIPELINE

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation_stream.h
@@ -674,9 +674,8 @@ EluActLoop:
     }
 }
 
-template <class data_T, class param_T, class res_T, typename CONFIG_T>
-void elu(hls::stream<data_T> &data, hls::stream<res_T> &res) {
-    elu<data_T, param_T, res_T, CONFIG_T>(data, 1.0, res);
+template <class data_T, class res_T, typename CONFIG_T> void elu(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+    elu<data_T, ap_uint<1>, res_T, CONFIG_T>(data, 1.0, res);
 }
 
 // *************************************************

--- a/test/pytest/test_activations.py
+++ b/test/pytest/test_activations.py
@@ -41,7 +41,7 @@ def test_activations(backend, activation, name, shape, io_type):
     activation = activation(input)
     keras_model = Model(inputs=input, outputs=activation)
 
-    hls_config = hls4ml.utils.config_from_keras_model(keras_model)
+    hls_config = hls4ml.utils.config_from_keras_model(keras_model, granularity='name', backend=backend)
     output_dir = str(test_root_path / 'hls4mlprj_activations_{}_{}_{}_{}').format(backend, io_type, str(shape), name)
 
     hls_model = hls4ml.converters.convert_from_keras_model(


### PR DESCRIPTION
# Description

The type of the parameter for parametrized activations were not configurable before, being set the same as either the input of result. Generally there is no reason for that requirement, so this makes the type explicitly configurable,

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Tests

The standard activations tests (slightly modified) provide the test.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
