### PR TITLE
Round inputs for dense unrolled RNN tests to make pytests more stable

### DIFF
--- a/hls4ml/converters/onnx_to_hls.py
+++ b/hls4ml/converters/onnx_to_hls.py
@@ -260,7 +260,7 @@ def parse_onnx_model(onnx_model):
         sanitize_layer_name(layer)
         print(f"Layer name: {layer['name']}, layer type: {layer['class_name']}, current shape: {input_shapes}")
         layer_list.append(layer)
-    print(output_layers)
+
     return layer_list, input_layers, output_layers
 
 

--- a/hls4ml/converters/onnx_to_hls.py
+++ b/hls4ml/converters/onnx_to_hls.py
@@ -260,7 +260,7 @@ def parse_onnx_model(onnx_model):
         sanitize_layer_name(layer)
         print(f"Layer name: {layer['name']}, layer type: {layer['class_name']}, current shape: {input_shapes}")
         layer_list.append(layer)
-
+    print(output_layers)
     return layer_list, input_layers, output_layers
 
 

--- a/test/pytest/test_dense_unrolled.py
+++ b/test/pytest/test_dense_unrolled.py
@@ -107,6 +107,7 @@ def test_resource_unrolled_rnn(rnn_layer, backend, io_type, static, reuse_factor
     # Subtract 0.5 to include negative values
     input_shape = (12, 8)
     X = np.random.rand(50, *input_shape) - 0.5
+    X = np.round(X * 2**16) * 2**-16  # make it exact ap_fixed<32,16>
 
     layer_name = rnn_layer.__name__.lower()
     keras_model = Sequential()


### PR DESCRIPTION
We are still having problems with numerical stability of RNNs in the pytests for dense unrolled. This PR aims to fix that by implementing the rounding @jmitrevs added in #1215 for these tests as well. As I haven't been able to reproduce the failure locally, I couldn't check if this actually fixes it

## Type of change



- [x] Bug fix (non-breaking change that fixes an issue)


## Tests


## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
