### PR TITLE
Change indexing in filling result for io_parallel convolutions, Vitis

### DIFF
--- a/hls4ml/templates/vitis/nnet_utils/nnet_conv1d_resource.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_conv1d_resource.h
@@ -94,7 +94,7 @@ PartitionLoop:
         ResultLoop:
             for (unsigned i_res = 0; i_res < mult_n_out; i_res++) {
                 #pragma HLS UNROLL
-                res[i_part * CONFIG_T::n_partitions * CONFIG_T::n_pixels + i_pxl * CONFIG_T::n_pixels + i_res] =
+                res[i_part * CONFIG_T::n_pixels * mult_n_out + i_pxl * mult_n_out + i_res] =
                     cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
             }
         }

--- a/hls4ml/templates/vitis/nnet_utils/nnet_conv1d_resource.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_conv1d_resource.h
@@ -94,7 +94,8 @@ PartitionLoop:
         ResultLoop:
             for (unsigned i_res = 0; i_res < mult_n_out; i_res++) {
                 #pragma HLS UNROLL
-                *(res++) = cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
+                res[i_part * CONFIG_T::n_partitions * CONFIG_T::n_pixels + i_pxl * CONFIG_T::n_pixels + i_res] =
+                    cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
             }
         }
     }

--- a/hls4ml/templates/vitis/nnet_utils/nnet_conv2d_resource.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_conv2d_resource.h
@@ -97,7 +97,8 @@ PartitionLoop:
         ResultLoop:
             for (unsigned i_res = 0; i_res < mult_n_out; i_res++) {
                 #pragma HLS UNROLL
-                *(res++) = cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
+                res[i_part * CONFIG_T::n_partitions * CONFIG_T::n_pixels + i_pxl * CONFIG_T::n_pixels + i_res] =
+                    cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
             }
         }
     }

--- a/hls4ml/templates/vitis/nnet_utils/nnet_conv2d_resource.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_conv2d_resource.h
@@ -97,7 +97,7 @@ PartitionLoop:
         ResultLoop:
             for (unsigned i_res = 0; i_res < mult_n_out; i_res++) {
                 #pragma HLS UNROLL
-                res[i_part * CONFIG_T::n_partitions * CONFIG_T::n_pixels + i_pxl * CONFIG_T::n_pixels + i_res] =
+                res[i_part * CONFIG_T::n_pixels * mult_n_out + i_pxl * mult_n_out + i_res] =
                     cast<data_T, res_T, typename CONFIG_T::mult_config>(acc[i_pxl][i_res]);
             }
         }

--- a/test/pytest/test_keras_api.py
+++ b/test/pytest/test_keras_api.py
@@ -119,9 +119,19 @@ padds_options = ['same', 'valid']
 
 
 @pytest.mark.parametrize('padds', padds_options)
-@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'oneAPI'])
+@pytest.mark.parametrize(
+    'backend,strategy',
+    [
+        ('Vivado', 'Resource'),
+        ('Vivado', 'Latency'),
+        ('Vitis', 'Resource'),
+        ('Vitis', 'Latency'),
+        ('Quartus', 'Resource'),
+        ('oneAPI', 'Resource'),
+    ],
+)
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
-def test_conv1d(padds, backend, io_type):
+def test_conv1d(padds, backend, strategy, io_type):
     model = tf.keras.models.Sequential()
     input_shape = (10, 128, 4)
     model.add(
@@ -144,7 +154,8 @@ def test_conv1d(padds, backend, io_type):
     keras_prediction = model.predict(X_input)
 
     config = hls4ml.utils.config_from_keras_model(model)
-    output_dir = str(test_root_path / f'hls4mlprj_keras_api_conv1d_{padds}_{backend}_{io_type}')
+    config['Model']['Strategy'] = strategy
+    output_dir = str(test_root_path / f'hls4mlprj_keras_api_conv1d_{padds}_{backend}_{strategy}_{io_type}')
     hls_model = hls4ml.converters.convert_from_keras_model(
         model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
     )
@@ -192,9 +203,19 @@ padds_options = ['same', 'valid']
 
 @pytest.mark.parametrize('chans', chans_options)
 @pytest.mark.parametrize('padds', padds_options)
-@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'oneAPI'])
+@pytest.mark.parametrize(
+    'backend,strategy',
+    [
+        ('Vivado', 'Resource'),
+        ('Vivado', 'Latency'),
+        ('Vitis', 'Resource'),
+        ('Vitis', 'Latency'),
+        ('Quartus', 'Resource'),
+        ('oneAPI', 'Resource'),
+    ],
+)
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
-def test_conv2d(chans, padds, backend, io_type):
+def test_conv2d(chans, padds, backend, strategy, io_type):
     model = tf.keras.models.Sequential()
     input_shape = (28, 28, 3)
     model.add(
@@ -215,7 +236,8 @@ def test_conv2d(chans, padds, backend, io_type):
     keras_prediction = model.predict(X_input)
 
     config = hls4ml.utils.config_from_keras_model(model)
-    output_dir = str(test_root_path / f'hls4mlprj_keras_api_conv2d_{backend}_{chans}_{padds}_{io_type}')
+    config['Model']['Strategy'] = strategy
+    output_dir = str(test_root_path / f'hls4mlprj_keras_api_conv2d_{backend}_{strategy}_{chans}_{padds}_{io_type}')
     hls_model = hls4ml.converters.convert_from_keras_model(
         model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
     )


### PR DESCRIPTION
# Description

Sometimes, though it's hard to exactly repeat the problem, one would see:

```
WARNING: [HLS 214-356] Array transformation on pointer indexing may lead to incorrect bank selection. Use array index instead of pointer. (firmware/nnet_utils/nnet_conv1d_resource.h:97:11)
ERROR: [HLS 214-384] in function 'void nnet::conv_1d_resource_cl<ap_ufixed<9, 0, (ap_q_mode)4, (ap_o_mode)0, 0>, ap_fixed<24, 9, (ap_q_mode)5, (ap_o_mode)3, 0>, config29>(ap_ufixed<9, 0, (ap_q_mode)4, (ap_o_mode)0, 0>*, ap_fixed<24, 9, (ap_q_mode)5, (ap_o_mode)3, 0>*, config29::weight_t*, config29::bias_t*) (.484)': Cannot apply array transformation pragma/directive because of full array load/store. (firmware/nnet_utils/nnet_conv1d_resource.h:97:11)
ERROR: [HLS 200-1715] Encountered problem during source synthesis
```

when using io_parallel convolutions with Vitis HLS. This change seems to fix the issue

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

The pytests should make sure this is correct. I made sure that the keras API tests run both `Resource` and `Latency` for conv1d and conv2d to make sure this code is tested. I was also able to test synthesis on the conv2d pytest project--note, it does not have any activation. (I understand the original version was a workaround for such a case.)

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
