### PR TITLE
Fix problem with scale being a multidimensional array.

### DIFF
--- a/hls4ml/model/optimizer/passes/quant_opt.py
+++ b/hls4ml/model/optimizer/passes/quant_opt.py
@@ -167,8 +167,8 @@ class FuseQuantWithConstant(OptimizerPass):
             scale_unit_or_po2 = (scale == np.ones_like(scale)).all()
             if not scale_unit_or_po2 and _ALSO_MATCH_PO2:
                 # This optimization only works if all scales are the same
-                if np.all(scale[0] == scale):
-                    mantissa, _ = np.frexp(scale[0])
+                if np.all(scale.item(0) == scale):
+                    mantissa, _ = np.frexp(scale.item(0))
                     scale_unit_or_po2 = mantissa == 0.5
 
             is_match = scale_unit_or_po2
@@ -187,7 +187,7 @@ class FuseQuantWithConstant(OptimizerPass):
         integer = bitwidth
         scale = node.get_attr('scale')
         if _ALSO_MATCH_PO2 and not (scale == np.ones_like(scale)).all():
-            _, exp = np.frexp(scale[0])  # know that np.all(scale[0] == scale) must be true
+            _, exp = np.frexp(scale.item(0))  # know that np.all(scale.item(0) == scale) must be true
             integer = bitwidth + exp - 1
 
         precision, quantizer = _calculate_precision_quantizer(bitwidth, integer, signed, narrow, rounding_mode)


### PR DESCRIPTION
In case scale is a multidimensional array (e.g. `1 x num_channels`) `scale[0]` does not return a scalar. Instead
scale.item(0) should be used. 

I had this problem on the model added bellow. It has channel-wise scaling factors. The problem was
that the match function returned an array, which then lead to errors (truth value of an array is ambiguous).

The change should not affect the rest of the code, nor does it change behavior.
Since the change is so trivial, I didn't bother adding a test. However, if this is deemed desired, I
can also add a test.

Type of change:
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests
None

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files
- [ ] I have added tests that prove my fix is effective or that my feature works.

[cnn_model.zip](https://github.com/user-attachments/files/17821675/cnn_model.zip)