### PR TITLE
Remove calls to remove_node(..., rewire) as the parameter was deprecated

### DIFF
--- a/hls4ml/backends/catapult/passes/bn_quant.py
+++ b/hls4ml/backends/catapult/passes/bn_quant.py
@@ -96,7 +96,7 @@ class MergeBatchNormAndQuantizedTanh(OptimizerPass):
             bn_layer.get_weights('scale').data, bn_layer.get_weights('bias').data, node.get_attr('threshold', 0.5)
         )
         # Remove the BatchNormalization layer
-        model.remove_node(bn_layer, rewire=True)
+        model.remove_node(bn_layer)
         # Replace the old Activation layer with this one
         model.replace_node(node, bnbt_layer)
 

--- a/hls4ml/backends/fpga/passes/final_reshape.py
+++ b/hls4ml/backends/fpga/passes/final_reshape.py
@@ -12,8 +12,7 @@ class RemoveFinalReshape(OptimizerPass):
     def transform(self, model, node):
         if model.config.get_config_value('IOType') == 'io_parallel':
             print('WARNING: Final layer is a Reshape, which does not affect the output for io_parallel; removing it')
-            # remove, but don't rewire because it's the output layer
-            model.remove_node(node, rewire=False)
+            model.remove_node(node)
             return True
         elif model.config.get_config_value('IOType') == 'io_stream':
             print(

--- a/hls4ml/backends/fpga/passes/hgq_proxy_model.py
+++ b/hls4ml/backends/fpga/passes/hgq_proxy_model.py
@@ -53,7 +53,7 @@ class ProcessFixedPointQuantizerLayer(OptimizerPass):
 
     def transform(self, model, node: FixedPointQuantizer):
         if node.fusible:
-            model.remove_node(node, rewire=True)
+            model.remove_node(node)
             return True
 
         if model.config.config['IOType'] != 'io_parallel':

--- a/hls4ml/backends/fpga/passes/remove_softmax.py
+++ b/hls4ml/backends/fpga/passes/remove_softmax.py
@@ -9,5 +9,5 @@ class SkipSoftmax(OptimizerPass):
         return is_softmax and remove_softmax
 
     def transform(self, model, node):
-        model.remove_node(node, rewire=True)
+        model.remove_node(node)
         return True

--- a/hls4ml/backends/oneapi/passes/bn_quant.py
+++ b/hls4ml/backends/oneapi/passes/bn_quant.py
@@ -149,7 +149,7 @@ class MergeBatchNormAndQuantizedTanh(OptimizerPass):
             bn_layer.get_weights('scale').data, bn_layer.get_weights('bias').data, node.get_attr('threshold', 0.5)
         )
         # Remove the BatchNormalization layer
-        model.remove_node(bn_layer, rewire=True)
+        model.remove_node(bn_layer)
         # Replace the old Activation layer with this one
         model.replace_node(node, bnbt_layer)
 

--- a/hls4ml/backends/quartus/passes/bn_quant.py
+++ b/hls4ml/backends/quartus/passes/bn_quant.py
@@ -96,7 +96,7 @@ class MergeBatchNormAndQuantizedTanh(OptimizerPass):
             bn_layer.get_weights('scale').data, bn_layer.get_weights('bias').data, node.get_attr('threshold', 0.5)
         )
         # Remove the BatchNormalization layer
-        model.remove_node(bn_layer, rewire=True)
+        model.remove_node(bn_layer)
         # Replace the old Activation layer with this one
         model.replace_node(node, bnbt_layer)
 

--- a/hls4ml/backends/vivado/passes/bn_quant.py
+++ b/hls4ml/backends/vivado/passes/bn_quant.py
@@ -96,7 +96,7 @@ class MergeBatchNormAndQuantizedTanh(OptimizerPass):
             bn_layer.get_weights('scale').data, bn_layer.get_weights('bias').data, node.get_attr('threshold', 0.5)
         )
         # Remove the BatchNormalization layer
-        model.remove_node(bn_layer, rewire=True)
+        model.remove_node(bn_layer)
         # Replace the old Activation layer with this one
         model.replace_node(node, bnbt_layer)
 

--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -517,7 +517,7 @@ class ModelGraph:
 
         self.graph = new_graph
 
