### PR TITLE
Add precisoin bits to recurrent pytorch pytest

### DIFF
--- a/test/pytest/test_recurrent_pytorch.py
+++ b/test/pytest/test_recurrent_pytorch.py
@@ -38,7 +38,9 @@ def test_gru(backend, io_type):
     model.eval()
 
     X_input = torch.randn(1, 1, 10)
+    X_input = np.round(X_input * 2**16) * 2**-16  # make it exact ap_fixed<32,16>
     h0 = torch.randn(1, 1, 20)
+    h0 = np.round(h0 * 2**16) * 2**-16
 
     pytorch_prediction = model(torch.Tensor(X_input), torch.Tensor(h0)).detach().numpy()
 
@@ -67,6 +69,7 @@ def test_gru_stream(backend, io_type):
     model.eval()
 
     X_input = torch.randn(1, 1, 10)
+    X_input = np.round(X_input * 2**16) * 2**-16  # make it exact ap_fixed<32,16>
 
     pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
 
@@ -75,9 +78,7 @@ def test_gru_stream(backend, io_type):
     )
     output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_gru_{backend}_{io_type}')
 
-    hls_model = convert_from_pytorch_model(
-        model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type, default_precision='fixed<32,16>'
-    )
+    hls_model = convert_from_pytorch_model(model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type)
 
     hls_model.compile()
 
@@ -113,8 +114,11 @@ def test_lstm(backend, io_type):
     model.eval()
 
     X_input = torch.randn(1, 1, 10)
+    X_input = np.round(X_input * 2**16) * 2**-16  # make it exact ap_fixed<32,16>
     h0 = torch.randn(1, 1, 20)
+    h0 = np.round(h0 * 2**16) * 2**-16
     c0 = torch.randn(1, 1, 20)
+    c0 = np.round(c0 * 2**16) * 2**-16
 
     pytorch_prediction = model(torch.Tensor(X_input), torch.Tensor(h0), torch.tensor(c0)).detach().numpy()
 
@@ -152,6 +156,7 @@ def test_lstm_stream(backend, io_type):
         model.eval()
 
         X_input = torch.randn(1, 1, 10)
+        X_input = np.round(X_input * 2**16) * 2**-16  # make it exact ap_fixed<32,16>
 
         pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
 
@@ -193,6 +198,7 @@ def test_rnn(backend, io_type):
         model.eval()
 
         X_input = torch.randn(1, 1, 10)
+        X_input = np.round(X_input * 2**16) * 2**-16  # make it exact ap_fixed<32,16>
         h0 = torch.zeros(1, 1, 20)
 
         pytorch_prediction = model(torch.Tensor(X_input), torch.Tensor(h0)).detach().numpy()
@@ -212,7 +218,6 @@ def test_rnn(backend, io_type):
             output_dir=output_dir,
             backend=backend,
             io_type=io_type,
-            default_precision='fixed<32,16>',
         )
 
         hls_model.compile()

--- a/test/pytest/test_recurrent_pytorch.py
+++ b/test/pytest/test_recurrent_pytorch.py
@@ -43,7 +43,11 @@ def test_gru(backend, io_type):
     pytorch_prediction = model(torch.Tensor(X_input), torch.Tensor(h0)).detach().numpy()
 
     config = config_from_pytorch_model(
-        model, [(None, 1, 10), (None, 1, 20)], channels_last_conversion="off", transpose_outputs=False
+        model,
+        [(None, 1, 10), (None, 1, 20)],
+        channels_last_conversion="off",
+        transpose_outputs=False,
+        default_precision='fixed<32,16>',
     )
     output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_gru_{backend}_{io_type}')
 
@@ -66,10 +70,14 @@ def test_gru_stream(backend, io_type):
 
     pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
 
-    config = config_from_pytorch_model(model, (None, 1, 10), channels_last_conversion="off", transpose_outputs=False)
+    config = config_from_pytorch_model(
+        model, (None, 1, 10), channels_last_conversion="off", transpose_outputs=False, default_precision='fixed<32,16>'
+    )
     output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_gru_{backend}_{io_type}')
 
-    hls_model = convert_from_pytorch_model(model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type)
+    hls_model = convert_from_pytorch_model(
+        model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type, default_precision='fixed<32,16>'
+    )
 
     hls_model.compile()
 
@@ -111,7 +119,11 @@ def test_lstm(backend, io_type):
     pytorch_prediction = model(torch.Tensor(X_input), torch.Tensor(h0), torch.tensor(c0)).detach().numpy()
 
     config = config_from_pytorch_model(
-        model, [(None, 1, 10), (None, 1, 20), (None, 1, 20)], channels_last_conversion="off", transpose_outputs=False
+        model,
+        [(None, 1, 10), (None, 1, 20), (None, 1, 20)],
+        channels_last_conversion="off",
+        transpose_outputs=False,
+        default_precision='fixed<32,16>',
     )
     output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_lstm_{backend}_{io_type}')
 
@@ -143,7 +155,9 @@ def test_lstm_stream(backend, io_type):
 
         pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
 
-        config = config_from_pytorch_model(model, [(None, 1, 10)], channels_last_conversion="off", transpose_outputs=False)
+        config = config_from_pytorch_model(
+            model, [(None, 1, 10)], channels_last_conversion="off", transpose_outputs=False, default_precision='fixed<32,16>'
+        )
         output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_lstm_{backend}_{io_type}')
 
         hls_model = convert_from_pytorch_model(
@@ -184,12 +198,21 @@ def test_rnn(backend, io_type):
         pytorch_prediction = model(torch.Tensor(X_input), torch.Tensor(h0)).detach().numpy()
 
         config = config_from_pytorch_model(
-            model, [(1, 10), (1, 20)], channels_last_conversion="off", transpose_outputs=False
+            model,
+            [(1, 10), (1, 20)],
+            channels_last_conversion="off",
+            transpose_outputs=False,
+            default_precision='fixed<32,16>',
         )
         output_dir = str(test_root_path / f'hls4mlprj_pytorch_api_rnn_{backend}_{io_type}')
 
         hls_model = convert_from_pytorch_model(
-            model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
+            model,
+            hls_config=config,
+            output_dir=output_dir,
+            backend=backend,
+            io_type=io_type,
+            default_precision='fixed<32,16>',
         )
 
         hls_model.compile()


### PR DESCRIPTION
# Description

The `test_recurrent_pytorch.py` pytest seemed to randomly fail with different seeds. (Quartus and oneAPI seemed to be the most sensitive.) This widens the default precision and also rounds all the input values so that they match between pytorch and hls4ml, which should make the tests less likely to fail due to quantization.

## Type of change

- [x] Other (Specify) - update pytest

## Tests

Should make `test_recurrent_pytorch.py` less likely to fail randomly

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
