### PR TITLE
add check for no inputs in insert_node

### DIFF
--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -494,7 +494,7 @@ class ModelGraph:
                 next_nodes.append(x)
 
         if before is None:
-            next_node = next((x for x in self.graph.values() if x.inputs[0] in prev_node.outputs), None)
+            next_node = next((x for x in self.graph.values() if x.inputs and x.inputs[0] in prev_node.outputs), None)
         else:
             if before not in next_nodes:
                 raise Exception(


### PR DESCRIPTION
# Description

`graph.insert_node()` assumes all the nodes have an input, but constant nodes do not. This adds a check to not fail if there is a node with no input in the graph.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

None at the moment, though we have a script that caused this to fail before. We should discuss whether we should add it.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