-    def remove_node(self, node, rewire=True):
+    def remove_node(self, node):
         """Removes a node from the graph.
 
         By default, this function connects the outputs of the previous
@@ -526,14 +526,10 @@ class ModelGraph:
 
         Args:
             node (Layer): The node to remove.
-            rewire (bool, optional): Deprecated, has no effect.
 
         Raises:
-            Exception: If an attempt is made to rewire a node with
+            Exception: If an attempt is made to remove a node with
             multiple inputs/outputs.
-
-        Note:
-            The `rewire` parameter is deprecated and has no effect.
         """
 
         inputs = [inp for inp in node.inputs if inp]

--- a/hls4ml/model/optimizer/passes/batchnorm_opt.py
+++ b/hls4ml/model/optimizer/passes/batchnorm_opt.py
@@ -38,7 +38,7 @@ class BatchNormOnnxConstantParameters(OptimizerPass):
         attributes['gamma_quantizer'] = gamma_node.get_attr('quantizer')
 
         node.inputs[1] = ''
-        model.remove_node(gamma_node, rewire=False)
+        model.remove_node(gamma_node)
 
         beta_node = node.get_input_node(node.inputs[2])
         if not isinstance(beta_node, Constant):
@@ -47,7 +47,7 @@ class BatchNormOnnxConstantParameters(OptimizerPass):
         attributes['beta_data'] = beta
         attributes['beta_quantizer'] = beta_node.get_attr('quantizer')
         node.inputs[2] = ''
-        model.remove_node(beta_node, rewire=False)
+        model.remove_node(beta_node)
 
         moving_mean_node = node.get_input_node(node.inputs[3])
         if not isinstance(moving_mean_node, Constant):
@@ -56,7 +56,7 @@ class BatchNormOnnxConstantParameters(OptimizerPass):
         attributes['mean_data'] = moving_mean
         attributes['mean_quantizer'] = moving_mean_node.get_attr('quantizer')
         node.inputs[3] = ''
-        model.remove_node(moving_mean_node, rewire=False)
+        model.remove_node(moving_mean_node)
 
         moving_variance_node = node.get_input_node(node.inputs[4])
         if not isinstance(moving_variance_node, Constant):
@@ -65,7 +65,7 @@ class BatchNormOnnxConstantParameters(OptimizerPass):
         attributes['variance_data'] = moving_variance
         attributes['variance_quantizer'] = moving_variance_node.get_attr('quantizer')
         node.inputs[4] = ''
-        model.remove_node(moving_variance_node, rewire=False)
+        model.remove_node(moving_variance_node)
 
         node.inputs = [inp for inp in node.inputs if inp]
         if len(node.inputs) != 1:
@@ -148,7 +148,7 @@ class ConstantBatchNormFusion(OptimizerPass):
             const_node.get_output_variable().type.precision = node.get_output_variable().type.precision
 
         # remove the batch norm node
-        model.remove_node(node, rewire=True)
+        model.remove_node(node)
 
         return True
 
@@ -250,7 +250,7 @@ class FuseConsecutiveBatchNormalization(OptimizerPass):
         node.add_weights_variable(name='scale', var_name='s{index}', data=scale_new, quantizer=s_quantizer, precision=s_prec)
         node.add_weights_variable(name='bias', var_name='b{index}', data=bias_new, quantizer=b_quantizer, precision=b_prec)
 
-        model.remove_node(prev_node, rewire=True)
+        model.remove_node(prev_node)
         return True
 
 
@@ -270,5 +270,5 @@ class RemoveNopBatchNormalization(OptimizerPass):
             return False
 
     def transform(self, model, node):
-        model.remove_node(node, rewire=True)
+        model.remove_node(node)
         return True

--- a/hls4ml/model/optimizer/passes/bn_fuse.py
+++ b/hls4ml/model/optimizer/passes/bn_fuse.py
@@ -89,6 +89,6 @@ class FuseBatchNormalization(OptimizerPass):
         parent_node.add_weights_variable(name='weight', var_name='w{index}', data=fused_weight, quantizer=w_quantizer)
         parent_node.add_weights_variable(name='bias', var_name='b{index}', data=fused_bias, quantizer=b_quantizer)
 
-        model.remove_node(node, rewire=True)
+        model.remove_node(node)
 
         return True

--- a/hls4ml/model/optimizer/passes/conv_to_convxd.py
+++ b/hls4ml/model/optimizer/passes/conv_to_convxd.py
@@ -84,9 +84,9 @@ class ConvToConvXD(OptimizerPass):
 
         # removing and replacing old nodes
         if bias_node:
-            model.remove_node(bias_node, rewire=False)
+            model.remove_node(bias_node)
             del node.inputs[2]
