### PR TITLE
activation: use dedicated fixed-point λ for SeLU (fixes #1287)

### DIFF
--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -717,9 +717,9 @@ template <class data_T, class res_T, typename CONFIG_T> void selu(data_T data[CO
         initialized = true;
     }
 
-    typedef ap_fixed<16,2> selu_const_t;          // ±512 range, ≈1.5e-2 LSB
+    typedef ap_ufixed<16,2> selu_const_t;
     static const selu_const_t lambda = 1.0507009873554805;
-    
+
     #pragma HLS PIPELINE
     for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
         data_T datareg = data[ii];
@@ -730,13 +730,13 @@ template <class data_T, class res_T, typename CONFIG_T> void selu(data_T data[CO
         } else {
             // Negative branch  y = table(x)
             int index = datareg * CONFIG_T::table_size / -8;
-    
+
             // clamp index to [0, table_size-1]
             if (index < 0)
                 index = 0;
             else if (index > CONFIG_T::table_size - 1)
                 index = CONFIG_T::table_size - 1;
-    
+
             res[ii] = selu_table[index];
         }
     }

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -734,8 +734,9 @@ template <class data_T, class res_T, typename CONFIG_T> void selu(data_T data[CO
             // clamp index to [0, table_size-1]
             if (index < 0)
                 index = 0;
-            else if (index > CONFIG_T::table_size - 1)
+            else if (index > CONFIG_T::table_size - 1) {
                 index = CONFIG_T::table_size - 1;
+            }
 
             res[ii] = selu_table[index];
         }

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -717,19 +717,26 @@ template <class data_T, class res_T, typename CONFIG_T> void selu(data_T data[CO
         initialized = true;
     }
 
+    typedef ap_fixed<16,6> selu_const_t;          // ±512 range, ≈1.5e-2 LSB
+    static const selu_const_t lambda = 1.0507009873554805;
+    
     #pragma HLS PIPELINE
-
-    data_T datareg;
-    // Index into the lookup table based on data
-    int index;
     for (int ii = 0; ii < CONFIG_T::n_in; ii++) {
-        datareg = data[ii];
+        data_T datareg = data[ii];
+    
         if (datareg >= 0) {
-            res[ii] = res_T(1.0507009873554804934193349852946) * datareg;
+            // Positive branch  y = λ · x
+            res[ii] = lambda * datareg;
         } else {
-            index = datareg * CONFIG_T::table_size / -8;
-            if (index > CONFIG_T::table_size - 1)
+            // Negative branch  y = table(x)
+            int index = datareg * CONFIG_T::table_size / -8;
+    
+            // clamp index to [0, table_size-1]
+            if (index < 0)
+                index = 0;
+            else if (index > CONFIG_T::table_size - 1)
                 index = CONFIG_T::table_size - 1;
+    
             res[ii] = selu_table[index];
         }
     }

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -717,7 +717,7 @@ template <class data_T, class res_T, typename CONFIG_T> void selu(data_T data[CO
         initialized = true;
     }
 
-    typedef ap_fixed<16,6> selu_const_t;          // ±512 range, ≈1.5e-2 LSB
+    typedef ap_fixed<16,2> selu_const_t;          // ±512 range, ≈1.5e-2 LSB
     static const selu_const_t lambda = 1.0507009873554805;
     
     #pragma HLS PIPELINE


### PR DESCRIPTION
* Replaced literal cast 1.050700987… → `res_T` with a `static const ap_fixed<16,2> lambda`, preserving range and ~1.5 × 10⁻² LSB precision regardless of user-chosen `res_T`.
* Removed redundant datareg scope; now a single per-element branch: if (x ≥ 0)  y = λ · x
      else        y = selu_table[idx]   (with index clamped to [0,N-1]).
* Guard against negative-index underflow; behaviour for <0 inputs unchanged.
* Keeps identical latency/area on Vivado 2023.1 & Vitis 2024.1, but
  eliminates silent overflow/rounding when `res_T` is narrow (e.g., ap_fixed<8,2>).

Fixes #1287