### PR TITLE
Improve precision for non-power-of-2 scales in brevitas -> QONNX workflow and add pytests

### DIFF
--- a/hls4ml/model/optimizer/passes/move_scales.py
+++ b/hls4ml/model/optimizer/passes/move_scales.py
@@ -12,6 +12,9 @@ import numpy as np
 from hls4ml.model.layers import ApplyAlpha, Constant, Conv, MatMul, Merge
 from hls4ml.model.optimizer import OptimizerPass
 
+# These attributes should not be copied. (Should add the output name to this)
+_attrs_not_to_copy = ['trace', 'precision', 'scale', 'bias', 'scale_data', 'bias_data']
+
 
 class ScaleDownMatMul(OptimizerPass):
     '''Shift an ApplyAlpha below a MatMul'''
@@ -62,7 +65,7 @@ class ScaleDownMatMul(OptimizerPass):
 
         output = node.get_output_variable()
         # to remove warning, since these get set again
-        new_attrs = {k: v for k, v in apply_alpha.attributes.items() if k not in ('trace', 'precision')}
+        new_attrs = {k: v for k, v in apply_alpha.attributes.items() if k not in _attrs_not_to_copy + apply_alpha.outputs}
 
         can_propagate = False
         if not bias.shape and bias == 0:
@@ -258,7 +261,7 @@ class ScaleDownConv(OptimizerPass):
                 return False
 
             # to remove warning, since these get set again
-            new_attrs = {k: v for k, v in in0.attributes.items() if k not in ('trace', 'precision')}
+            new_attrs = {k: v for k, v in in0.attributes.items() if k not in _attrs_not_to_copy + in0.outputs}
             new_name = in0.name
             model.remove_node(in0)
 
@@ -305,7 +308,7 @@ class ScaleDownConv(OptimizerPass):
                 return False
 
             # to remove warning, since these get set again
-            new_attrs = {k: v for k, v in in0.attributes.items() if k not in ('trace', 'precision')}
+            new_attrs = {k: v for k, v in in0.attributes.items() if k not in _attrs_not_to_copy + in0.outputs}
             new_name = in1.name
             model.remove_node(in1)
 
@@ -329,7 +332,7 @@ class ScaleDownConv(OptimizerPass):
                 return False
 
             # to remove warning, since these get set again
-            new_attrs = {k: v for k, v in in2.attributes.items() if k not in ('trace', 'precision')}
+            new_attrs = {k: v for k, v in in2.attributes.items() if k not in _attrs_not_to_copy + in2.outputs}
             new_name = in2.name
             model.remove_node(in2)
 
@@ -391,7 +394,7 @@ class ScaleDownConv(OptimizerPass):
                 return False
 
             # to remove warning, since these get set again
-            new_attrs = {k: v for k, v in in0.attributes.items() if k not in ('trace', 'precision')}
+            new_attrs = {k: v for k, v in in0.attributes.items() if k not in _attrs_not_to_copy + in0.outputs}
             new_name = in1.name
             model.remove_node(in0)
             model.remove_node(in1)
@@ -415,7 +418,7 @@ class ScaleDownConv(OptimizerPass):
                 return False
 
             # to remove warning, since these get set again
-            new_attrs = {k: v for k, v in in0.attributes.items() if k not in ('trace', 'precision')}
+            new_attrs = {k: v for k, v in in0.attributes.items() if k not in _attrs_not_to_copy + in0.outputs}
             new_name = in0.name
             model.remove_node(in0)
             model.remove_node(in2)
@@ -442,7 +445,7 @@ class ScaleDownConv(OptimizerPass):
                 return False
 
             # to remove warning, since these get set again
-            new_attrs = {k: v for k, v in in1.attributes.items() if k not in ('trace', 'precision')}
+            new_attrs = {k: v for k, v in in1.attributes.items() if k not in _attrs_not_to_copy + in1.outputs}
             new_name = in1.name
             model.remove_node(in1)
             model.remove_node(in2)
@@ -478,7 +481,7 @@ class ScaleDownConv(OptimizerPass):
                 return False
 
             # to remove warning, since these get set again
-            new_attrs = {k: v for k, v in in0.attributes.items() if k not in ('trace', 'precision')}
+            new_attrs = {k: v for k, v in in0.attributes.items() if k not in _attrs_not_to_copy + in0.outputs}
             new_name = in0.name
             model.remove_node(in0)
             model.remove_node(in1)

--- a/hls4ml/model/optimizer/passes/quant_opt.py
+++ b/hls4ml/model/optimizer/passes/quant_opt.py
@@ -343,8 +343,16 @@ class ConstQuantToConstAlpha(OptimizerPass):
 
         rescale = scale
         rebias = -bias * scale
+
+        # precision of the scale is important for overall model accuracy, so it is increased here
+        # This is somewhat stupid and needs a better solution
+        frac_bits = node.get_attr('bitwidth') * 2
+        scale_precision, scale_quantizer = _calculate_precision_quantizer(frac_bits, 0, signed, narrow, rounding_mode)
+
         attributes_rescale['scale_data'] = np.broadcast_to(rescale, inshape)
         attributes_rescale['bias_data'] = np.broadcast_to(rebias, inshape)
+        attributes_rescale['scale_quantizer'] = scale_quantizer
+        attributes_rescale['scale_precision'] = scale_precision
 
         rescale_node = model.make_node(
             ApplyAlpha, rescale_name, attributes_rescale, [x for x in node.inputs], [x for x in node.outputs]


### PR DESCRIPTION
Adds simple pytests for the brevitas -> QONNX -> hls4ml workflow.

Tested are models using both power-of-2 and non-power-of-2 scales. For the latter, the accuracy is generally poor, driven by insufficient precision for the scale variable in the rescaling operation. So far I have only come up with a stupid fix that chooses an arbitrary higher precision to improve things, and I would like to discuss better options to infer the required precision. 

## Type of change

- [x] Other (Specify)

Mostly adds tests

## Tests

This PR adds the relevant pytests to test the brevitas -> QONNX -> hsl4ml workflow for a simple model with a linear layer and activation. More tests can be added, if desired. 

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
