### PR TITLE
Add a vertical line for x = 1 = 2^0 in the box plots

### DIFF
--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -84,6 +84,8 @@ def boxplot(data, fmt='longform'):
         if hue is not None:
             vp.get_legend().remove()
         vp.set_xscale('log', base=2)
+        plt.gca().axvline(x=1, color='gray', linestyle='--', linewidth=1, zorder=0, label='x = 1')  # Add vertical line for 1 (2^0) behind the boxes
+        plt.legend()
         return f
     elif fmt == 'summary':
         from matplotlib.patches import Rectangle
@@ -92,6 +94,7 @@ def boxplot(data, fmt='longform'):
         f, ax = plt.subplots(1, 1)
         data.reverse()
         colors = sb.color_palette("Blues", len(data))
+        ax.axvline(x=1, color='gray', linestyle='--', linewidth=1, zorder=0, label='x = 1')  # Add vertical line for 1 (2^0) behind the boxes
         bp = ax.bxp(data, showfliers=False, vert=False, medianprops=medianprops)
         # add colored boxes
         for line, color in zip(bp['boxes'], colors):
@@ -104,6 +107,7 @@ def boxplot(data, fmt='longform'):
         ax.set_yticklabels([d['weight'] for d in data])
         ax.set_xscale('log', base=2)
         plt.xlabel('x')
+        plt.legend()
         return f
     else:
         return None
@@ -467,6 +471,7 @@ def numerical(model=None, hls_model=None, X=None, plot='boxplot'):
 
     if hls_model_present:
         data = weights_hlsmodel(hls_model_unoptimized, fmt='summary', plot=plot)
+        print(data)
     elif model_present:
         if __keras_profiling_enabled__ and isinstance(model, keras.Model):
             data = weights_keras(model, fmt='summary', plot=plot)

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -84,7 +84,9 @@ def boxplot(data, fmt='longform'):
         if hue is not None:
             vp.get_legend().remove()
         vp.set_xscale('log', base=2)
-        plt.gca().axvline(x=1, color='gray', linestyle='--', linewidth=1, zorder=0, label='x = 1')  # Add vertical line for 1 (2^0) behind the boxes
+        plt.gca().axvline(
+            x=1, color='gray', linestyle='--', linewidth=1, zorder=0, label='x = 1'
+        )  # Add vertical line for 1 (2^0) behind the boxes
         plt.legend()
         return f
     elif fmt == 'summary':
@@ -94,7 +96,9 @@ def boxplot(data, fmt='longform'):
         f, ax = plt.subplots(1, 1)
         data.reverse()
         colors = sb.color_palette("Blues", len(data))
-        ax.axvline(x=1, color='gray', linestyle='--', linewidth=1, zorder=0, label='x = 1')  # Add vertical line for 1 (2^0) behind the boxes
+        ax.axvline(
+            x=1, color='gray', linestyle='--', linewidth=1, zorder=0, label='x = 1'
+        )  # Add vertical line for 1 (2^0) behind the boxes
         bp = ax.bxp(data, showfliers=False, vert=False, medianprops=medianprops)
         # add colored boxes
         for line, color in zip(bp['boxes'], colors):