-        model.remove_node(weight_node, rewire=False)
+        model.remove_node(weight_node)
         del node.inputs[1]
         model.replace_node(node, new_node)
 

--- a/hls4ml/model/optimizer/passes/conv_to_depthwiseconvxd.py
+++ b/hls4ml/model/optimizer/passes/conv_to_depthwiseconvxd.py
@@ -85,9 +85,9 @@ class ConvToDepthwiseConvXD(OptimizerPass):
 
         # removing and replacing old nodes
         if bias_node:
-            model.remove_node(bias_node, rewire=False)
+            model.remove_node(bias_node)
             del node.inputs[2]
-        model.remove_node(weight_node, rewire=False)
+        model.remove_node(weight_node)
         del node.inputs[1]
         model.replace_node(node, new_node)
 

--- a/hls4ml/model/optimizer/passes/expand_layer_group.py
+++ b/hls4ml/model/optimizer/passes/expand_layer_group.py
@@ -36,11 +36,9 @@ class ExpandLayerGroup(OptimizerPass):
             if isinstance(new_node, Input):
                 inserted_input_nodes.append(new_node)
 
-        rewire = not node.outputs[0] in model.outputs
-
-        model.remove_node(node, rewire)
+        model.remove_node(node)
 
         for input_node in inserted_input_nodes:
-            model.remove_node(input_node, rewire=True)
+            model.remove_node(input_node)
 
         return True

--- a/hls4ml/model/optimizer/passes/fuse_biasadd.py
+++ b/hls4ml/model/optimizer/passes/fuse_biasadd.py
@@ -13,6 +13,6 @@ class FuseBiasAdd(OptimizerPass):
         dense_layer = node.get_input_node()
         dense_layer.get_weights('bias').data = node.get_weights('bias').data
 
-        model.remove_node(node, rewire=True)
+        model.remove_node(node)
 
         return True

--- a/hls4ml/model/optimizer/passes/matmul_const_to_dense.py
+++ b/hls4ml/model/optimizer/passes/matmul_const_to_dense.py
@@ -51,7 +51,7 @@ class MatmulConstToDense(OptimizerPass):
         new_dense = model.make_node(Dense, new_name, attributes, [node.inputs[0]], [x for x in node.outputs])
 
         # removing and replacing old nodes
-        model.remove_node(const_node, rewire=False)
+        model.remove_node(const_node)
         del node.inputs[1]
         model.replace_node(node, new_dense)
 

--- a/hls4ml/model/optimizer/passes/merge_const.py
+++ b/hls4ml/model/optimizer/passes/merge_const.py
@@ -57,10 +57,10 @@ class MergeTwoConstants(OptimizerPass):
             const_node0.get_output_variable().type.precision = quantizer.hls_type
         const_node0.set_attr('value', new_val)
 
-        model.remove_node(const_node1, rewire=False)
+        model.remove_node(const_node1)
 
         # remove the batch norm node
-        model.remove_node(node, rewire=True)
+        model.remove_node(node)
 
         return True
 
@@ -168,7 +168,7 @@ class MergeToApplyAlpha(OptimizerPass):
             ApplyAlpha, new_name, attributes, [node.inputs[input_node_idx]], [x for x in node.outputs]
         )
 
-        model.remove_node(const_node, rewire=False)
+        model.remove_node(const_node)
         del node.inputs[const_node_idx]
         model.replace_node(node, aa_layer)
 
@@ -238,7 +238,7 @@ class MergeToApplyAlphaDiv(OptimizerPass):
 
         bn_layer = model.make_node(ApplyAlpha, new_name, attributes, [node.inputs[0]], [x for x in node.outputs])
 
-        model.remove_node(const_node, rewire=False)
+        model.remove_node(const_node)
         del node.inputs[1]
         model.replace_node(node, bn_layer)
 

--- a/hls4ml/model/optimizer/passes/quant_opt.py
+++ b/hls4ml/model/optimizer/passes/quant_opt.py
@@ -52,14 +52,14 @@ class QuantConstantParameters(OptimizerPass):
             if isinstance(scale_node, Constant):
                 node.set_attr('scale', scale_node.get_attr('value'))
                 node.inputs[1] = ''
-                model.remove_node(scale_node, rewire=False)
+                model.remove_node(scale_node)
 
         if node.get_input_node(node.inputs[2]):
             zeropt_node = node.get_input_node(node.inputs[2])
             if isinstance(zeropt_node, Constant):
                 node.set_attr('zeropt', zeropt_node.get_attr('value'))
                 node.inputs[2] = ''
