### PR TITLE
Fix logic in oneAPI transorm types to not convert a variable twice

### DIFF
--- a/hls4ml/backends/oneapi/passes/transform_types.py
+++ b/hls4ml/backends/oneapi/passes/transform_types.py
@@ -33,7 +33,7 @@ class TransformTypes(GlobalOptimizerPass):
                     new_var = self.interface_var_converter.convert(var, pragma='stream')
                 elif out_name in node.model.outputs:
                     new_var = self.interface_var_converter.convert(var, pragma='stream')
-                if isinstance(var, InplaceTensorVariable):
+                elif isinstance(var, InplaceTensorVariable):
                     new_var = self.inplace_stream_var_converter.convert(var, pragma='stream')
                 else:
                     new_var = self.stream_var_converter.convert(var, pragma='stream')


### PR DESCRIPTION
# Description

The code currently transforms input and output variables twice in io_stream when using oneAPI. It doesn't seem to break anything since in io_stream the input and output variables aren't very different from the standard variables.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Should not break any pytests

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