--- a/test/pytest/test_boxplot.py
+++ b/test/pytest/test_boxplot.py
@@ -1,0 +1,58 @@
+import pytest
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import logging
+from hls4ml.model.profiling import boxplot
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+@pytest.fixture
+def mock_data():
+    """Fixture to create mock data for testing."""
+    return pd.DataFrame({
+        'x': np.random.lognormal(mean=0, sigma=1, size=100),
+        'weight': ['layer1'] * 100
+    })
+
+def generate_random_summary_data(num_layers=3, num_weights_per_layer=2):
+    data = []
+    for layer_idx in range(1, num_layers + 1):
+        layer_name = f"dense_{layer_idx}"
+        for weight_idx in range(num_weights_per_layer):
+            weight_type = f"w" if weight_idx == 0 else f"b"
+            weight_label = f"{layer_name}/{weight_type}"
+            med = np.random.uniform(0.1, 1.0)
+            q1 = med - np.random.uniform(0.05, 0.2)
+            q3 = med + np.random.uniform(0.05, 0.2)
+            whislo = max(0.0, q1 - np.random.uniform(0.05, 0.1))
+            whishi = q3 + np.random.uniform(0.05, 0.1)
+            data.append({'med': med, 'q1': q1, 'q3': q3, 'whislo': whislo, 'whishi': whishi, 'layer': layer_name, 'weight': weight_label})
+    return data
+
+@pytest.mark.parametrize("fmt", ["longform", "summary"])
+def test_boxplot_vertical_line(mock_data, fmt):
+    # Test if the vertical line at x=1 exists in the boxplot.
+    if fmt == "summary":
+        mock_data = generate_random_summary_data()
+    fig = boxplot(mock_data, fmt=fmt)
+    output_path = f"boxplot_vertical_line_{fmt}.png"
+    fig.savefig(output_path)
+    logger.info(f"Boxplot with vertical line ({fmt}) saved to: {output_path}")
+    ax = plt.gca()
+    found_vertical_line = any(len(line.get_xdata()) == 2 and line.get_xdata()[0] == line.get_xdata()[1] == 1 for line in ax.get_lines())
+    assert found_vertical_line, f"Vertical line at x=1 (2^0) is missing in the boxplot ({fmt})."
+    plt.close(fig)
+
+@pytest.mark.parametrize("fmt", ["longform", "summary"])
+def test_boxplot_output(mock_data, fmt):
+    # Test if the boxplot function produces a valid matplotlib figure.
+    if fmt == "summary":
+        mock_data = generate_random_summary_data()
+    fig = boxplot(mock_data, fmt=fmt)
+    output_path = f"boxplot_output_{fmt}.png"
+    fig.savefig(output_path)
+    logger.info(f"Boxplot output ({fmt}) saved to: {output_path}")
+    assert isinstance(fig, plt.Figure), f"The boxplot function did not return a matplotlib Figure ({fmt})."
+    plt.close(fig)

--- a/test/pytest/test_boxplot.py
+++ b/test/pytest/test_boxplot.py
@@ -1,35 +1,47 @@
-import pytest
-import matplotlib.pyplot as plt
-import pandas as pd
-import numpy as np
 import logging
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
 from hls4ml.model.profiling import boxplot
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 @pytest.fixture
 def mock_data():
     """Fixture to create mock data for testing."""
-    return pd.DataFrame({
-        'x': np.random.lognormal(mean=0, sigma=1, size=100),
-        'weight': ['layer1'] * 100
-    })
+    return pd.DataFrame({'x': np.random.lognormal(mean=0, sigma=1, size=100), 'weight': ['layer1'] * 100})
+
 
 def generate_random_summary_data(num_layers=3, num_weights_per_layer=2):
     data = []
     for layer_idx in range(1, num_layers + 1):
         layer_name = f"dense_{layer_idx}"
         for weight_idx in range(num_weights_per_layer):
-            weight_type = f"w" if weight_idx == 0 else f"b"
+            weight_type = "w" if weight_idx == 0 else "b"
             weight_label = f"{layer_name}/{weight_type}"
             med = np.random.uniform(0.1, 1.0)
             q1 = med - np.random.uniform(0.05, 0.2)
             q3 = med + np.random.uniform(0.05, 0.2)
             whislo = max(0.0, q1 - np.random.uniform(0.05, 0.1))
             whishi = q3 + np.random.uniform(0.05, 0.1)
-            data.append({'med': med, 'q1': q1, 'q3': q3, 'whislo': whislo, 'whishi': whishi, 'layer': layer_name, 'weight': weight_label})
+            data.append(
+                {
+                    'med': med,
+                    'q1': q1,
+                    'q3': q3,
+                    'whislo': whislo,
+                    'whishi': whishi,
+                    'layer': layer_name,
+                    'weight': weight_label,
+                }
+            )
     return data
+
 
 @pytest.mark.parametrize("fmt", ["longform", "summary"])
 def test_boxplot_vertical_line(mock_data, fmt):
@@ -41,9 +53,12 @@ def test_boxplot_vertical_line(mock_data, fmt):
     fig.savefig(output_path)
     logger.info(f"Boxplot with vertical line ({fmt}) saved to: {output_path}")
     ax = plt.gca()
