### PR TITLE
oneAPI 2025.0 include changes

### DIFF
--- a/hls4ml/templates/oneapi/myproject_test.cpp
+++ b/hls4ml/templates/oneapi/myproject_test.cpp
@@ -11,6 +11,10 @@
 
 #include <sycl/ext/intel/fpga_extensions.hpp>
 
+#if (__INTEL_CLANG_COMPILER < 20250000)
+#include <sycl/ext/intel/prototype/interfaces.hpp>
+#endif
+
 #include "exception_handler.hpp"
 // hls-fpga-machine-learning insert bram
 


### PR DESCRIPTION
# Removing include for 2025.0

## Type of change

oneAPI 2025.0 removes `interfaces.hpp` and the relevant functions are available from `fpga_extensions.hpp`

- [x] Bug fix (non-breaking change that fixes an issue)


## Checklist

- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.

