### PR TITLE
Split hgq tests and isolate qkeras tests to make tests run in under 1h

### DIFF
--- a/test/pytest/generate_ci_yaml.py
+++ b/test/pytest/generate_ci_yaml.py
@@ -25,7 +25,7 @@ n_test_files_per_yml = int(os.environ.get('N_TESTS_PER_YAML', 4))
 BLACKLIST = {'test_reduction'}
 
 # Long-running tests will not be bundled with other tests
-LONGLIST = {'test_hgq_layers', 'test_hgq_players', 'test_qkeras'}
+LONGLIST = {'test_hgq_layers', 'test_hgq_players', 'test_qkeras', 'test_pytorch_api'}
 
 
 def path_to_name(test_path):

--- a/test/pytest/generate_ci_yaml.py
+++ b/test/pytest/generate_ci_yaml.py
@@ -18,13 +18,14 @@ pytest.{}:
     EXAMPLEMODEL: {}
 """
 
+
 n_test_files_per_yml = int(os.environ.get('N_TESTS_PER_YAML', 4))
 
 # Blacklisted tests will be skipped
 BLACKLIST = {'test_reduction'}
 
 # Long-running tests will not be bundled with other tests
-LONGLIST = {'test_hgq_layers','test_hgq_players','test_qkeras'}
+LONGLIST = {'test_hgq_layers', 'test_hgq_players', 'test_qkeras'}
 
 
 def path_to_name(test_path):

--- a/test/pytest/generate_ci_yaml.py
+++ b/test/pytest/generate_ci_yaml.py
@@ -72,7 +72,7 @@ def generate_test_yaml(test_root='.'):
         name = path.stem.replace('test_', '')
         test_file = str(path.relative_to(test_root))
         needs_examples = uses_example_model(path)
-        diff_yml = yaml.safe_load(template.format(name, test_file, needs_examples))
+        diff_yml = yaml.safe_load(template.format(name, test_file, int(needs_examples)))
         yml.update(diff_yml)
 
     return yml

--- a/test/pytest/generate_ci_yaml.py
+++ b/test/pytest/generate_ci_yaml.py
@@ -24,7 +24,7 @@ n_test_files_per_yml = int(os.environ.get('N_TESTS_PER_YAML', 4))
 BLACKLIST = {'test_reduction'}
 
 # Long-running tests will not be bundled with other tests
-LONGLIST = {'test_hgq_layers'}
+LONGLIST = {'test_hgq_layers','test_hgq_players','test_qkeras'}
 
 
 def path_to_name(test_path):

--- a/test/pytest/test_hgq_layers.py
+++ b/test/pytest/test_hgq_layers.py
@@ -19,7 +19,6 @@ from HGQ.layers import (  # noqa: F401
     Signature,
 )
 from HGQ.proxy import to_proxy_model
-from HGQ.proxy.fixed_point_quantizer import gfixed
 from tensorflow import keras
 
 from hls4ml.converters import convert_from_keras_model

--- a/test/pytest/test_hgq_players.py
+++ b/test/pytest/test_hgq_players.py
@@ -123,11 +123,13 @@ def create_player_model(layer: str, rnd_strategy: str, io_type: str):
 
     return model
 
+
 def get_data(shape: tuple[int, ...], v: float, max_scale: float):
     rng = np.random.default_rng()
     a1 = rng.uniform(-v, v, shape).astype(np.float32)
     a2 = rng.uniform(0, max_scale, (1, shape[1])).astype(np.float32)
     return (a1 * a2).astype(np.float32)
+
 
 @pytest.mark.parametrize(
     'layer',

--- a/test/pytest/test_hgq_players.py
+++ b/test/pytest/test_hgq_players.py
@@ -79,44 +79,49 @@ def run_model_test(
     _run_synth_match_test(proxy, data, io_type, backend, dir, cond=cond)
 
 
-def create_hlayer_model(layer: str, rnd_strategy: str, io_type: str):
+def create_player_model(layer: str, rnd_strategy: str, io_type: str):
     pa_config = get_default_paq_conf()
     pa_config['rnd_strategy'] = rnd_strategy
     pa_config['skip_dims'] = 'all' if io_type == 'io_stream' else 'batch'
     set_default_paq_conf(pa_config)
 
-    inp = keras.Input(shape=(16))
-    if 'Add' in layer:
+    inp = keras.Input(shape=(15))
+    if 'PConcatenate' in layer:
         _inp = [HQuantize()(inp)] * 2
-    elif 'Conv2D' in layer:
-        _inp = PReshape((4, 4, 1))(HQuantize()(inp))
-    elif 'Conv1D' in layer:
-        _inp = PReshape((16, 1))(HQuantize()(inp))
+        out = eval(layer)(_inp)
+        out = HDense(15)(out)
+        return keras.Model(inp, out)
+    elif 'Signature' in layer:
+        _inp = eval(layer)(inp)
+        out = HDense(15)(_inp)
+        return keras.Model(inp, out)
+    elif 'Pool2D' in layer:
+        _inp = PReshape((3, 5, 1))(HQuantize()(inp))
+    elif 'Pool1D' in layer:
+        _inp = PReshape((5, 3))(HQuantize()(inp))
     elif 'Dense' in layer or 'Activation' in layer:
         _inp = HQuantize()(inp)
+    elif 'Flatten' in layer:
+        out = HQuantize()(inp)
+        out = PReshape((3, 5))(out)
+        out = HConv1D(2, 2)(out)
+        out = eval(layer)(out)
+        out = HDense(15)(out)
+        return keras.Model(inp, out)
     else:
         raise Exception(f'Please add test for {layer}')
 
-    _layer = eval('HGQ.layers.' + layer)
-    if hasattr(_layer, 'bias') and _layer.bias is not None:
-        bias: tf.Variable = _layer.bias
-        bias.assign(tf.constant(np.random.uniform(-4, 4, _layer.bias.shape).astype(np.float32)))
-
-    out = _layer(_inp)
+    out = eval(layer)(_inp)
     model = keras.Model(inp, out)
 
     for layer in model.layers:
-        # Randomize weight bitwidths
-        if hasattr(layer, 'kq'):
-            fbw: tf.Variable = layer.kq.fbw
-            fbw.assign(tf.constant(np.random.uniform(2, 6, fbw.shape).astype(np.float32)))
+        # No weight bitwidths to randomize
         # And activation bitwidths
         if hasattr(layer, 'paq'):
             fbw: tf.Variable = layer.paq.fbw
-            fbw.assign(tf.constant(np.random.uniform(2, 6, fbw.shape).astype(np.float32)))
+            fbw.assign(tf.constant(np.random.uniform(4, 6, fbw.shape).astype(np.float32)))
 
     return model
-
 
 def get_data(shape: tuple[int, ...], v: float, max_scale: float):
     rng = np.random.default_rng()
@@ -124,56 +129,41 @@ def get_data(shape: tuple[int, ...], v: float, max_scale: float):
     a2 = rng.uniform(0, max_scale, (1, shape[1])).astype(np.float32)
     return (a1 * a2).astype(np.float32)
 
-
-def softmax_cond(proxy, hls):
-    match_precent = np.mean(np.argmax(proxy, axis=1) == np.argmax(hls, axis=1))
-    assert (
-        match_precent > 0.90
-    ), f"Proxy-HLS4ML mismatch: {(1-match_precent) * 100}% of samples are different. Sample: {proxy[:5]} vs {hls[:5]}"
-
-
-def custom_activation_fn(x):
-    return tf.sin(x) ** 2.0 - x  # type: ignore
-
-
 @pytest.mark.parametrize(
     'layer',
     [
-        "HDense(10)",
-        "HDense(10, use_bias=False)",
-        "HDenseBatchNorm(10)",
-        "HConv1D(2, 3, padding='same')",
-        "HConv1D(2, 3, padding='valid')",
-        "HConv1D(2, 3, padding='valid', use_bias=False)",
-        "HConv1D(2, 3, padding='valid', strides=2)",
-        "HConv1D(2, 3, padding='same', strides=2)",
-        "HConv1DBatchNorm(2, 3, padding='valid')",
-        "HConv2D(2, (3,3), padding='same')",
-        "HConv2D(2, (3,3), padding='valid')",
-        "HConv2D(2, (3,3), padding='valid', use_bias=False)",
-        "HConv2D(2, (3,3), padding='valid', strides=2)",
-        "HConv2D(2, (3,3), padding='same', strides=2)",
-        "HConv2DBatchNorm(2, (3,3), padding='valid')",
-        "HAdd()",
-        "HActivation('relu')",
-        #   "HActivation('leaky_relu')",
-        "HActivation('tanh')",
-        "HActivation('sigmoid')",
-        # "HActivation('softmax')",
-        "HActivation(custom_activation_fn)",
+        "PConcatenate()",
+        "PMaxPool1D(2, padding='same')",
+        "PMaxPool1D(4, padding='same')",
+        "PMaxPool2D((5,3), padding='same')",
+        "PMaxPool1D(2, padding='valid')",
+        "PMaxPool2D((2,3), padding='valid')",
+        "Signature(1,6,3)",
+        "PAvgPool1D(2, padding='same')",
+        "PAvgPool2D((1,2), padding='same')",
+        "PAvgPool2D((2,2), padding='same')",
+        "PAvgPool1D(2, padding='valid')",
+        "PAvgPool2D((1,2), padding='valid')",
+        "PAvgPool2D((2,2), padding='valid')",
+        "PFlatten()",
     ],
 )
 @pytest.mark.parametrize("N", [1000])
-@pytest.mark.parametrize("rnd_strategy", ['standard_round', 'floor'])
+@pytest.mark.parametrize("rnd_strategy", ['floor', 'standard_round'])
 @pytest.mark.parametrize("io_type", ['io_parallel', 'io_stream'])
 @pytest.mark.parametrize("cover_factor", [1.0])
 @pytest.mark.parametrize("aggressive", [True, False])
 @pytest.mark.parametrize("backend", ['vivado', 'vitis'])
-def test_syn_hlayers(layer, N: int, rnd_strategy: str, io_type: str, cover_factor: float, aggressive: bool, backend: str):
-    model = create_hlayer_model(layer=layer, rnd_strategy=rnd_strategy, io_type=io_type)
-    data = get_data((N, 16), 7, 1)
+def test_syn_players(layer, N: int, rnd_strategy: str, io_type: str, cover_factor: float, aggressive: bool, backend: str):
+    model = create_player_model(layer=layer, rnd_strategy=rnd_strategy, io_type=io_type)
+    data = get_data((N, 15), 7, 1)
 
-    cond = None if 'softmax' not in layer else softmax_cond
     path = test_path / f'hls4mlprj_hgq_{layer}_{rnd_strategy}_{io_type}_{aggressive}_{backend}'
 
-    run_model_test(model, cover_factor, data, io_type, backend, str(path), aggressive, cond=cond)
+    if 'Signature' in layer:
+        q = gfixed(1, 6, 3)
+        data = q(data).numpy()
+    if "padding='same'" in layer and io_type == 'io_stream':
+        pytest.skip("io_stream does not support padding='same' for pools at the moment")
+
+    run_model_test(model, cover_factor, data, io_type, backend, str(path), aggressive)


### PR DESCRIPTION
Attempt to reconfigure pytests so that they reliably finish in under 1h and don't get killed. 

The HGQ tests are split into two and both are run standalone. The QKeras test is also added to the list of long-running tests that should not be run in the same batch as other tests. 

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [x] Other (Specify)

## Tests

No new tests, but hopefully existing ones will pass. 

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
