### PR TITLE
update sympy version

### DIFF
--- a/hls4ml/backends/symbolic/passes/expr_templates.py
+++ b/hls4ml/backends/symbolic/passes/expr_templates.py
@@ -33,6 +33,7 @@ class HLSCodePrinter(CXX11CodePrinter):
                 user_functions = settings.get('user_functions', {})
                 user_functions.update(lut_functions)
                 settings['user_functions'] = user_functions
+            settings['strict'] = False
 
         super().__init__(settings)
         self.layer = layer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ optional-dependencies.qkeras = [
   "tensorflow-model-optimization<=0.7.5",
 ]
 optional-dependencies.quartus-report = [ "calmjs-parse", "tabulate" ]
-optional-dependencies.sr = [ "sympy" ]
+optional-dependencies.sr = [ "sympy>=1.13.1" ]
 optional-dependencies.testing = [
   "calmjs-parse",
   "hgq>=0.2.3",


### PR DESCRIPTION
# Description

This PR addresses compatibility issues identified in issue #1207 related to `sympy` in symbolic backend.
Specifically, it updates the dependency requirements to ensure `sympy` version `1.13.1` or newer is used, which is necessary due to changes in the sympy library that affect hls4ml's custom `HLSCodePrinter` class.
The problem surfaced after updating the hls4ml-testing image version used in PR #1200.

The change is crucial to ensure that hls4ml remains functional and compatible with new versions of `sympy`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

The modifications were tested by rerunning `test_sr.py`, confirming that with `sympy` version 1.13.1, the `PrintMethodNotImplementedError` does not occur, ensuring that the library's functionality is intact.


## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.

For further details, please see the discussion in issue #1207.