### PR TITLE
Change default part to agilex 7, turn of hyper-optimized handshaking, pass clock period

### DIFF
--- a/hls4ml/backends/oneapi/oneapi_backend.py
+++ b/hls4ml/backends/oneapi/oneapi_backend.py
@@ -130,12 +130,15 @@ class OneAPIBackend(FPGABackend):
     def get_writer_flow(self):
         return self._writer_flow
 
-    def create_initial_config(self, part='Arria10', clock_period=5, io_type='io_parallel', write_tar=False, **_):
+    def create_initial_config(
+        self, part='Agilex7', clock_period=5, hyperopt_handshake=False, io_type='io_parallel', write_tar=False, **_
+    ):
         """Create initial configuration of the oneAPI backend.
 
         Args:
-            part (str, optional): The FPGA part to be used. Defaults to 'Arria10'.
-            clock_period (int, optional): The clock period. Defaults to 5.
+            part (str, optional): The FPGA part to be used. Defaults to 'Agilex7'.
+            clock_period (int, optional): The clock period in ns. Defaults to 5.
+            hyperopt_handshake (bool, optional): Should hyper-optimized handshaking be used? Defaults to False
             io_type (str, optional): Type of implementation used. One of
                 'io_parallel' or 'io_stream'. Defaults to 'io_parallel'.
             write_tar (bool, optional): If True, compresses the output directory into a .tar.gz file. Defaults to False.
@@ -146,8 +149,9 @@ class OneAPIBackend(FPGABackend):
 
         config = {}
 
-        config['Part'] = part if part is not None else 'Arria10'
+        config['Part'] = part if part is not None else 'Agilex7'
         config['ClockPeriod'] = clock_period
+        config['HyperoptHandshake'] = hyperopt_handshake
         config['IOType'] = io_type
         config['HLSConfig'] = {}
         config['WriterConfig'] = {
@@ -167,7 +171,7 @@ class OneAPIBackend(FPGABackend):
             Exception: If the project failed to compile
 
         Returns:
-            string: Returns the name of the compiled library.
+            Path: Returns the name of the compiled library.
         """
         outdir = Path(Path.cwd(), model.config.get_output_dir())
         builddir = outdir / 'build'

--- a/hls4ml/templates/oneapi/CMakeLists.txt
+++ b/hls4ml/templates/oneapi/CMakeLists.txt
@@ -35,15 +35,15 @@ set(LIBRARY_NAME myproject-${LIB_STAMP})
 # path to the board support package (BSP), this usually is in your install
 # folder.
 #
-# You can also specify a device family (E.g. "Arria10" or "Stratix10") or a
+# You can also specify a device family (E.g. "Agilex7" or "Stratix10") or a
 # specific part number (E.g. "10AS066N3F40E2SG") to generate a standalone IP.
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Arria10")
+    set(FPGA_DEVICE "Agilex7")
 endif()
 
 # Use cmake -DUSER_FPGA_FLAGS=<flags> to set extra flags for FPGA backend
 # compilation.
-set(USER_FPGA_FLAGS -Wno-unused-label ${USER_FPGA_FLAGS})
+set(USER_FPGA_FLAGS -Wno-unused-label;${USER_FPGA_FLAGS})
 
 # Use cmake -DUSER_FLAGS=<flags> to set extra flags for general compilation.
 set(USER_FLAGS -Wno-unused-label -fconstexpr-steps=134217728 ${USER_FLAGS})

--- a/hls4ml/writer/oneapi_writer.py
+++ b/hls4ml/writer/oneapi_writer.py
@@ -517,6 +517,8 @@ class OneAPIWriter(Writer):
         # Makefile
         filedir = os.path.dirname(os.path.abspath(__file__))
         device = model.config.get_config_value('Part')
+        period = model.config.get_config_value('ClockPeriod')
+        hyper = model.config.get_config_value('HyperoptHandshake')
         with (
             open(os.path.join(filedir, '../templates/oneapi/CMakeLists.txt')) as f,
             open(f'{model.config.get_output_dir()}/CMakeLists.txt', 'w') as fout,
@@ -527,6 +529,11 @@ class OneAPIWriter(Writer):
 
                 if 'set(FPGA_DEVICE' in line:
                     line = f'    set(FPGA_DEVICE "{device}")\n'
+
+                if 'set(USER_FPGA_FLAGS' in line:
+                    line += f'set(USER_FPGA_FLAGS -Xsclock={period}ns; ${{USER_FPGA_FLAGS}})\n'
+                    if not hyper:
+                        line += 'set(USER_FPGA_FLAGS -Xsoptimize=latency; ${USER_FPGA_FLAGS})\n'
 
                 fout.write(line)
 


### PR DESCRIPTION
# Description

This fixes a bug in oneAPI that the passed clock period was ignored. Additionally, it adds an option to turn off or on the hyper-optimized handshaking (now default off, since usually it hurts, unless you really want high clocks), and it changes the default part to agilex 7 for oneAPI, updating the technology.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [x] Other:  change defaults

## Tests

This should not break any pytests. The change should only matter for synthesis.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
