### PR TITLE
Updating get_global_input_shape

### DIFF
--- a/hls4ml/converters/onnx_to_hls.py
+++ b/hls4ml/converters/onnx_to_hls.py
@@ -44,7 +44,7 @@ def get_global_input_shape(graph, inp):
     Raises:
         StopIteration:  If the global input name is not found
     """
-    try: 
+    try:
         inp_shape = next(x.type.tensor_type.shape.dim for x in graph.input if x.name == inp)
     except StopIteration:
         # The input is not in the graph input, likely it's the output

--- a/hls4ml/converters/onnx_to_hls.py
+++ b/hls4ml/converters/onnx_to_hls.py
@@ -44,7 +44,11 @@ def get_global_input_shape(graph, inp):
     Raises:
         StopIteration:  If the global input name is not found
     """
-    inp_shape = next(x.type.tensor_type.shape.dim for x in graph.input if x.name == inp)
+    try: 
+        inp_shape = next(x.type.tensor_type.shape.dim for x in graph.input if x.name == inp)
+    except StopIteration:
+        # The input is not in the graph input, likely it's the output
+        inp_shape = next(x.type.tensor_type.shape.dim for x in graph.output if x.name == inp)
     return list(x.dim_value for x in inp_shape)
 
 


### PR DESCRIPTION
# Description
This PR is prepared for issue #1261

## Type of change

In the case of multiple outputs, the ONNX parser does not look in model output to find the input shape. This PR fixes that. 

In addition, the PR updates the clone pass names. 

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>
> * Provide instructions so we can reproduce.
> * Please also list any relevant details for your test configuration.

**Test Configuration**:

## Checklist

- [ ] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
