### PR TITLE
remove incorrect input from Constant nodes

### DIFF
--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -357,7 +357,7 @@ class Input(Layer):
 
 
 class Constant(Layer):
-    # one could consider making this a weight attribute, but given it's transient nature, I am not sure it helps
+    # one could consider making this a weight attribute, but given its transient nature, I am not sure it helps
     _expected_attributes = [
         Attribute('value', value_type=np.ndarray),
     ]
@@ -370,6 +370,10 @@ class Constant(Layer):
             self.set_attr('value', np.array([value]))
         dims = [f'{self.name}_{i}' for i in range(len(shape))]
         quantizer = self.get_attr('quantizer')
+
+        # the graph._make_graph function sets the input node to the previous node
+        # if it is not set. That is incorrect for Constant nodes, so remove the input node
+        self.inputs = []
 
         # Should the else clause below be None or UnspecifiedPrecisionType
         precision = quantizer.hls_type if quantizer is not None else UnspecifiedPrecisionType()


### PR DESCRIPTION
# Description

The code in `graph._make_graph` adds an input to a layer if one is not specified, being the previous layer in the layer list. This follows the Sequential style in Keras. (As an aside, would it make sense in the future to move this logic to when the layer list is created instead of where it is?)

This behavior is wrong for Constant nodes, since they actually do not have an input. Most likely it causes no actual problem since it's ignored everywhere else, but this makes it consistent by changing it back to say there's no input.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

This is more for logical consistency, and I do not think it caused any problems, but it's better to have it correct, in case a problem comes up. Nevertheless, one should double-check as always that this doesn't break anyting.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
