### PR TITLE
Fix paths to weights in build_lib.sh for VivadoAccelator backend

### DIFF
--- a/hls4ml/templates/vivado_accelerator/build_lib.sh
+++ b/hls4ml/templates/vivado_accelerator/build_lib.sh
@@ -9,9 +9,11 @@ fi
 INCFLAGS="-Ifirmware/ap_types/"
 PROJECT=myproject
 LIB_STAMP=mystamp
+BASEDIR="$(cd "$(dirname "$0")" && pwd)"
+WEIGHTS_DIR="\"${BASEDIR}/firmware/weights\""
 
-${CC} ${CFLAGS} ${INCFLAGS} -c firmware/${PROJECT}.cpp -o ${PROJECT}.o
-${CC} ${CFLAGS} ${INCFLAGS} -c firmware/${PROJECT}_axi.cpp -o ${PROJECT}_axi.o
-${CC} ${CFLAGS} ${INCFLAGS} -c ${PROJECT}_bridge.cpp -o ${PROJECT}_bridge.o
+${CC} ${CFLAGS} ${INCFLAGS} -D WEIGHTS_DIR="${WEIGHTS_DIR}" -c firmware/${PROJECT}.cpp -o ${PROJECT}.o
+${CC} ${CFLAGS} ${INCFLAGS} -D WEIGHTS_DIR="${WEIGHTS_DIR}" -c firmware/${PROJECT}_axi.cpp -o ${PROJECT}_axi.o
+${CC} ${CFLAGS} ${INCFLAGS} -D WEIGHTS_DIR="${WEIGHTS_DIR}" -c ${PROJECT}_bridge.cpp -o ${PROJECT}_bridge.o
 ${CC} ${CFLAGS} ${INCFLAGS} -shared ${PROJECT}.o ${PROJECT}_axi.o ${PROJECT}_bridge.o -o firmware/${PROJECT}-${LIB_STAMP}.so
 rm -f *.o


### PR DESCRIPTION
Fixes crashes of part7a of the tutorial in v.1.0.0 reported in https://github.com/fastmachinelearning/hls4ml/issues/1157. 
These were found to be to a missing configuration of the path to the weight files in the `VivadoAccelator` background and thus a failure of the `predict()` function of the compiled model. 

Fixed by explicitly setting the path in `build_lib.sh` in the `VivadoAccelerator`, copied from the same file in the `Vivado` backend. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

With v1.0.0 and the main branch, part7a of the tutorial crashes on the line 

`y_hls = hls_model.predict(np.ascontiguousarray(X_test))`

With this fix, it no longer crashes. 

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
