### PR TITLE
Unify handling of remove-node when ouput is in outputs

### DIFF
--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -542,14 +542,14 @@ class ModelGraph:
         if len(inputs) > 1 or len(outputs) > 1:
             raise Exception('Cannot delete a node with multiple inputs/outputs')
 
-        if len(inputs) == 1:
+        if len(outputs) == 1 and len(inputs) == 1:
+
             # Connect inputs -> $outputs
-            if node.name in self.outputs:
+            if node.outputs[0] in self.outputs:
                 msg = f'Remove leaf node {node.name} will connect its input node {inputs[0]} to output, but it already is.'
                 assert inputs[0] not in self.outputs, msg
-                self.outputs = [inputs[0] if name == node.name else name for name in self.outputs]
+                self.outputs = [inputs[0] if name == node.outputs[0] else name for name in self.outputs]
 
-        if len(outputs) == 1 and len(inputs) == 1:
             inp_var = node.get_input_variable()
             out_var = node.get_output_variable()
 
@@ -565,9 +565,6 @@ class ModelGraph:
                     if outputs[0] == nxt_inp:
                         next_node.inputs[i] = inputs[0]
 
-        if node.outputs[0] in self.outputs:
-            prev_node = node.get_input_node(node.inputs[0])
-            self.outputs[self.outputs.index(node.outputs[0])] = prev_node.outputs[0]
         del self.output_vars[node.outputs[0]]
         del self.graph[node.name]
 


### PR DESCRIPTION
# Description

PR #1205 fixed an issue where we removed the node whose output was in the network outputs. However, there was logic before it that was supposed to handle this particular case but failed. This PR unifies the two fixes so that we do not have multiple attempts to fix the same problem.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Other (Specify)  clean up code

## Tests

The standard pytests should not break, nor should new brevitas tests.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
