### PR TITLE
remove np.float_ (deprecated in numpy>=2.0)

### DIFF
--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -732,7 +732,7 @@ class ModelGraph:
         if x0.dtype in [np.single, np.float32]:
             top_function = getattr(self._top_function_lib, self.config.get_project_name() + '_float')
             ctype = ctypes.c_float
-        elif x0.dtype in [np.double, np.float64, np.float_]:
+        elif x0.dtype in [np.double, np.float64]:
             top_function = getattr(self._top_function_lib, self.config.get_project_name() + '_double')
             ctype = ctypes.c_double
         else:


### PR DESCRIPTION
A# Description

`np.float_` is deprecated in `numpy>=2.0`. As it was [merely an alias of `np.double`](https://numpy.org/doc/1.22/reference/arrays.scalars.html?highlight=float_#numpy.double), there is no reason to keep it for type checking.
  
## Type of change

Note: Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Test env dep, not applicable.

## Checklist

- [x] all
