### PR TITLE
Fixes to parsing of pytorch models when using torch functionals

### DIFF
--- a/hls4ml/converters/pytorch/pooling.py
+++ b/hls4ml/converters/pytorch/pooling.py
@@ -90,15 +90,19 @@ def parse_pooling_layer(operation, layer_name, input_names, input_shapes, node, 
                 layer['stride_height'] = node.kwargs['stride'][0]
                 layer['stride_width'] = node.kwargs['stride'][1]
             else:
-                layer['stride_height'] = node.kwargs['stride']
-                layer['stride_width'] = node.kwargs['stride']
-            if type(node.kwargs['kernel_size']) is tuple:
-                layer['pool_height'] = node.kwargs['kernel_size'][0]
-                layer['pool_width'] = node.kwargs['kernel_size'][1]
+                if node.kwargs['stride'] is None:
+                    # if stride is not set it is supposed to default to the kernel size
+                    layer['stride_height'] = node.args[1]
+                    layer['stride_width'] = node.args[1]
+                else:
+                    layer['stride_height'] = node.kwargs['stride']
+                    layer['stride_width'] = node.kwargs['stride']
+            if type(node.args[1]) is tuple:
+                layer['pool_height'] = node.args[1][0]
+                layer['pool_width'] = node.args[1][1]
             else:
-                layer['pool_height'] = node.kwargs['kernel_size']
-                layer['pool_width'] = node.kwargs['kernel_size']
-
+                layer['pool_height'] = node.args[1]
+                layer['pool_width'] = node.args[1]
             if type(node.kwargs['padding']) is tuple:
                 padding = node.kwargs['padding']
             else:

--- a/hls4ml/converters/pytorch/pooling.py
+++ b/hls4ml/converters/pytorch/pooling.py
@@ -86,7 +86,6 @@ def parse_pooling_layer(operation, layer_name, input_names, input_shapes, node, 
                 padding = [class_object.padding, class_object.padding]
 
         else:
-            print(node.args)
             if type(node.kwargs['stride']) is tuple:
                 layer['stride_height'] = node.kwargs['stride'][0]
                 layer['stride_width'] = node.kwargs['stride'][1]

--- a/hls4ml/converters/pytorch/pooling.py
+++ b/hls4ml/converters/pytorch/pooling.py
@@ -86,6 +86,7 @@ def parse_pooling_layer(operation, layer_name, input_names, input_shapes, node, 
                 padding = [class_object.padding, class_object.padding]
 
         else:
+            print(node.args)
             if type(node.kwargs['stride']) is tuple:
                 layer['stride_height'] = node.kwargs['stride'][0]
                 layer['stride_width'] = node.kwargs['stride'][1]

--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -93,7 +93,7 @@ def parse_flatten_layer(operation, layer_name, input_names, input_shapes, node, 
     layer['class_name'] = 'Reshape'
     layer['name'] = layer_name
     layer['inputs'] = input_names
-    if node.op == "call_module":
+    if node.op == 'call_module':
         start_dim = class_object.start_dim
         end_dim = class_object.end_dim
         if end_dim + 1 == 0 or end_dim + 1 > len(input_shapes[0]):

--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -93,13 +93,23 @@ def parse_flatten_layer(operation, layer_name, input_names, input_shapes, node, 
     layer['class_name'] = 'Reshape'
     layer['name'] = layer_name
     layer['inputs'] = input_names
-
-    start_dim = class_object.start_dim
-    end_dim = class_object.end_dim
-    if end_dim + 1 == 0 or end_dim + 1 > len(input_shapes[0]):
-        end_dim = len(input_shapes[0])
+    if node.op == "call_module":
+        start_dim = class_object.start_dim
+        end_dim = class_object.end_dim
+        if end_dim + 1 == 0 or end_dim + 1 > len(input_shapes[0]):
+            end_dim = len(input_shapes[0])
+        else:
+            end_dim = end_dim + 1
     else:
-        end_dim = end_dim + 1
+        start_dim = node.args[1]
+        if len(node.args) == 3:
+            end_dim = node.args[2]
+        else:
+            end_dim = -1
+        if end_dim + 1 == 0 or end_dim + 1 > len(input_shapes[0]):
+            end_dim = len(input_shapes[0])
+        else:
+            end_dim = end_dim + 1
 
     layer['target_shape'] = (
         input_shapes[0][0:start_dim] + [np.prod(input_shapes[0][start_dim:end_dim])] + input_shapes[0][end_dim:]


### PR DESCRIPTION
A# Description

When torch functionals are used for pooling and flatten operations, some arguments were not correctly caught (or in the case of flatten, this type of usage was not supported at all). This PR fixes these issues. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

The example model in https://github.com/pytorch/examples/blob/main/mnist/main.py would fail to parse before, and now succeeds, modulo the not supported log_softmax activiation in the end. 


## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
