### PR TITLE
update keras activation parsing, especially leaky relu

### DIFF
--- a/hls4ml/converters/keras/core.py
+++ b/hls4ml/converters/keras/core.py
@@ -62,8 +62,13 @@ def parse_activation_layer(keras_layer, input_names, input_shapes, data_reader):
 
     if layer['class_name'] != 'Activation':
         layer['activation'] = layer['class_name']
+
+    if layer['activation'] == 'elu':
+        layer['class_name'] = 'ELU'  # always use ELU type for elu, even if passed as activation
+
     if layer['class_name'] == 'LeakyReLU':
-        layer['activ_param'] = keras_layer['config'].get('alpha', 0.3)
+        # the name changes for version 3
+        layer['activ_param'] = keras_layer['config'].get('negative_slope', keras_layer['config'].get('alpha', 0.3))
     elif layer['class_name'] == 'ThresholdedReLU':
         layer['activ_param'] = keras_layer['config'].get('theta', 1.0)
     elif layer['class_name'] == 'ELU':
@@ -79,6 +84,10 @@ def parse_activation_layer(keras_layer, input_names, input_shapes, data_reader):
         layer['class_name'] = 'HardActivation'
     if layer['class_name'] == 'Softmax':
         layer['axis'] = keras_layer['config'].get('axis', -1)
+    if layer['class_name'] == 'Activation' and layer['activation'] == 'leaky_relu':
+        layer['class_name'] = 'LeakyReLU'
+        # The parameter name changes for API v3; the default is different than in LeakyReLU layer
+        layer['activ_param'] = keras_layer['config'].get('negative_slope', keras_layer['config'].get('alpha', 0.2))
 
     return layer, [shape for shape in input_shapes[0]]
 

--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -297,26 +297,18 @@ def parse_keras_model(model_arch, reader):
         layer_list.append(layer)
         if 'activation' in layer and layer['class_name'] not in activation_layers + recurrent_layers:  # + qkeras_layers:
             act_layer = {}
+            act_details = layer['activation']
             # Workaround for QKeras activations passed as an argument
-            if isinstance(layer['activation'], dict):
-                act_details = layer['activation']
+            if isinstance(act_details, dict):
                 act_layer['class_name'] = 'QActivation'
                 act_layer['config'] = {
                     'name': layer['name'] + '_' + act_details['class_name'],
                     'activation': act_details,
                 }
-                act_layer, output_shape = layer_handlers['QActivation'](act_layer, None, [output_shape], reader)
             else:
-                act_layer['name'] = layer['name'] + '_' + layer['activation']
-                act_layer['activation'] = layer['activation']
-                if 'activ_param' in layer:
-                    act_layer['activ_param'] = layer['activ_param']
-                    act_layer['class_name'] = layer['activation']
-                elif layer['activation'] == 'softmax':
-                    act_layer['class_name'] = 'Softmax'
-                    act_layer['axis'] = -1
-                else:
-                    act_layer['class_name'] = 'Activation'
+                act_layer['class_name'] = 'Activation'
+                act_layer['config'] = {'name': layer['name'] + '_' + act_details, 'activation': act_details}
+            act_layer, output_shape = layer_handlers[act_layer['class_name']](act_layer, None, [output_shape], reader)
             inputs_map[layer['name']] = act_layer['name']
             if output_layers is not None and layer['name'] in output_layers:
                 output_layers = [act_layer['name'] if name == layer['name'] else name for name in output_layers]

--- a/test/pytest/test_activations.py
+++ b/test/pytest/test_activations.py
@@ -19,6 +19,7 @@ test_root_path = Path(__file__).parent
     [
         (ReLU(), 'relu'),
         (LeakyReLU(alpha=1.5), 'leaky_relu'),
+        (Activation('leaky_relu'), 'leaky_relu_act'),
         (ThresholdedReLU(theta=0.75), 'threshold_relu'),
         (ELU(alpha=1.25), 'elu'),
         (Activation('selu'), 'selu'),


### PR DESCRIPTION
# Description

Issue #1076 showed that hls4ml didn't parse leaky_relu passed as a parameter (`activation='leaky_relu'`) in Keras properly. One could argue that it was not explicitly described in v2 of the API documentation, but it was in the code, and it is officially described in v3 of the API, so we should support it.

As an aside, I don't think we support relu with an alpha parameter properly--maybe I should add a check to change relu to leaky_relu in that case.

I noticed also that the `Activation` layer handler was not called for activations passed as arguments. Special cases had to be handled in two places, once in the Activation layer handler, once in the activations passed as arguments section. This I believe is error-prone, and elu passed as an argument would break the oneAPI backend if I don't duplicate code. I think it is better to unify and always call the Activation layer handler, so that is what I did instead.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Tests

I added a leaky_relu passed as argument test, and it's also important not to break the other tests.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
