### PR TITLE
Automatic type inference for `param_t` in Parametrised Activations

### DIFF
--- a/hls4ml/model/optimizer/passes/infer_precision.py
+++ b/hls4ml/model/optimizer/passes/infer_precision.py
@@ -574,14 +574,17 @@ class InferPrecisionTypes(ConfigurableOptimizerPass):
             e = bits[-23 - 8 : -23]
             return m, e
 
-        alpha = node.get_attr(attr_name)
-        m, e = get_man_exp(alpha)
-        I_bits = int(e, 2) - 127 + 1  # -127 is the bias of the exponent
-        W_bits = m.rindex('1') + 2  # + 1 for accounting the index starting from 0, +1 for the leading 1 of the exponent
-        if alpha < 0:
-            I_bits += 1
+        param = node.get_attr(attr_name)
+        m, e = get_man_exp(param)
+        I_pos = int(e, 2) - 127 + 1  # -127 is the bias of the exponent
+        try:
+            W_bits = m.rindex('1') + 2  # + 1 for accounting the index starting from 0, +1 for the leading 1 of the exponent
+        except Exception:
+            W_bits = 1  # the value is a power of 2, 1 bit is needed, I_pos will offset the bit in the proper place
+        if param < 0:
+            I_pos += 1
             W_bits += 1
-        node.attributes[type_to_infer].precision = FixedPrecisionType(W_bits, I_bits, True if alpha < 0 else False)
+        node.attributes[type_to_infer].precision = FixedPrecisionType(W_bits, I_pos, True if param < 0 else False)
         inferred_types.append(type_to_infer)
         return inferred_types
 

--- a/hls4ml/model/optimizer/passes/infer_precision.py
+++ b/hls4ml/model/optimizer/passes/infer_precision.py
@@ -581,7 +581,7 @@ class InferPrecisionTypes(ConfigurableOptimizerPass):
             W_bits = m.rindex('1') + 2  # + 1 for accounting the index starting from 0, +1 for the leading 1 of the exponent
         except Exception:
             W_bits = 1  # the value is a power of 2, 1 bit is needed, I_pos will offset the bit in the proper place
-        if param < 0:
+        if param < 0 and W_bits > 1:  # for po2 values the increment is not needed
             I_pos += 1
             W_bits += 1
         node.attributes[type_to_infer].precision = FixedPrecisionType(W_bits, I_pos, True if param < 0 else False)

--- a/hls4ml/model/optimizer/passes/infer_precision.py
+++ b/hls4ml/model/optimizer/passes/infer_precision.py
@@ -1,8 +1,8 @@
 import math
+import struct
 from typing import Iterable
 
 import numpy as np
-import struct
 
 from hls4ml.model.optimizer import ConfigurableOptimizerPass
 from hls4ml.model.types import (
@@ -564,22 +564,24 @@ class InferPrecisionTypes(ConfigurableOptimizerPass):
 
     def _infer_const_precision(self, node, type_to_infer, attr_name):
         inferred_types = []
+
         def get_man_exp(f):
             f = np.abs(f)
             s = struct.pack('>f', f)
-            l = struct.unpack('>l', s)[0]
-            bits = '{:032b}'.format(l)
+            l_float = struct.unpack('>l', s)[0]
+            bits = f'{l_float:032b}'
             m = bits[-23:]
-            e = bits[-23-8:-23]
+            e = bits[-23 - 8 : -23]
             return m, e
+
         alpha = node.get_attr(attr_name)
         m, e = get_man_exp(alpha)
-        I = int(e, 2) - 127 + 1 # -127 is the bias of the exponent
-        W = m.rindex('1') + 2 # + 1 for accounting the index starting from 0, +1 for the leading 1 of the exponent
+        I_bits = int(e, 2) - 127 + 1  # -127 is the bias of the exponent
+        W_bits = m.rindex('1') + 2  # + 1 for accounting the index starting from 0, +1 for the leading 1 of the exponent
         if alpha < 0:
-            I += 1
-            W += 1
-        node.attributes[type_to_infer].precision = FixedPrecisionType(W, I, True if alpha < 0 else False)
+            I_bits += 1
+            W_bits += 1
+        node.attributes[type_to_infer].precision = FixedPrecisionType(W_bits, I_bits, True if alpha < 0 else False)
         inferred_types.append(type_to_infer)
         return inferred_types
 


### PR DESCRIPTION
This simple PR implement a part related 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

I run some tests related to Parametrised Activations, already present in the pytests of hls4ml.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
