### PR TITLE
remove incorrect setting of result_t

### DIFF
--- a/hls4ml/model/optimizer/passes/linear.py
+++ b/hls4ml/model/optimizer/passes/linear.py
@@ -40,7 +40,6 @@ class MergeLinearActivation(OptimizerPass):
         # if the activation has a quantizer (usually from a QONNX Quant node), set the previous node's output precision
         if quantizer is not None:
             prev_node.set_attr("quantizer", quantizer)
-            prev_node.types['result_t'] = quantizer.hls_type
             prev_node.get_output_variable().type.precision = quantizer.hls_type
         model.remove_node(node)
         return True

--- a/hls4ml/model/optimizer/passes/merge_const.py
+++ b/hls4ml/model/optimizer/passes/merge_const.py
@@ -54,7 +54,6 @@ class MergeTwoConstants(OptimizerPass):
         const_node0.set_attr('quantizer', quantizer)  # overwrite the quantizer
         if quantizer:
             const_node0.set_attr('quantizer', quantizer)
-            const_node0.types['result_t'] = quantizer.hls_type
             const_node0.get_output_variable().type.precision = quantizer.hls_type
         const_node0.set_attr('value', new_val)
 

--- a/hls4ml/model/optimizer/passes/quant_opt.py
+++ b/hls4ml/model/optimizer/passes/quant_opt.py
@@ -194,7 +194,6 @@ class FuseQuantWithConstant(OptimizerPass):
 
         const_node = node.get_input_node(node.inputs[0])
         const_node.set_attr('quantizer', quantizer)
-        const_node.set_attr('result_t', precision)
         const_node.get_output_variable().type.precision = precision
 
         # Should we update the configuration to reflect the new precision? I don't think it's necessary
@@ -331,7 +330,6 @@ class ConstQuantToConstAlpha(OptimizerPass):
         const_node.set_attr('value', new_val)
         const_node.set_attr('quantizer', quantizer)
 
-        const_node.types['result_t'].precision = precision
         const_node.get_output_variable().type.precision = precision
 
         inshape = node.get_input_variable().shape


### PR DESCRIPTION
# Description

The result_t was incorrect set in the MergeLinearActivation optimizer. This removes the setting, which wasn't needed anyway. Setting `get_output_variable().type.precision` already sets it properly as a side-effect.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

This fixes a bug found in #1122. The test is there.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
