### PR TITLE
Fix typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ optional-dependencies.qkeras = [
   "tensorflow>=2.8,<=2.14.1",
   "tensorflow-model-optimization<=0.7.5",
 ]
-optional-dependencies.quartus_report = [ "calmjs-parse", "tabulate" ]
+optional-dependencies.quartus-report = [ "calmjs-parse", "tabulate" ]
 optional-dependencies.sr = [ "sympy" ]
 optional-dependencies.testing = [
   "calmjs-parse",


### PR DESCRIPTION
`quartus-testing` was mispelled as `quartus_testing` in pyproject.toml. 

## Type of change


- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Seems to fix crashes on import of hls4ml. 

## Checklist

Yes. 
