### PR TITLE
Don't overwrite already set accum_t, fix pointwise output resolution

### DIFF
--- a/hls4ml/backends/fpga/fpga_layers.py
+++ b/hls4ml/backends/fpga/fpga_layers.py
@@ -73,12 +73,14 @@ class BatchNormalizationQuantizedTanh(Layer):
 class PointwiseConv1D(Conv1D):
     '''Optimized Conv1D implementation for 1x1 kernels.'''
 
-    # Nothing to do, will pick up function and config from class name
-    pass
+    def initialize(self):
+        # Do noting, values copied
+        pass
 
 
 class PointwiseConv2D(Conv2D):
     '''Optimized Conv2D implementation for 1x1 kernels.'''
 
-    # Nothing to do, will pick up function and config from class name
-    pass
+    def initialize(self):
+        # Do noting, values copied
+        pass

--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -176,10 +176,12 @@ class Layer:
         return NamedType(name=name, precision=precision)
 
     def _set_accum_t(self):
-        has_accum_t = any(a for a in self.expected_attributes if a.name == 'accum_t' and isinstance(a, TypeAttribute))
-        if has_accum_t:
-            accum_t = NamedType(*reversed(self.model.config.get_precision(self, 'accum')))
-            self.set_attr('accum_t', accum_t)
+        """Set the accumulator, but don't overwrite an existing one"""
+        if self.get_attr('accum_t') is None:
+            has_accum_t = any(a for a in self.expected_attributes if a.name == 'accum_t' and isinstance(a, TypeAttribute))
+            if has_accum_t:
+                accum_t = NamedType(*reversed(self.model.config.get_precision(self, 'accum')))
+                self.set_attr('accum_t', accum_t)
 
     def _set_type_t(self, name):
         has_type_t = any(a for a in self.expected_attributes if a.name == name + '_t' and isinstance(a, TypeAttribute))

--- a/hls4ml/model/optimizer/__init__.py
+++ b/hls4ml/model/optimizer/__init__.py
@@ -59,7 +59,6 @@ register_flow(
     'convert',
     [
         'channels_last_converter',
-        'merge_linear_activation',
         'seperable_to_depthwise_and_conv',
         'remove_transpose_before_flatten',
         'remove_nop_transpose',
@@ -74,6 +73,7 @@ register_flow(
         'replace_multidimensional_dense_with_conv',
         'enforce_proxy_model_embedded_config',
         'eliminate_linear_activation',
+        'merge_linear_activation',
         # many of the above optimzers need to be done before this
         'infer_precision_types',
     ],


### PR DESCRIPTION
# Description

Modify `Layer._set_accum_t()` to not overwrite an already existing `accum_t`, which can happen in an optimizer. Also, modify the pointwise init functions to do nothing, since the values are already set. Otherwise, the result_t was overwritten, potentially nullifying an explicit value set by a quantizer (a Quant node in a failing test). 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

The failing test that this fixes will be added soon. It is important that it doesn't break anything else.

TODO:  We should confirm that there are no other optimizers that may cause the same probelm

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
