### PR TITLE
Fix pytorch upsample parsing

### DIFF
--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -152,7 +152,7 @@ def handle_upsample(operation, layer_name, input_names, input_shapes, node, clas
         layer['out_height'] = int(layer['in_height'] * scale_height)
         layer['out_width'] = int(layer['in_width'] * scale_width)
 
-        output_shape = [layer['n_chan'], layer['out_height'], layer['out_width']]
+        output_shape = [input_shapes[0][0], layer['n_chan'], layer['out_height'], layer['out_width']]
     else:
         raise Exception(f'Parsing "Upsample" with {len(input_shape)}-dimensional tensors is not yet supported.')
 

--- a/test/pytest/test_upsampling_pytorch.py
+++ b/test/pytest/test_upsampling_pytorch.py
@@ -33,9 +33,10 @@ class Upsample1DModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.upsample = nn.Upsample(scale_factor=2)
+        self.relu = nn.ReLU()
 
     def forward(self, x):
-        return self.upsample(x)
+        return self.relu(self.upsample(x))
 
 
 class Upsample2DModel(nn.Module):
@@ -43,9 +44,10 @@ class Upsample2DModel(nn.Module):
         super().__init__()
         # this scale_factor tests proper output shape calculation with fractional scaling and parsing per-axis scales
         self.upsample = nn.UpsamplingNearest2d(scale_factor=(1, 2.4))  # Would also work with Upsample(mode='nearest')
+        self.relu = nn.ReLU()
 
     def forward(self, x):
-        return self.upsample(x)
+        return self.relu(self.upsample(x))
 
 
 @pytest.mark.parametrize('io_type', ['io_stream', 'io_parallel'])


### PR DESCRIPTION
# Description

The parser for PyTorch `Upsampling` layer ignores including the batch dimension in output shape, causing the failure of parsing subsequent layers. Fixes #1184.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Extended `test_upsampling_pytorch.py` to have a layer afterwards.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
