### PR TITLE
Fix concat3d when axis=3 /-1

### DIFF
--- a/hls4ml/templates/catapult/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/catapult/nnet_utils/nnet_merge.h
@@ -204,7 +204,7 @@ void concatenate3d_2(input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * 
                 int data_idx = ii * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + jj * CONFIG_T::n_elem1_2 + kk;
                 res[res_idx] = data1[data_idx];
             }
-            for (int kk = 0; kk < CONFIG_T::n_elem1_2; kk++) {
+            for (int kk = 0; kk < CONFIG_T::n_elem2_2; kk++) {
                 int res_idx = ii * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) +
                               jj * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) + kk + CONFIG_T::n_elem1_2;
                 int data_idx = ii * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2 + jj * CONFIG_T::n_elem2_2 + kk;

--- a/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_merge.h
@@ -207,7 +207,7 @@ void concatenate3d_2(const input1_T &data1, const input2_T &data2, res_T &res) {
             }
 
             #pragma unroll
-            for (int k = 0; k < CONFIG_T::n_elem1_2; k++) {
+            for (int k = 0; k < CONFIG_T::n_elem2_2; k++) {
                 int res_idx = i * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) +
                               j * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) + k + CONFIG_T::n_elem1_2;
                 int data_idx = i * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2 + j * CONFIG_T::n_elem2_2 + k;

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_merge.h
@@ -221,7 +221,7 @@ void concatenate3d_2(input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * 
             }
 
             #pragma unroll
-            for (int k = 0; k < CONFIG_T::n_elem1_2; k++) {
+            for (int k = 0; k < CONFIG_T::n_elem2_2; k++) {
                 int res_idx = i * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) +
                               j * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) + k + CONFIG_T::n_elem1_2;
                 int data_idx = i * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2 + j * CONFIG_T::n_elem2_2 + k;

--- a/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
@@ -226,7 +226,7 @@ void concatenate3d_2(input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * 
                 int data_idx = ii * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + jj * CONFIG_T::n_elem1_2 + kk;
                 res[res_idx] = data1[data_idx];
             }
-            for (int kk = 0; kk < CONFIG_T::n_elem1_2; kk++) {
+            for (int kk = 0; kk < CONFIG_T::n_elem2_2; kk++) {
                 int res_idx = ii * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) +
                               jj * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2) + kk + CONFIG_T::n_elem1_2;
                 int data_idx = ii * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2 + jj * CONFIG_T::n_elem2_2 + kk;

--- a/test/pytest/test_merge.py
+++ b/test/pytest/test_merge.py
@@ -79,10 +79,11 @@ def test_dot(axes, io_type, backend):
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
 @pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'oneAPI'])
 def test_concatenate1d(io_type, backend):
-    input_shape = (10,)
+    input_shape1 = (10,)
+    input_shape2 = (8,)
 
-    in1 = Input(shape=input_shape)
-    in2 = Input(shape=input_shape)
+    in1 = Input(shape=input_shape1)
+    in2 = Input(shape=input_shape2)
     out = Concatenate()([in1, in2])
 
     model = tf.keras.models.Model(inputs=[in1, in2], outputs=out)
@@ -95,8 +96,8 @@ def test_concatenate1d(io_type, backend):
     )
     hls_model.compile()
 
-    X_input1 = np.random.rand(100, *input_shape)
-    X_input2 = np.random.rand(100, *input_shape)
+    X_input1 = np.random.rand(100, *input_shape1)
+    X_input2 = np.random.rand(100, *input_shape2)
 
     keras_prediction = model.predict([X_input1, X_input2])
     hls_prediction = hls_model.predict([X_input1, X_input2]).reshape(keras_prediction.shape)
@@ -108,10 +109,14 @@ def test_concatenate1d(io_type, backend):
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
 @pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'oneAPI'])
 def test_concatenate2d(axis, io_type, backend):
-    input_shape = (10, 3)
+    input_shape1 = [10, 3]
+    input_shape2 = [10, 4]
 
-    in1 = Input(shape=input_shape)
-    in2 = Input(shape=input_shape)
+    input_shape1.insert(axis - 1, input_shape1.pop(1))
+    input_shape2.insert(axis - 1, input_shape2.pop(1))
+
+    in1 = Input(shape=input_shape1)
+    in2 = Input(shape=input_shape2)
     out = Concatenate(axis=axis)([in1, in2])
 
     model = tf.keras.models.Model(inputs=[in1, in2], outputs=out)
@@ -124,8 +129,8 @@ def test_concatenate2d(axis, io_type, backend):
     )
     hls_model.compile()
 
-    X_input1 = np.random.rand(100, *input_shape)
-    X_input2 = np.random.rand(100, *input_shape)
+    X_input1 = np.random.rand(100, *input_shape1)
+    X_input2 = np.random.rand(100, *input_shape2)
 
     keras_prediction = model.predict([X_input1, X_input2])
     hls_prediction = hls_model.predict([X_input1, X_input2]).reshape(keras_prediction.shape)
@@ -137,10 +142,14 @@ def test_concatenate2d(axis, io_type, backend):
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
 @pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'oneAPI'])
 def test_concatenate3d(axis, io_type, backend):
-    input_shape = (10, 10, 3)
+    input_shape1 = [10, 10, 3]
+    input_shape2 = [10, 10, 4]
 
-    in1 = Input(shape=input_shape)
-    in2 = Input(shape=input_shape)
+    input_shape1.insert(axis - 1, input_shape1.pop(2))
+    input_shape2.insert(axis - 1, input_shape2.pop(2))
+
+    in1 = Input(shape=input_shape1)
+    in2 = Input(shape=input_shape2)
     out = Concatenate(axis=axis)([in1, in2])
 
     model = tf.keras.models.Model(inputs=[in1, in2], outputs=out)
@@ -153,8 +162,8 @@ def test_concatenate3d(axis, io_type, backend):
     )
     hls_model.compile()
 
-    X_input1 = np.random.rand(100, *input_shape)
-    X_input2 = np.random.rand(100, *input_shape)
+    X_input1 = np.random.rand(100, *input_shape1)
+    X_input2 = np.random.rand(100, *input_shape2)
 
     keras_prediction = model.predict([X_input1, X_input2])
     hls_prediction = hls_model.predict([X_input1, X_input2]).reshape(keras_prediction.shape)


### PR DESCRIPTION
# Description

There is a bug in all backends that uses incorrect shape when concatenating on the last dimension of a 3d tensor. Our tests didn't catch this since the dimension is the same (was (10, 10, 3)).

This was discovered while debugging Inception model (from @thaarres group at ETH). It wasn't easy to catch since it would only occasionally cause stack smashing in the subsequent layer (in this case a relu), depending on the data types used.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

I extended `test_merge.py` to cover this case. I also ensured 1d and 2d are tested properly, but there were no problems there.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
