### PR TITLE
Jit compile

### DIFF
--- a/hls4ml/backends/fpga/fpga_backend.py
+++ b/hls4ml/backends/fpga/fpga_backend.py
@@ -727,7 +727,7 @@ class FPGABackend(Backend):
 
         generated_code = (
             "template<class data_T, typename CONFIG_T>\n"
-            "class fill_buffer_{index} : public FillConv1DBuffer<data_T, CONFIG_T> {{\n"
+            "class fill_buffer_{index} : public nnet::FillConv1DBuffer<data_T, CONFIG_T> {{\n"
             "    public:\n"
             "    static void fill_buffer(\n"
             "        data_T data[CONFIG_T::in_width * CONFIG_T::n_chan],\n"
@@ -857,7 +857,7 @@ class FPGABackend(Backend):
 
         generated_code = (
             "template<class data_T, typename CONFIG_T>\n"
-            "class fill_buffer_{index} : public FillConv2DBuffer<data_T, CONFIG_T> {{\n"
+            "class fill_buffer_{index} : public nnet::FillConv2DBuffer<data_T, CONFIG_T> {{\n"
             "    public:\n"
             "    static void fill_buffer(\n"
             "        data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_chan],\n"

--- a/hls4ml/backends/fpga/passes/hgq_proxy_model.py
+++ b/hls4ml/backends/fpga/passes/hgq_proxy_model.py
@@ -79,7 +79,7 @@ class ProcessFixedPointQuantizerCall(FunctionCallTemplate):
 
     def format(self, node):
         params = self._default_function_params(node)
-        namespace = node.model.config.get_writer_config.get('Namespace', None) or 'nnet'
+        namespace = node.model.config.writer_config.get('Namespace', None) or 'nnet'
         params['namespace'] = namespace
 
         return self.template.format(**params)

--- a/hls4ml/backends/fpga/passes/hgq_proxy_model.py
+++ b/hls4ml/backends/fpga/passes/hgq_proxy_model.py
@@ -75,10 +75,12 @@ class ProcessFixedPointQuantizerLayer(OptimizerPass):
 class ProcessFixedPointQuantizerCall(FunctionCallTemplate):
     def __init__(self):
         super().__init__(FixedPointQuantizer, include_header=[])
-        self.template = 'nnet::{name}<{input_t}, {output_t}>({input}, {output});'
+        self.template = '{namespace}::{name}<{input_t}, {output_t}>({input}, {output});'
 
     def format(self, node):
         params = self._default_function_params(node)
+        namespace = node.model.config.get_writer_config()['Namespace'] or 'nnet'
+        params['namespace'] = namespace
 
         return self.template.format(**params)
 

--- a/hls4ml/backends/fpga/passes/hgq_proxy_model.py
+++ b/hls4ml/backends/fpga/passes/hgq_proxy_model.py
@@ -79,7 +79,7 @@ class ProcessFixedPointQuantizerCall(FunctionCallTemplate):
 
     def format(self, node):
         params = self._default_function_params(node)
-        namespace = node.model.config.get_writer_config()['Namespace'] or 'nnet'
+        namespace = node.model.config.get_writer_config.get('Namespace', None) or 'nnet'
         params['namespace'] = namespace
 
         return self.template.format(**params)

--- a/hls4ml/backends/template.py
+++ b/hls4ml/backends/template.py
@@ -62,7 +62,7 @@ class LayerConfigTemplate(Template):
         params = self._default_params(layer)
         params['iotype'] = layer.model.config.get_config_value('IOType')
         params['reuse'] = layer.get_attr('reuse_factor')
-        params['namespace'] = layer.model.config.get_writer_config().get('Namespace', 'nnet')
+        params['namespace'] = layer.model.config.get_writer_config()['Namespace'] or 'nnet'
 
         return params
 

--- a/hls4ml/backends/template.py
+++ b/hls4ml/backends/template.py
@@ -62,7 +62,7 @@ class LayerConfigTemplate(Template):
         params = self._default_params(layer)
         params['iotype'] = layer.model.config.get_config_value('IOType')
         params['reuse'] = layer.get_attr('reuse_factor')
-        params['namespace'] = layer.model.config.get_writer_config()['Namespace'] or 'nnet'
+        params['namespace'] = layer.model.config.get_writer_config().get('Namespace', None) or 'nnet'
 
         return params
 

--- a/hls4ml/backends/template.py
+++ b/hls4ml/backends/template.py
@@ -62,6 +62,7 @@ class LayerConfigTemplate(Template):
         params = self._default_params(layer)
         params['iotype'] = layer.model.config.get_config_value('IOType')
         params['reuse'] = layer.get_attr('reuse_factor')
+        params['namespace'] = layer.model.config.get_writer_config().get('Namespace', 'nnet')
 
         return params
 

--- a/hls4ml/backends/vivado/passes/convolution_templates.py
+++ b/hls4ml/backends/vivado/passes/convolution_templates.py
@@ -232,16 +232,17 @@ class Conv2DConfigTemplate(LayerConfigTemplate):
             node.get_input_variable().type.precision, node.get_weights('weight').type.precision
         )
 
+        namespace = params['namespace']
         if node.get_attr('strategy').lower() == 'latency':
-            mult_params['dense_function'] = 'DenseLatency'
+            mult_params['dense_function'] = 'nnet::DenseLatency'
         elif node.get_attr('strategy').lower() == 'resource':
             if int(mult_params['reuse_factor']) <= int(mult_params['n_in']):
-                mult_params['dense_function'] = 'DenseResource_rf_leq_nin'
+                mult_params['dense_function'] = 'nnet::DenseResource_rf_leq_nin'
             else:
-                mult_params['dense_function'] = 'DenseResource_rf_gt_nin_rem0'
+                mult_params['dense_function'] = 'nnet::DenseResource_rf_gt_nin_rem0'
             # The 3rd case is never used
         elif node.get_attr('strategy').lower() == 'resource_unrolled':
-            mult_params['dense_function'] = f'dense_resource_unrolled_{node.index}'
+            mult_params['dense_function'] = f'{namespace}::dense_resource_unrolled_{node.index}'
 
         mult_config = self.mult_template.format(**mult_params)
 

--- a/hls4ml/backends/vivado/passes/convolution_templates.py
+++ b/hls4ml/backends/vivado/passes/convolution_templates.py
@@ -23,7 +23,7 @@ conv_mult_config_template = """struct config{index}_mult : nnet::dense_config {{
     typedef {bias_t.name} bias_t;
     typedef {weight_t.name} weight_t;
     template<class data_T, class res_T, class CONFIG_T>
-    using kernel = nnet::{dense_function}<data_T, res_T, CONFIG_T>;
+    using kernel = {dense_function}<data_T, res_T, CONFIG_T>;
     template<class x_T, class y_T>
     using product = nnet::product::{product_type}<x_T, y_T>;
 }};\n"""
@@ -53,7 +53,7 @@ conv1d_config_template = """struct config{index} : nnet::conv1d_config {{
     static const unsigned n_partitions = {n_partitions};
     static const unsigned n_pixels = out_width / n_partitions;
     template<class data_T, class CONFIG_T>
-    using fill_buffer = nnet::{fill_fn}<data_T, CONFIG_T>;
+    using fill_buffer = {fill_fn}<data_T, CONFIG_T>;
     typedef {accum_t.name} accum_t;
     typedef {bias_t.name} bias_t;
     typedef {weight_t.name} weight_t;
@@ -89,9 +89,10 @@ class Conv1DConfigTemplate(LayerConfigTemplate):
             params['scale_index_type'] = 'scale_index_regular'
 
         if node.model.config.get_config_value('IOType') == 'io_parallel':
-            params['fill_fn'] = f'fill_buffer_{node.index}'
+            namespace = params['namespace']
+            params['fill_fn'] = f'{namespace}::fill_buffer_{node.index}'
         else:
-            params['fill_fn'] = 'FillConv1DBuffer'
+            params['fill_fn'] = 'nnet::FillConv1DBuffer'
 
         conv_config = self.template.format(**params)
 
@@ -103,16 +104,18 @@ class Conv1DConfigTemplate(LayerConfigTemplate):
             node.get_input_variable().type.precision, node.get_weights('weight').type.precision
         )
 
+        namespace = params['namespace']
+
         if node.get_attr('strategy').lower() == 'latency':
-            mult_params['dense_function'] = 'DenseLatency'
+            mult_params['dense_function'] = 'nnet::DenseLatency'
         elif node.get_attr('strategy').lower() == 'resource':
             if int(mult_params['reuse_factor']) <= int(mult_params['n_in']):
-                mult_params['dense_function'] = 'DenseResource_rf_leq_nin'
+                mult_params['dense_function'] = 'nnet::DenseResource_rf_leq_nin'
             else:
-                mult_params['dense_function'] = 'DenseResource_rf_gt_nin_rem0'
+                mult_params['dense_function'] = 'nnet::DenseResource_rf_gt_nin_rem0'
             # The 3rd case is never used
         elif node.get_attr('strategy').lower() == 'resource_unrolled':
-            mult_params['dense_function'] = f'dense_resource_unrolled_{node.index}'
+            mult_params['dense_function'] = f'{namespace}::dense_resource_unrolled_{node.index}'
 
         mult_config = self.mult_template.format(**mult_params)
 
@@ -170,7 +173,7 @@ conv2d_config_template = """struct config{index} : nnet::conv2d_config {{
     static const unsigned n_partitions = {n_partitions};
     static const unsigned n_pixels = out_height * out_width / n_partitions;
     template<class data_T, class CONFIG_T>
-    using fill_buffer = nnet::{fill_fn}<data_T, CONFIG_T>;
+    using fill_buffer = {fill_fn}<data_T, CONFIG_T>;
     typedef {accum_t.name} accum_t;
     typedef {bias_t.name} bias_t;
     typedef {weight_t.name} weight_t;
@@ -214,9 +217,10 @@ class Conv2DConfigTemplate(LayerConfigTemplate):
             params['scale_index_width_type'] = 'scale_index_regular'
 
         if node.model.config.get_config_value('IOType') == 'io_parallel':
-            params['fill_fn'] = f'fill_buffer_{node.index}'
+            namespace = params['namespace']
+            params['fill_fn'] = f'{namespace}::fill_buffer_{node.index}'
         else:
-            params['fill_fn'] = 'FillConv2DBuffer'
+            params['fill_fn'] = 'nnet::FillConv2DBuffer'
 
         conv_config = self.template.format(**params)
 
@@ -313,9 +317,10 @@ class SeparableConv1DConfigTemplate(LayerConfigTemplate):
         params['weight_t'] = node.get_weights('depthwise').type
         params['bias_t'] = node.get_weights('zero_bias').type
         if node.model.config.get_config_value('IOType') == 'io_parallel':
-            params['fill_fn'] = f'fill_buffer_{node.index}_dw'
+            namespace = params['namespace']
+            params['fill_fn'] = f'{namespace}::fill_buffer_{node.index}_dw'
         else:
-            params['fill_fn'] = 'FillConv1DBuffer'
+            params['fill_fn'] = 'nnet::FillConv1DBuffer'
 
         if node.get_attr('unscaled'):
             params['scale_index_type'] = 'scale_index_unscaled'
@@ -359,9 +364,10 @@ class SeparableConv1DConfigTemplate(LayerConfigTemplate):
         params['min_width'] = params['in_width']
         params['instructions'] = '0'
         if node.model.config.get_config_value('IOType') == 'io_parallel':
-            params['fill_fn'] = f'fill_buffer_{node.index}_pw'
+            namespace = params['namespace']
+            params['fill_fn'] = f'{namespace}::fill_buffer_{node.index}_pw'
         else:
-            params['fill_fn'] = 'FillConv1DBuffer'
+            params['fill_fn'] = 'nnet::FillConv1DBuffer'
 
         if node.get_attr('unscaled'):
             params['scale_index_type'] = 'scale_index_unscaled'
@@ -446,9 +452,10 @@ class SeparableConv2DConfigTemplate(LayerConfigTemplate):
         params['index'] = str(node.index) + '_depthwise'
         params['weight_t'] = node.get_weights('depthwise').type
         if node.model.config.get_config_value('IOType') == 'io_parallel':
-            params['fill_fn'] = f'fill_buffer_{node.index}_dw'
+            namespace = params['namespace']
+            params['fill_fn'] = f'{namespace}::fill_buffer_{node.index}_dw'
         else:
-            params['fill_fn'] = 'FillConv2DBuffer'
+            params['fill_fn'] = 'nnet::FillConv2DBuffer'
 
         if node.get_attr('unscaled_h'):
             params['scale_index_height_type'] = 'scale_index_unscaled'
@@ -500,9 +507,10 @@ class SeparableConv2DConfigTemplate(LayerConfigTemplate):
         params['min_width'] = params['in_width']
         params['instructions'] = '0'
         if node.model.config.get_config_value('IOType') == 'io_parallel':
-            params['fill_fn'] = f'fill_buffer_{node.index}_pw'
+            namespace = params['namespace']
+            params['fill_fn'] = f'{namespace}::fill_buffer_{node.index}_pw'
         else:
-            params['fill_fn'] = 'FillConv2DBuffer'
+            params['fill_fn'] = 'nnet::FillConv2DBuffer'
 
         if node.get_attr('unscaled_h'):
             params['scale_index_height_type'] = 'scale_index_unscaled'

--- a/hls4ml/backends/vivado/passes/core_templates.py
+++ b/hls4ml/backends/vivado/passes/core_templates.py
@@ -20,7 +20,7 @@ dense_config_template = """struct config{index} : nnet::dense_config {{
     typedef {weight_t.name} weight_t;
     typedef {index_t.name} index_t;
     template<class data_T, class res_T, class CONFIG_T>
-    using kernel = nnet::{dense_function}<data_T, res_T, CONFIG_T>;
+    using kernel = {dense_function}<data_T, res_T, CONFIG_T>;
     template<class x_T, class y_T>
     using product = nnet::product::{product_type}<x_T, y_T>;
 }};\n"""
@@ -43,16 +43,18 @@ class DenseConfigTemplate(LayerConfigTemplate):
             node.get_input_variable().type.precision, node.get_weights('weight').type.precision
         )
 
+        namespace = params['namespace']
+
         if node.get_attr('strategy').lower() == 'latency':
-            params['dense_function'] = 'DenseLatency'
+            params['dense_function'] = 'nnet::DenseLatency'
         elif node.get_attr('strategy').lower() == 'resource':
             if int(params['reuse_factor']) <= int(params['n_in']):
-                params['dense_function'] = 'DenseResource_rf_leq_nin'
+                params['dense_function'] = 'nnet::DenseResource_rf_leq_nin'
             else:
-                params['dense_function'] = 'DenseResource_rf_gt_nin_rem0'
+                params['dense_function'] = 'nnet::DenseResource_rf_gt_nin_rem0'
             # The 3rd case is never used
         elif node.get_attr('strategy').lower() == 'resource_unrolled':
-            params['dense_function'] = f'dense_resource_unrolled_{node.index}'
+            params['dense_function'] = f'{namespace}::dense_resource_unrolled_{node.index}'
 
         return self.template.format(**params)
 

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -220,6 +220,13 @@ def convert_from_keras_model(
         ModelGraph: hls4ml model.
     """
 
+    if os.environ.get('HLS4ML_USE_JIT', '0') == '1':
+        import random
+        import string
+
+        rand_namespace = ''.join(random.choices(string.ascii_lowercase + string.ascii_uppercase, k=16))
+        kwargs.setdefault('namespace', rand_namespace)
+
     config = create_config(output_dir=output_dir, project_name=project_name, backend=backend, **kwargs)
 
     config['KerasModel'] = model

--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -220,13 +220,6 @@ def convert_from_keras_model(
         ModelGraph: hls4ml model.
     """
 
-    if os.environ.get('HLS4ML_USE_JIT', '0') == '1':
-        import random
-        import string
-
-        rand_namespace = ''.join(random.choices(string.ascii_lowercase + string.ascii_uppercase, k=16))
-        kwargs.setdefault('namespace', rand_namespace)
-
     config = create_config(output_dir=output_dir, project_name=project_name, backend=backend, **kwargs)
 
     config['KerasModel'] = model

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -764,11 +764,17 @@ class ModelGraph:
 
     def _compile(self, jit=None):
         if jit is None:
-            jit = os.environ.get('HLS4ML_USE_JIT', '0') == '1'
-
-        if self.config.config['Backend'].lower() == 'oneapi':
-            print('INFO: OneAPI backend does not support JIT compilation, using shared library compilation', file=sys.stderr)
             jit = False
+            backend = self.config.config['Backend'].lower()
+            if backend == 'vivado' or backend == 'vitis':
+                jit = os.environ.get('HLS4ML_USE_JIT', '0') == '1'
+
+        if self.config.config['Backend'].lower() not in ['vivado', 'vitis', 'quartus']:
+            if jit:
+                print(
+                    'JIT compilation is not supported for this backend, falling back to normal compilation', file=sys.stderr
+                )
+                jit = False
 
         if jit:
             self.jit_compile()

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -771,9 +771,7 @@ class ModelGraph:
                 jit = os.environ.get('HLS4ML_USE_JIT', '0') == '1'
 
         if self.config.config['Backend'].lower() not in ['vivado', 'vitis', 'quartus'] and jit:
-            print(
-                'JIT compilation is not supported for this backend, falling back to normal compilation', file=sys.stderr
-            )
+            print('JIT compilation is not supported for this backend, falling back to normal compilation', file=sys.stderr)
             jit = False
 
         write_weights_txt = self.config.writer_config.get('WriteWeightsTxt', False)

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -36,7 +36,6 @@ def compile_worker(config, var_types: Sequence[str], var_names: Sequence[str], v
             print('Adding Vivado paths')
             cppyy.add_include_path(str(prj_path / 'firmware/ap_types'))
         case 'quartus':
-            cppyy.add_include_path(str(prj_path / 'firmware/ap_types'))
             cppyy.add_include_path(str(prj_path / 'firmware/ac_types'))
         # case 'catapult':                          # Doesn't work, unknown error
         #     print('Adding MGC paths')

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -59,6 +59,8 @@ def compile_worker(config, var_types: Sequence[str], var_names: Sequence[str], v
         for w_type, w_name, w_val in zip(var_types, var_names, var_vals):
             cpp_w = getattr(cpp_namespace, w_name, None)
             if cpp_w is None:
+                cpp_w = getattr(cppyy.gbl, w_name, None)
+            if cpp_w is None:
                 continue
             fill_fn = cpp_namespace.fill_weight[w_type]
             fill_fn(cpp_w, w_val.ravel().astype(np.float32))

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -774,7 +774,7 @@ class ModelGraph:
         config = {
             'OutputDir': self.config.config['OutputDir'],
             'ProjectName': self.config.config['ProjectName'],
-            'Namespace': self.config.config['WriterConfig']['Namespace'],
+            'Namespace': self.config.config['WriterConfig'].get('Namespace', None) or 'nnet',
             'WriteWeightsTxt': self.config.config['WriterConfig'].get('WriteWeightsTxt', False),
         }
 

--- a/hls4ml/templates/catapult/firmware/myproject.cpp
+++ b/hls4ml/templates/catapult/firmware/myproject.cpp
@@ -13,12 +13,14 @@ void CCS_BLOCK(myproject)(
 
     // hls-fpga-machine-learning insert IO
 
+#ifndef HLS4ML_EXTERNAL_WEIGHT_LOAD
 #ifndef __SYNTHESIS__
     static bool loaded_weights = false;
     if (!loaded_weights) {
         // hls-fpga-machine-learning insert load weights
         loaded_weights = true;
     }
+#endif
 #endif
 
     // ****************************************

--- a/hls4ml/templates/catapult/myproject_test.cpp
+++ b/hls4ml/templates/catapult/myproject_test.cpp
@@ -79,12 +79,14 @@ CCS_MAIN(int argc, char *argv[]) {
 #endif
     std::ofstream fout(RESULTS_LOG);
 
+#ifndef HLS4ML_EXTERNAL_WEIGHT_LOAD
 #ifndef __SYNTHESIS__
     static bool loaded_weights = false;
     if (!loaded_weights) {
         // hls-fpga-machine-learning insert load weights
         loaded_weights = true;
     }
+#endif
 #endif
     std::string iline;
     std::string pline;

--- a/hls4ml/templates/quartus/build_lib.sh
+++ b/hls4ml/templates/quartus/build_lib.sh
@@ -8,7 +8,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     CFLAGS="-O3 -fPIC -std=c++11"
 fi
 LDFLAGS=
-INCFLAGS="-Ifirmware/ac_types/ -Ifirmware/ap_types/"
+INCFLAGS="-Ifirmware/ac_types/"
 PROJECT=myproject
 LIB_STAMP=mystamp
 

--- a/hls4ml/templates/vivado/firmware/myproject.cpp
+++ b/hls4ml/templates/vivado/firmware/myproject.cpp
@@ -11,8 +11,15 @@ void myproject(
 
     // hls-fpga-machine-learning insert IO
 
-    // hls-fpga-machine-learning insert load weights
-
+#ifndef HLS4ML_EXTERNAL_WEIGHT_LOAD
+#ifndef __SYNTHESIS__
+    static bool loaded_weights = false;
+    if (!loaded_weights) {
+        // hls-fpga-machine-learning insert load weights
+        loaded_weights = true;
+    }
+#endif
+#endif
     // ****************************************
     // NETWORK INSTANTIATION
     // ****************************************

--- a/hls4ml/writer/catapult_writer.py
+++ b/hls4ml/writer/catapult_writer.py
@@ -921,6 +921,7 @@ class CatapultWriter(Writer):
         self.write_parameters(model)
         self.write_test_bench(model)
         self.write_bridge(model)
+        self.write_jit_bridge(model)
         self.write_build_script(model)
         self.write_nnet_utils(model)
         self.write_generated_code(model)

--- a/hls4ml/writer/catapult_writer.py
+++ b/hls4ml/writer/catapult_writer.py
@@ -921,7 +921,7 @@ class CatapultWriter(Writer):
         self.write_parameters(model)
         self.write_test_bench(model)
         self.write_bridge(model)
-        self.write_jit_bridge(model)
+        # self.write_jit_bridge(model)
         self.write_build_script(model)
         self.write_nnet_utils(model)
         self.write_generated_code(model)

--- a/hls4ml/writer/oneapi_writer.py
+++ b/hls4ml/writer/oneapi_writer.py
@@ -961,6 +961,7 @@ class OneAPIWriter(Writer):
         self.write_parameters(model)
         self.write_test_bench(model)
         self.write_bridge(model)
+        self.write_jit_bridge(model)
         self.write_build_script(model)
         self.write_nnet_utils(model)
         self.write_activation_tables(model)

--- a/hls4ml/writer/oneapi_writer.py
+++ b/hls4ml/writer/oneapi_writer.py
@@ -961,7 +961,7 @@ class OneAPIWriter(Writer):
         self.write_parameters(model)
         self.write_test_bench(model)
         self.write_bridge(model)
-        self.write_jit_bridge(model)
+        # self.write_jit_bridge(model)
         self.write_build_script(model)
         self.write_nnet_utils(model)
         self.write_activation_tables(model)

--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -1356,6 +1356,7 @@ class QuartusWriter(Writer):
         self.write_parameters(model)
         self.write_test_bench(model)
         self.write_bridge(model)
+        self.write_jit_bridge(model)
         self.write_build_script(model)
         self.write_nnet_utils(model)
         self.write_activation_tables(model)

--- a/hls4ml/writer/symbolic_writer.py
+++ b/hls4ml/writer/symbolic_writer.py
@@ -111,6 +111,7 @@ class SymbolicExpressionWriter(VivadoWriter):
         self.write_parameters(model)
         self.write_test_bench(model)
         self.write_bridge(model)
+        self.write_jit_bridge(model)
         self.write_build_script(model)
         self.write_nnet_utils(model)
         self.write_generated_code(model)

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -790,6 +790,7 @@ class VivadoWriter(Writer):
         contents = f.readlines()
         f.close()
         f = open(path, 'w')
+        namespace = model.config.get_writer_config().get('Namespace', None)
 
         for line in contents:
             if '// hls4ml insert code' in line:
@@ -799,6 +800,9 @@ class VivadoWriter(Writer):
                         newline += str(generated_code)
             else:
                 newline = line
+            if namespace is not None:
+                if 'namespace nnet' in newline:
+                    newline = newline.replace('namespace nnet', f'namespace {namespace}')
             f.write(newline)
         f.close()
 

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -165,11 +165,6 @@ class VivadoWriter(Writer):
             elif '// hls-fpga-machine-learning insert load weights' in line:
                 newline = line
                 if model.config.get_writer_config()['WriteWeightsTxt']:
-
-                    newline += '#ifndef __SYNTHESIS__\n'
-                    newline += '    static bool loaded_weights = false;\n'
-                    newline += '    if (!loaded_weights) {\n'
-
                     for layer in model.get_layers():
                         for w in layer.get_weights():
                             if w.weight_class == 'CompressedWeightVariable':
@@ -190,10 +185,6 @@ class VivadoWriter(Writer):
                                 newline += indent + '    nnet::load_weights_from_txt<{}, {}>({}, "{}.txt");\n'.format(
                                     w.type.name, w.data_length, w.name, w.name
                                 )
-
-                    newline += '        loaded_weights = true;'
-                    newline += '    }\n'
-                    newline += '#endif'
 
             # Add input/output type
             elif '// hls-fpga-machine-learning insert IO' in line:
@@ -853,6 +844,7 @@ class VivadoWriter(Writer):
         self.write_parameters(model)
         self.write_test_bench(model)
         self.write_bridge(model)
+        self.write_jit_bridge(model)
         self.write_build_script(model)
         self.write_nnet_utils(model)
         self.write_generated_code(model)

--- a/hls4ml/writer/writers.py
+++ b/hls4ml/writer/writers.py
@@ -10,6 +10,7 @@ if typing.TYPE_CHECKING:
 def create_jit_bridge_fn(model: 'ModelGraph'):
     inp_vars = model.get_input_variables()
     out_vars = model.get_output_variables()
+    prj_name = model.config.config['ProjectName']
 
     inp_shapes = [tuple(v.shape) for v in inp_vars]
     out_shapes = [tuple(v.shape) for v in out_vars]
@@ -61,12 +62,20 @@ auto batch_inference(
 
     {ptr_buf_def}
 
-    for (int i = 0; i < n_samples; i++) {{
-        myproject_float(
-            {args_def}
-        );
+    if (std::is_same<T, double>::value) {{
+        for (int i = 0; i < n_samples; i++)
+            {prj_name}_double(
+                {args_def}
+            );
+    }} else if (std::is_same<T, float>::value) {{
+        for (int i = 0; i < n_samples; i++)
+            {prj_name}_float(
+                {args_def}
+            );
+    }} else {{
+        throw std::runtime_error("Unsupported type");
     }}
-
+    
     return {return_def};
 }}
 """

--- a/hls4ml/writer/writers.py
+++ b/hls4ml/writer/writers.py
@@ -1,9 +1,116 @@
+import typing
+from math import prod
+from pathlib import Path
+
+if typing.TYPE_CHECKING:
+    from hls4ml.model import ModelGraph
+
+
+def create_jit_bridge_fn(model: 'ModelGraph'):
+    inp_vars = model.get_input_variables()
+    out_vars = model.get_output_variables()
+
+    inp_shapes = [tuple(v.shape) for v in inp_vars]
+    out_shapes = [tuple(v.shape) for v in out_vars]
+
+    inp_names = [v.name for v in inp_vars]
+    out_names = [v.name for v in out_vars]
+
+    inp_sizes = [prod(s) for s in inp_shapes]
+    out_sizes = [prod(s) for s in out_shapes]
+
+    n_out = len(out_names)
+
+    input_def = '\n    '.join(f'std::vector<T> {v.name}, ' for v in inp_vars)[:-2]
+
+    inp_size_def = '\n        '.join(f'constexpr size_t {n}_size = {s};' for n, s in zip(inp_names, inp_sizes))
+    out_size_def = '\n        '.join(f'constexpr size_t {n}_size = {s};' for n, s in zip(out_names, out_sizes))
+
+    ptr_buf_def = '\n        '.join(f'T* {v.name}_ptr = {v.name}.data();' for v in inp_vars + out_vars)
+    n_samples_def = f'{inp_vars[0].name}.size() / {inp_vars[0].name}_size'
+
+    assertions_def = ' ||\n            '.join(f'({n}.size() != {n}_size * n_samples)' for n in inp_names)
+
+    inp_args_def_list = [f'{n}_ptr + i * {n}_size,' for n in inp_names]
+    out_args_def_list = [f'{n}_ptr + i * {n}_size,' for n in out_names]
+    args_def = ('\n' + ' ' * 12).join(inp_args_def_list + out_args_def_list)[:-1]
+
+    out_var_def = '\n        '.join(f'std::vector<T> {v.name}({v.name}_size * n_samples);' for v in out_vars)
+
+    _ret_template_arg = ('std::vector<T>, ' * n_out)[:-2]
+    _ret_tuple_arg = ', '.join(out_names)
+    return_def = f'std::tuple<{_ret_template_arg}>({_ret_tuple_arg})'
+
+    cpp_fn = f"""
+    template <typename T>
+    auto batch_inference(
+        {input_def}
+    ){{
+        {inp_size_def}
+        {out_size_def}
+
+        size_t n_samples = {n_samples_def};
+
+        if (
+            {assertions_def}
+        )
+            throw std::runtime_error("Invalid input sizes: number of samples or input sizes do not match");
+
+        {out_var_def}
+
+        {ptr_buf_def}
+
+        for (int i = 0; i < n_samples; i++) {{
+            myproject_float(
+                {args_def}
+            );
+        }}
+
+        return {return_def};
+    }}
+"""
+    return cpp_fn
+
+
+def create_jit_weight_filler(model: 'ModelGraph'):
+    filler_fn = """
+    template <typename T>
+    void fill_weight(T weight[], std::vector<float> vec) {{
+        for (size_t i = 0; i < vec.size(); i++) {{
+            weight[i] = vec[i];
+        }}
+    }}
+"""
+    return filler_fn
+
+
 class Writer:
     def __init__(self):
         pass
 
     def write_hls(self, model):
         raise NotImplementedError
+
+    def write_jit_bridge(self, model: 'ModelGraph'):
+        """Write the Python-C++ bridge for JIT compilation (myproject_bridge_jit.cpp)"""
+
+        prj_name = model.config.get_project_name()
+        prj_path = Path(model.config.get_output_dir())
+        path_c_bridge = prj_path / f'{prj_name}_bridge.cpp'
+        path_jit_bridge = prj_path / f'{prj_name}_jit_bridge.cpp'
+
+        namespace = model.config.get_writer_config()['Namespace'] or 'nnet'
+
+        cpp_source_bridge = path_c_bridge.read_text()
+
+        jit_bridge_fn = create_jit_bridge_fn(model)
+        weight_filler_fn = create_jit_weight_filler(model)
+
+        _plugin_code = f'namespace {namespace} {{\n' + jit_bridge_fn + '\n\n' + weight_filler_fn + '\n'
+
+        cpp_source_bridge = cpp_source_bridge.replace('extern "C" {', _plugin_code)
+
+        path_jit_bridge.write_text(cpp_source_bridge)
 
 
 writer_map = {}

--- a/hls4ml/writer/writers.py
+++ b/hls4ml/writer/writers.py
@@ -62,18 +62,19 @@ auto batch_inference(
 
     {ptr_buf_def}
 
-    if (std::is_same<T, double>::value) {{
-        for (int i = 0; i < n_samples; i++)
+    #pragma omp parallel for
+    for (int i = 0; i < n_samples; i++) {{
+        if (std::is_same<T, double>::value) {{
             {prj_name}_double(
                 {args_def}
             );
-    }} else if (std::is_same<T, float>::value) {{
-        for (int i = 0; i < n_samples; i++)
+        }} else if (std::is_same<T, float>::value) {{
             {prj_name}_float(
                 {args_def}
             );
-    }} else {{
-        throw std::runtime_error("Unsupported type");
+        }} else {{
+            throw std::runtime_error("Unsupported type");
+        }}
     }}
     
     return {return_def};

--- a/hls4ml/writer/writers.py
+++ b/hls4ml/writer/writers.py
@@ -76,7 +76,7 @@ auto batch_inference(
             throw std::runtime_error("Unsupported type");
         }}
     }}
-    
+
     return {return_def};
 }}
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,8 @@ pytest_randomly.random_seeder =
 [options.extras_require]
 HGQ =
     HGQ~=0.2.0
+jit =
+    cppyy
 optimization =
     keras-tuner==1.1.3
     ortools==9.4.1874

--- a/test/pytest/ci-template.yml
+++ b/test/pytest/ci-template.yml
@@ -9,7 +9,7 @@
     - git submodule update --init --recursive hls4ml/templates/catapult/
     - if [ $EXAMPLEMODEL == 1 ]; then git submodule update --init example-models; fi
     - conda activate hls4ml-testing
-    - pip install .[testing,sr,optimization]
+    - pip install .[testing,sr,optimization,jit]
   script:
     - cd test/pytest
     - pytest $PYTESTFILE -rA --cov-report xml --cov-report term --cov=hls4ml --junitxml=report.xml --randomly-seed=42 --randomly-dont-reorganize --randomly-dont-reset-seed

--- a/test/pytest/test_jit.py
+++ b/test/pytest/test_jit.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+from keras.layers import Dense
+from tensorflow import keras
+
+from hls4ml.converters import convert_from_keras_model
+
+test_root_path = Path(__file__).parent
+
+
+@pytest.fixture(scope='module')
+def model():
+    in1 = keras.Input(shape=(10,))
+    in2 = keras.Input(shape=(9,))
+    x = Dense(8, name='dense1')(in1)
+    y = Dense(7, name='dense2')(in2)
+    model = keras.Model([in1, in2], [x, y])
+    return model
+
+
+@pytest.fixture(scope='module')
+def data():
+    IN1 = np.random.normal(0, 1, (1000, 10)).astype(np.float32)
+    IN2 = np.random.normal(0, 1, (1000, 9)).astype(np.float32)
+    return IN1, IN2
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Quartus', 'Vitis'])
+@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
+@pytest.mark.parametrize('strategy', ['Resource', 'Latency'])
+def test_jit(model, data, backend: str, io_type: str, strategy: str):
+    output_dir = str(test_root_path / f'hls4mlprj_jit_{backend}_{io_type}_{strategy}')
+
+    model_hls = convert_from_keras_model(
+        model, backend=backend, output_dir=output_dir, io_type=io_type, hls_config={'Model': {'Strategy': strategy, 'ReuseFactor': 1, 'Precision': 'ap_fixed<16,6>'}}
+    )
+
+    model_hls.write()
+    model_hls.compile_shared_lib()
+    model_hls.jit_compile()
+
+    ctypes_pred = model_hls.predict(data, jit=False)
+    jit_pred = model_hls.predict(data, jit=True)
+
+    assert np.all(ctypes_pred[0] == jit_pred[0])
+    assert np.all(ctypes_pred[1] == jit_pred[1])

--- a/test/pytest/test_jit.py
+++ b/test/pytest/test_jit.py
@@ -34,7 +34,11 @@ def test_jit(model, data, backend: str, io_type: str, strategy: str):
     output_dir = str(test_root_path / f'hls4mlprj_jit_{backend}_{io_type}_{strategy}')
 
     model_hls = convert_from_keras_model(
-        model, backend=backend, output_dir=output_dir, io_type=io_type, hls_config={'Model': {'Strategy': strategy, 'ReuseFactor': 1, 'Precision': 'ap_fixed<16,6>'}}
+        model,
+        backend=backend,
+        output_dir=output_dir,
+        io_type=io_type,
+        hls_config={'Model': {'Strategy': strategy, 'ReuseFactor': 1, 'Precision': 'ap_fixed<16,6>'}},
     )
 
     model_hls.write()


### PR DESCRIPTION
# Description

Allow jit compiling `vivado`/`vitis` (and quartus, but sometimes slower) cpp code. Compilation time may be reduced or increased, depending on the exact configuration (reduced if weights are not embedded in header in general, and vice versa).

Unfortunately, due to some confliction (probably related to macros), one isolated process is required for each jitted-model to separate the runtime. This introduces some overhead in runtime and ram usage.

Setting `HLS4ML_USE_JIT=1` in envvar will enable jit compilation for supported models by default.

Setting `EXTRA_CLING_ARGS=-fopenmp` will enable parallel inference, if `openmp` presents.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

Run the current set of tests with `HLS4ML_USE_JIT=1` will work. Added `test_jit.py` for standlone test.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
