### PR TITLE
Fix Vivado Accelerator missing partition factor variable

### DIFF
--- a/hls4ml/writer/vivado_accelerator_writer.py
+++ b/hls4ml/writer/vivado_accelerator_writer.py
@@ -394,6 +394,8 @@ class VivadoAcceleratorWriter(VivadoWriter):
         f.write('set clock_uncertainty {}\n'.format(model.config.get_config_value('ClockUncertainty', '12.5%')))
         f.write('variable version\n')
         f.write('set version "{}"\n'.format(model.config.get_config_value('Version', '1.0.0')))
+        f.write('variable maximum_size\n')
+        f.write('set maximum_size {}\n'.format(model.config.get_config_value('MaximumSize', '4096')))
         if self.vivado_accelerator_config.get_interface() == 'axi_stream':
             in_bit, out_bit = self.vivado_accelerator_config.get_io_bitwidth()
             f.write(f'set bit_width_hls_output {in_bit}\n')


### PR DESCRIPTION
# Description

> :memo: Fixes the missing maximum_size variable for the partition_factor in Vivado Accelerator backend
>
> * (Possible) Fix for #1157

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Tests
None yet; still needs confirmation that it fixes the issue confirmed in #1157

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
