### PR TITLE
Update install_requires for 1.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,12 +27,13 @@ install_requires =
     numpy
     onnx>=1.4.0
     pydigitalwavetools==1.1
+    pyparsing
     pyyaml
-    qkeras
+    qkeras@git+https://github.com/google/qkeras.git
     tabulate
-    tensorflow
+    tensorflow>=2.8.0,<=2.14.1
     tensorflow-model-optimization<=0.7.5
-python_requires = >=3.10
+python_requires = >=3.10, <=3.12
 include_package_data = True
 scripts = scripts/hls4ml
 


### PR DESCRIPTION
# Description

The current hls4ml won't install properly on an empty environment as this will pull TF 2.18 and keras v3 which are not compatible. We mention in the docs the supported versions of TF are between 2.8 and 2.14, but this was not enforced. Due to the restriction of TF 2.14 not working on python 3.12, we can only support python 3.10 and 3.11. Furthermore QKeras installation pulls version 0.9.0 which is not supported anymore. This was changed to the git version (we can put our own version if needed).

In the future once we move to a more modular base (beginnings of which are in #1094) we should also move to pyproject.toml for managing dependencies.

## Type of change

- [x] Other (Specify) - setup update

## Tests

Only concerns the environments. Shouldn't break existing test pipeline.

## Checklist
yeah, yeah, I've done all of this.