### PR TITLE
more general build_lib script

### DIFF
--- a/hls4ml/templates/catapult/build_lib.sh
+++ b/hls4ml/templates/catapult/build_lib.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 CC=g++
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11 -fno-gnu-unique"
-elif [[ "$OSTYPE" == "linux"* ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11 -fno-gnu-unique -Wno-pragmas"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11"
+CFLAGS="-O3 -fPIC -std=c++11"
+
+# Include -fno-gnu-unique if it is there
+if echo "" | ${CC} -Werror -fsyntax-only -fno-gnu-unique -xc++ - -o /dev/null &> /dev/null; then
+  CFLAGS+=" -fno-gnu-unique -Wno-pragmas"
 fi
+
 LDFLAGS=
 
 # Pick up AC libraries from Catapult install first

--- a/hls4ml/templates/quartus/build_lib.sh
+++ b/hls4ml/templates/quartus/build_lib.sh
@@ -2,11 +2,13 @@
 set -e
 
 CC=g++
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11 -fno-gnu-unique"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11"
+CFLAGS="-O3 -fPIC -std=c++11"
+
+# Include -fno-gnu-unique if it is there
+if echo "" | ${CC} -Werror -fsyntax-only -fno-gnu-unique -xc++ - -o /dev/null &> /dev/null; then
+  CFLAGS+=" -fno-gnu-unique"
 fi
+
 LDFLAGS=
 INCFLAGS="-Ifirmware/ac_types/ -Ifirmware/ap_types/"
 PROJECT=myproject

--- a/hls4ml/templates/symbolic/build_lib.sh
+++ b/hls4ml/templates/symbolic/build_lib.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 CC=g++
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11 -fno-gnu-unique"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11"
+CFLAGS="-O3 -fPIC -std=c++11"
+
+# Include -fno-gnu-unique if it is there
+if echo "" | ${CC} -Werror -fsyntax-only -fno-gnu-unique -xc++ - -o /dev/null &> /dev/null; then
+  CFLAGS+=" -fno-gnu-unique"
 fi
+
 HLS_LIBS_PATH=mylibspath
 LDFLAGS="-Wl,--no-undefined -Wl,--no-allow-shlib-undefined -Wl,--no-as-needed -Wl,-rpath,${HLS_LIBS_PATH}/lib/csim -L ${HLS_LIBS_PATH}/lib/csim -lhlsmc++-GCC46 -lhlsm-GCC46 -fno-builtin -fno-inline -Wl,-rpath,${HLS_LIBS_PATH}/tools/fpo_v7_0 -L ${HLS_LIBS_PATH}/tools/fpo_v7_0 -lgmp -lmpfr -lIp_floating_point_v7_0_bitacc_cmodel"
 INCFLAGS="-Ifirmware/ap_types/"

--- a/hls4ml/templates/vivado/build_lib.sh
+++ b/hls4ml/templates/vivado/build_lib.sh
@@ -2,11 +2,13 @@
 set -e
 
 CC=g++
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11 -fno-gnu-unique"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11"
+CFLAGS="-O3 -fPIC -std=c++11"
+
+# Include -fno-gnu-unique if it is there
+if echo "" | ${CC} -Werror -fsyntax-only -fno-gnu-unique -xc++ - -o /dev/null &> /dev/null; then
+  CFLAGS+=" -fno-gnu-unique"
 fi
+
 LDFLAGS=
 INCFLAGS="-Ifirmware/ap_types/"
 PROJECT=myproject

--- a/hls4ml/templates/vivado_accelerator/build_lib.sh
+++ b/hls4ml/templates/vivado_accelerator/build_lib.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 CC=g++
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11 -fno-gnu-unique"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    CFLAGS="-O3 -fPIC -std=c++11"
+CFLAGS="-O3 -fPIC -std=c++11"
+
+# Include -fno-gnu-unique if it is there
+if echo "" | ${CC} -Werror -fsyntax-only -fno-gnu-unique -xc++ - -o /dev/null &> /dev/null; then
+  CFLAGS+=" -fno-gnu-unique"
 fi
+
 INCFLAGS="-Ifirmware/ap_types/"
 PROJECT=myproject
 LIB_STAMP=mystamp


### PR DESCRIPTION
# Description

`$OSTYPE` is not a reliable source for determining the platform. On OpenSUSE 20250503, bash returns `"linux"` instead of `"linux-gnu"` and the script failed without `-fPIC`.

The updated script checks if  `-fno-gnu-unique` is supported, and appends it if so.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Triggers on specific platforms.