### PR TITLE
Temporary workaround for QKeras installation

### DIFF
--- a/hls4ml/__init__.py
+++ b/hls4ml/__init__.py
@@ -1,4 +1,34 @@
-from hls4ml import converters, report, utils  # noqa: F401
+# Temporary workaround for QKeras installation requirement, will be removed after 1.0.0
+def maybe_install_qkeras():
+    import subprocess
+    import sys
+
+    QKERAS_PKG_NAME = 'QKeras'
+    # QKERAS_PKG_SOURCE = QKERAS_PKG_NAME
+    QKERAS_PKG_SOURCE = 'qkeras@git+https://github.com/fastmachinelearning/qkeras.git'
+
+    def pip_list():
+        p = subprocess.run([sys.executable, '-m', 'pip', 'list'], check=True, capture_output=True)
+        return p.stdout.decode()
+
+    def pip_install(package):
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+
+    all_pkgs = pip_list()
+    if QKERAS_PKG_NAME not in all_pkgs:
+        print('QKeras installation not found, installing one...')
+        pip_install(QKERAS_PKG_SOURCE)
+        print('QKeras installed.')
+
+
+try:
+    maybe_install_qkeras()
+except Exception:
+    print('Could not find QKeras installation, make sure you have QKeras installed.')
+
+# End of workaround
+
+from hls4ml import converters, report, utils  # noqa: F401, E402
 
 try:
     from ._version import version as __version__

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ install_requires =
     pydigitalwavetools==1.1
     pyparsing
     pyyaml
-    qkeras@git+https://github.com/google/qkeras.git
     tabulate
     tensorflow>=2.8.0,<=2.14.1
     tensorflow-model-optimization<=0.7.5


### PR DESCRIPTION
# Description

Temporary workaround for installing without QKeras dependency since PyPI won't allow us to submit a package with direct dependencies. Relying on published version of QKeras breaks things, so there's no nice solution.

The workaround is to install qkeras if it is not already present in the environment prior to initialization of hls4ml package itself. It has been tested in various environment configurations and seems to work without breaking other stuff.

Dumbest PR so far!

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Tests

Any import of hls4ml should trigger this.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
