### PR TITLE
Fix initiation interval of pooling and zeropadding layers on Vitis backend

### DIFF
--- a/hls4ml/templates/vitis/nnet_utils/nnet_pooling_stream.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_pooling_stream.h
@@ -105,12 +105,14 @@ void pooling2d_cl(hls::stream<data_T> &data, hls::stream<res_T> &res) {
                                                                                     [CONFIG_T::n_filt];
     #pragma HLS ARRAY_PARTITION variable = line_buffer complete dim = 2
 
+    constexpr int pack_factor = data_T::size / CONFIG_T::n_filt;
+
 ReadInputHeight:
     for (unsigned i_ih = 0; i_ih < CONFIG_T::in_height; i_ih++) {
     ReadInputWidth:
         for (unsigned i_iw = 0; i_iw < CONFIG_T::in_width; i_iw++) {
             #pragma HLS LOOP_FLATTEN
-            #pragma HLS PIPELINE
+            #pragma HLS PIPELINE II=pack_factor
 
             compute_pool_buffer_2d<data_T, res_T, CONFIG_T>(data.read(), line_buffer, res);
         }

--- a/hls4ml/templates/vivado/nnet_utils/nnet_padding_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_padding_stream.h
@@ -57,6 +57,7 @@ PadTop:
 
 PadMain:
     for (int i = 0; i < CONFIG_T::in_height; i++) {
+        #pragma HLS PIPELINE II=1
     PadLeft:
         for (int j = 0; j < CONFIG_T::pad_left; j++) {
             fill_zero<res_T, CONFIG_T>(res);


### PR DESCRIPTION
On the `Vitis` backend and `io_stream`, zeropadding and pooling layers don't reach `II=1`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Synthesized the zeropadding and pooling models in the pytests. Code achieves `II=1` and Latency cycles  match the tripcount. LUT and FF usage is increased by a small fraction, same applies to the synthesis time of zeropadding.

**Test Configuration**:

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