-                model.remove_node(zeropt_node, rewire=False)
+                model.remove_node(zeropt_node)
 
         if node.get_input_node(node.inputs[3]):
             bitwidth_node = node.get_input_node(node.inputs[3])
@@ -69,7 +69,7 @@ class QuantConstantParameters(OptimizerPass):
                     raise RuntimeError('Only scalar bitwidth values are supporeted by the Quant node')
                 node.set_attr('bitwidth', bitwidth[0])
                 node.inputs[3] = ''
-                model.remove_node(bitwidth_node, rewire=False)
+                model.remove_node(bitwidth_node)
 
         node.inputs = [inp for inp in node.inputs if inp]
         if len(node.inputs) != 1:
@@ -199,7 +199,7 @@ class FuseQuantWithConstant(OptimizerPass):
         # Should we update the configuration to reflect the new precision? I don't think it's necessary
 
         # remove the Quant node
-        model.remove_node(node, rewire=True)
+        model.remove_node(node)
 
         return True
 

--- a/hls4ml/model/optimizer/passes/reshape_const.py
+++ b/hls4ml/model/optimizer/passes/reshape_const.py
@@ -21,7 +21,7 @@ class ReshapeConstant(OptimizerPass):
         shape_node = node.get_input_node(node.inputs[1])
         node.inputs[1] = ''
         if not isinstance(shape_node, Constant):
-            raise RuntimeError("Nonconstant shape inputs are not currently supported")
-        model.remove_node(shape_node, rewire=False)
+            raise RuntimeError('Nonconstant shape inputs are not currently supported')
+        model.remove_node(shape_node)
 
         return True

--- a/hls4ml/model/optimizer/passes/resize_remove_constants.py
+++ b/hls4ml/model/optimizer/passes/resize_remove_constants.py
@@ -23,16 +23,16 @@ class ResizeRemoveConstants(OptimizerPass):
         scales_node = node.get_input_node(node.inputs[scales_idx])
         node.inputs[scales_idx] = ''
         if not isinstance(scales_node, Constant):
-            raise RuntimeError("Non-constant shape inputs are not supported")
-        model.remove_node(scales_node, rewire=False)
+            raise RuntimeError('Non-constant shape inputs are not supported')
+        model.remove_node(scales_node)
         # RoI position is always 1 when present
         roi_node = node.get_input_node(node.inputs[roi_index])
         if roi_node.get_attr('value'):
             warn('RoI value vector is not empty. Consider that RoI is not supported in hls4ml', stacklevel=2)
         node.inputs[roi_index] = ''
         if not isinstance(roi_node, Constant):
-            raise RuntimeError("Non-constant RoI inputs are not supported")
-        model.remove_node(roi_node, rewire=False)
+            raise RuntimeError('Non-constant RoI inputs are not supported')
+        model.remove_node(roi_node)
         # Clean all the '' inputs
         node.inputs = list(filter(None, node.inputs))
         return True

--- a/hls4ml/model/optimizer/passes/transpose_opt.py
+++ b/hls4ml/model/optimizer/passes/transpose_opt.py
@@ -13,11 +13,7 @@ class RemoveNopTranspose(OptimizerPass):
 
     def transform(self, model, node):
         print(f'Unnecessary transpose node ({node.name}) detected, optimizing ...')
-        if not node.get_output_nodes():
-            print(f'WARNING: {node.name} is the output layer! No rewiring performed.')
-            model.remove_node(node, rewire=False)  # Don't rewire if there is no output layer
-        else:
-            model.remove_node(node, rewire=True)
+        model.remove_node(node)
 
         return True
 

--- a/test/pytest/test_extensions.py
+++ b/test/pytest/test_extensions.py
@@ -46,8 +46,8 @@ class RemoveDuplicateReverse(hls4ml.model.optimizer.OptimizerPass):
         first = node.get_input_node()
         second = node
 
-        model.remove_node(first, rewire=True)
-        model.remove_node(second, rewire=True)
+        model.remove_node(first)
+        model.remove_node(second)
         return True
 
 


### PR DESCRIPTION
# Description

A while ago `ModelGraph.remove_node()`  deprecated its `rewire` parameter. The rest of the codebase still used it. This PR cleans it up.

## Type of change

- [x] Other (Specify) - Cleanup

## Tests

Existing tests are sufficient.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