-    found_vertical_line = any(len(line.get_xdata()) == 2 and line.get_xdata()[0] == line.get_xdata()[1] == 1 for line in ax.get_lines())
+    found_vertical_line = any(
+        len(line.get_xdata()) == 2 and line.get_xdata()[0] == line.get_xdata()[1] == 1 for line in ax.get_lines()
+    )
     assert found_vertical_line, f"Vertical line at x=1 (2^0) is missing in the boxplot ({fmt})."
     plt.close(fig)
+
 
 @pytest.mark.parametrize("fmt", ["longform", "summary"])
 def test_boxplot_output(mock_data, fmt):

--- a/test/pytest/test_boxplot.py
+++ b/test/pytest/test_boxplot.py
@@ -20,10 +20,10 @@ def mock_data():
 def generate_random_summary_data(num_layers=3, num_weights_per_layer=2):
     data = []
     for layer_idx in range(1, num_layers + 1):
-        layer_name = f"dense_{layer_idx}"
+        layer_name = f'dense_{layer_idx}'
         for weight_idx in range(num_weights_per_layer):
-            weight_type = "w" if weight_idx == 0 else "b"
-            weight_label = f"{layer_name}/{weight_type}"
+            weight_type = 'w' if weight_idx == 0 else 'b'
+            weight_label = f'{layer_name}/{weight_type}'
             med = np.random.uniform(0.1, 1.0)
             q1 = med - np.random.uniform(0.05, 0.2)
             q3 = med + np.random.uniform(0.05, 0.2)
@@ -43,31 +43,31 @@ def generate_random_summary_data(num_layers=3, num_weights_per_layer=2):
     return data
 
 
-@pytest.mark.parametrize("fmt", ["longform", "summary"])
+@pytest.mark.parametrize('fmt', ['longform', 'summary'])
 def test_boxplot_vertical_line(mock_data, fmt):
     # Test if the vertical line at x=1 exists in the boxplot.
-    if fmt == "summary":
+    if fmt == 'summary':
         mock_data = generate_random_summary_data()
     fig = boxplot(mock_data, fmt=fmt)
-    output_path = f"boxplot_vertical_line_{fmt}.png"
+    output_path = f'boxplot_vertical_line_{fmt}.png'
     fig.savefig(output_path)
-    logger.info(f"Boxplot with vertical line ({fmt}) saved to: {output_path}")
+    logger.info(f'Boxplot with vertical line ({fmt}) saved to: {output_path}')
     ax = plt.gca()
     found_vertical_line = any(
         len(line.get_xdata()) == 2 and line.get_xdata()[0] == line.get_xdata()[1] == 1 for line in ax.get_lines()
     )
-    assert found_vertical_line, f"Vertical line at x=1 (2^0) is missing in the boxplot ({fmt})."
+    assert found_vertical_line, f'Vertical line at x=1 (2^0) is missing in the boxplot ({fmt}).'
     plt.close(fig)
 
 
-@pytest.mark.parametrize("fmt", ["longform", "summary"])
+@pytest.mark.parametrize('fmt', ['longform', 'summary'])
 def test_boxplot_output(mock_data, fmt):
     # Test if the boxplot function produces a valid matplotlib figure.
-    if fmt == "summary":
+    if fmt == 'summary':
         mock_data = generate_random_summary_data()
     fig = boxplot(mock_data, fmt=fmt)
-    output_path = f"boxplot_output_{fmt}.png"
+    output_path = f'boxplot_output_{fmt}.png'
     fig.savefig(output_path)
-    logger.info(f"Boxplot output ({fmt}) saved to: {output_path}")
-    assert isinstance(fig, plt.Figure), f"The boxplot function did not return a matplotlib Figure ({fmt})."
+    logger.info(f'Boxplot output ({fmt}) saved to: {output_path}')
+    assert isinstance(fig, plt.Figure), f'The boxplot function did not return a matplotlib Figure ({fmt}).'
     plt.close(fig)


### PR DESCRIPTION
# Description

Add a vertical line for x = 1 = 2^0 in the box plots. This way, i find it easier to identify the integer and decimal part in the ranges.

## Type of change

This is a new (but very minimal) feature.

## Tests

I provided a test in `test/pytest/test_boxplot.py`.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
