### PR TITLE
make test_activations less sensitive to random seed values

### DIFF
--- a/test/pytest/test_pytorch_api.py
+++ b/test/pytest/test_pytorch_api.py
@@ -80,6 +80,7 @@ def test_activations(activation_function, backend, io_type):
     model.eval()
 
     X_input = np.random.rand(1)
+    X_input = np.round(X_input * 2**10) * 2**-10  # make it an exact ap_fixed<16,6>
 
     pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
 


### PR DESCRIPTION
# Description

This rounds the inputs in `test_activations` in `test_pytorch_api.py` so that the input values are the same for both the pytorch and hls4ml models. This should decrease the sensitivity to random numbers, which caused for example, the test failure in #1200.
 
## Type of change

- [x] Other (Specify) - pytest robustness

## Tests

Hopefully the pytest will no longer fail apparently randomly.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
