### PR TITLE
Add RF to config templates for "Merge" layers

### DIFF
--- a/hls4ml/backends/catapult/passes/merge_templates.py
+++ b/hls4ml/backends/catapult/passes/merge_templates.py
@@ -6,6 +6,7 @@ from hls4ml.model.layers import Concatenate, Dot, Merge
 
 merge_config_template = """struct config{index} : nnet::merge_config {{
     static const unsigned n_elem = {n_elem};
+    static const unsigned reuse_factor = {reuse};
 }};\n"""
 
 merge_function_template = 'nnet::{merge}<{input1_t}, {input2_t}, {output_t}, {config}>({input1}, {input2}, {output});'

--- a/hls4ml/backends/oneapi/passes/merge_templates.py
+++ b/hls4ml/backends/oneapi/passes/merge_templates.py
@@ -10,6 +10,7 @@ from hls4ml.model.layers import Concatenate, Dot, Merge
 # Merge templates
 merge_config_template = """struct config{index} : nnet::merge_config {{
     static const unsigned n_elem = {n_elem};
+    static const unsigned reuse_factor = {reuse};
 }};\n"""
 
 merge_function_template = 'nnet::{merge}<{input1_t}, {input2_t}, {output_t}, {config}>({input1}, {input2}, {output});'

--- a/hls4ml/backends/quartus/passes/merge_templates.py
+++ b/hls4ml/backends/quartus/passes/merge_templates.py
@@ -9,6 +9,7 @@ from hls4ml.model.layers import Concatenate, Dot, Merge
 # Merge templates
 merge_config_template = """struct config{index} : nnet::merge_config {{
     static const unsigned n_elem = {n_elem};
+    static const unsigned reuse_factor = {reuse};
 }};\n"""
 
 merge_function_template = 'nnet::{merge}<{input1_t}, {input2_t}, {output_t}, {config}>({input1}, {input2}, {output});'

--- a/hls4ml/backends/vivado/passes/merge_templates.py
+++ b/hls4ml/backends/vivado/passes/merge_templates.py
@@ -6,6 +6,7 @@ from hls4ml.model.layers import Concatenate, Dot, Merge
 
 merge_config_template = """struct config{index} : nnet::merge_config {{
     static const unsigned n_elem = {n_elem};
+    static const unsigned reuse_factor = {reuse};
 }};\n"""
 
 merge_function_template = 'nnet::{merge}<{input1_t}, {input2_t}, {output_t}, {config}>({input1}, {input2}, {output});'

--- a/hls4ml/templates/catapult/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/catapult/nnet_utils/nnet_merge.h
@@ -11,6 +11,7 @@ namespace nnet {
 
 struct merge_config {
     static const unsigned n_elem = 10;
+    static const unsigned reuse_factor = 1;
 };
 
 struct dot_config {

--- a/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_merge.h
@@ -7,6 +7,7 @@ namespace nnet {
 
 struct merge_config {
     static const unsigned n_elem = 10;
+    static const unsigned reuse_factor = 1;
 };
 
 struct dot_config {

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_merge.h
@@ -7,6 +7,7 @@ namespace nnet {
 
 struct merge_config {
     static const unsigned n_elem = 10;
+    static const unsigned reuse_factor = 1;
 };
 
 struct dot_config {

--- a/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
@@ -10,6 +10,7 @@ namespace nnet {
 
 struct merge_config {
     static const unsigned n_elem = 10;
+    static const unsigned reuse_factor = 1;
 };
 
 struct dot_config {


### PR DESCRIPTION
# Description

Recent changes to `nnet_merge_stream.h` make it rely on RF, which is not set in the config template. This adds the missing functionality. I've added it across all backends, even though some don't rely on the feature (yet). Closes #1088 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

This would show up if we synthesized the projects from test_merge (that use vivado + io_stream)


## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
