### PR TITLE
test cvmfs availability in pytests

### DIFF
--- a/test/pytest/generate_ci_yaml.py
+++ b/test/pytest/generate_ci_yaml.py
@@ -1,84 +1,20 @@
-import itertools
-import os
-from pathlib import Path
-
 import yaml
 
-'''
-Create a Gitlab CI yml file with a separate entry for each test_* file
-in the pytests directory to parallelise the CI jobs.
-'''
-
-
 template = """
-pytest.{}:
+pytest.test_cvmfs_mount:
   extends: .pytest
   variables:
-    PYTESTFILE: {}
-    EXAMPLEMODEL: {}
+    PYTESTFILE: 'test_cvmfs_mount.py'
+    EXAMPLEMODEL: 0
 """
 
 
-n_test_files_per_yml = int(os.environ.get('N_TESTS_PER_YAML', 4))
-
-# Blacklisted tests will be skipped
-BLACKLIST = {'test_reduction'}
-
-# Long-running tests will not be bundled with other tests
-LONGLIST = {'test_hgq_layers', 'test_hgq_players', 'test_qkeras', 'test_pytorch_api'}
-
-
-def path_to_name(test_path):
-    path = Path(test_path)
-    name = path.stem.replace('test_', '')
-    return name
-
-
-def batched(iterable, chunk_size):
-    iterator = iter(iterable)
-    while chunk := tuple(itertools.islice(iterator, chunk_size)):
-        yield chunk
-
-
-def uses_example_model(test_filename):
-    with open(test_filename) as f:
-        content = f.read()
-        return 'example-models' in content
-
-
-def generate_test_yaml(test_root='.'):
-    test_root = Path(test_root)
-    test_paths = [path for path in test_root.glob('**/test_*.py') if path.stem not in (BLACKLIST | LONGLIST)]
-    need_example_models = [uses_example_model(path) for path in test_paths]
-
-    idxs = list(range(len(need_example_models)))
-    idxs = sorted(idxs, key=lambda i: f'{need_example_models[i]}_{path_to_name(test_paths[i])}')
-
-    yml = None
-    for batch_idxs in batched(idxs, n_test_files_per_yml):
-        batch_paths: list[Path] = [test_paths[i] for i in batch_idxs]
-        names = [path_to_name(path) for path in batch_paths]
-        name = '+'.join(names)
-        test_files = ' '.join([str(path.relative_to(test_root)) for path in batch_paths])
-        batch_need_example_model = int(any([need_example_models[i] for i in batch_idxs]))
-        diff_yml = yaml.safe_load(template.format(name, test_files, batch_need_example_model))
-        if yml is None:
-            yml = diff_yml
-        else:
-            yml.update(diff_yml)
-
-    test_paths = [path for path in test_root.glob('**/test_*.py') if path.stem in LONGLIST]
-    for path in test_paths:
-        name = path.stem.replace('test_', '')
-        test_file = str(path.relative_to(test_root))
-        needs_examples = uses_example_model(path)
-        diff_yml = yaml.safe_load(template.format(name, test_file, int(needs_examples)))
-        yml.update(diff_yml)
-
+def generate_fixed_test_yaml():
+    yml = yaml.safe_load(template)
     return yml
 
 
 if __name__ == '__main__':
-    yml = generate_test_yaml(Path(__file__).parent)
+    yml = generate_fixed_test_yaml()
     with open('pytests.yml', 'w') as yamlfile:
-        yaml.safe_dump(yml, yamlfile)
+        yaml.safe_dump(yml, yamlfile, default_flow_style=False)

--- a/test/pytest/generate_ci_yaml.py
+++ b/test/pytest/generate_ci_yaml.py
@@ -4,7 +4,7 @@ template = """
 pytest.test_cvmfs_mount:
   extends: .pytest
   variables:
-    PYTESTFILE: 'test_cvmfs_mount.py'
+    PYTESTFILE: test_cvmfs_mount.py
     EXAMPLEMODEL: 0
 """
 

--- a/test/pytest/test_cvmfs_mount.py
+++ b/test/pytest/test_cvmfs_mount.py
@@ -1,0 +1,9 @@
+import os
+
+
+def test_vivado_hls_availability():
+
+    vivado_dir = '/cvmfs/projects.cern.ch/hls4ml/vivado/2020.1_v1/vivado-2020.1_v1'
+
+    contents = os.listdir(vivado_dir)
+    print("Contents of Vivado HLS bin directory:", contents)


### PR DESCRIPTION
# Description

This draft PR is intended to trigger the GitLab CI pipeline and verify that CVMFS is mounted in the GitLab jobs where tests are run.

This code is not meant to be merged into the main branch but is instead used to check the availability of CVMFS and Vivado in the containers where the CI test jobs are executed.

To determine whether CVMFS and Vivado are accessible in PyTests, the `generate_ci_yaml.py` file has been modified to run only one job with the necessary test cases, thus avoiding the execution of other time and resource-consuming tests.

`test/pytest/test_cvmfs_mount.py` has been added to specifically test CVMFS configuration and availability. This is the only file from which tests should run for this draft PR.

## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

- [x] Other (Specify) - Testing infrastructure

## Tests

Check the output of the test cases on GitLab piepline to see if CVMFS and Vivado are available.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
