### PR TITLE
remove passing of size to stream clone and repack

### DIFF
--- a/hls4ml/backends/oneapi/passes/clone_templates.py
+++ b/hls4ml/backends/oneapi/passes/clone_templates.py
@@ -17,7 +17,7 @@ class CloneTaskSequenceTemplate(TaskSequenceTemplate):
 
         output_pipes = ', '.join([f'{{output{i + 1}_pipe}}' for i in range(len(node.outputs))])
 
-        template = f'task_sequence<nnet::clone_stream<{{input_pipe}}, {output_pipes}, {{size}}>> {{name}};'
+        template = f'task_sequence<nnet::clone_stream<{{input_pipe}}, {output_pipes}>> {{name}};'
         return template.format(**params)
 
 

--- a/hls4ml/backends/oneapi/passes/reshaping_templates.py
+++ b/hls4ml/backends/oneapi/passes/reshaping_templates.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from hls4ml.backends.oneapi.oneapi_template import StreamFunctionCallTemplate, TaskSequenceTemplate
 from hls4ml.backends.template import FunctionCallTemplate, LayerConfigTemplate
 from hls4ml.model.layers import Reshape, Resize, Transpose, ZeroPadding1D, ZeroPadding2D
@@ -215,7 +213,7 @@ class TransposeTaskSequenceTemplate(TaskSequenceTemplate):
 
 
 # Reshape template (only used in streaming)
-reshape_task_sequence_template = 'task_sequence<nnet::repack_stream<{input_pipe}, {output_pipe}, {size}>> {name};'
+reshape_task_sequence_template = 'task_sequence<nnet::repack_stream<{input_pipe}, {output_pipe}>> {name};'
 reshape_include_list = ['nnet_utils/nnet_stream.h']
 
 
@@ -244,5 +242,4 @@ class ReshapeTaskSequenceTemplate(TaskSequenceTemplate):
 
     def format(self, node):
         params = self._default_function_params(node)
-        params['size'] = int(np.prod(node.get_output_variable().shape))
         return self.template.format(**params)

--- a/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_stream.h
+++ b/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_stream.h
@@ -12,88 +12,82 @@ struct broadcast_config {
     static const unsigned n_dupl = 2;
 };
 
-template <class data_pipe, class res1_pipe, class res2_pipe, int N> void clone_stream() {
+template <class data_pipe, class res1_pipe, class res2_pipe> void clone_stream() {
     using data_T = typename ExtractPipeType<data_pipe>::value_type;
     using res1_T = typename ExtractPipeType<res1_pipe>::value_type;
     using res2_T = typename ExtractPipeType<res2_pipe>::value_type;
     constexpr auto datasize = std::tuple_size<data_T>{};
-CloneLoop:
-    [[intel::initiation_interval(1)]] for (int i = 0; i < N / datasize; i++) {
-        data_T in_data = data_pipe::read();
-        res1_T out_data1;
-        res2_T out_data2;
 
-    ClonePack:
-        #pragma unroll
-        for (int j = 0; j < datasize; j++) {
-            out_data1[j] = in_data[j];
-            out_data2[j] = in_data[j];
-        }
+    data_T in_data = data_pipe::read();
+    res1_T out_data1;
+    res2_T out_data2;
 
-        res1_pipe::write(out_data1);
-        res2_pipe::write(out_data2);
+ClonePack:
+    #pragma unroll
+    for (int j = 0; j < datasize; j++) {
+        out_data1[j] = in_data[j];
+        out_data2[j] = in_data[j];
     }
+
+    res1_pipe::write(out_data1);
+    res2_pipe::write(out_data2);
 }
 
-template <class data_pipe, class res1_pipe, class res2_pipe, class res3_pipe, int N> void clone_stream() {
+template <class data_pipe, class res1_pipe, class res2_pipe, class res3_pipe> void clone_stream() {
     using data_T = typename ExtractPipeType<data_pipe>::value_type;
     using res1_T = typename ExtractPipeType<res1_pipe>::value_type;
     using res2_T = typename ExtractPipeType<res2_pipe>::value_type;
     using res3_T = typename ExtractPipeType<res3_pipe>::value_type;
     constexpr auto datasize = std::tuple_size<data_T>{};
-CloneLoop:
-    [[intel::initiation_interval(1)]] for (int i = 0; i < N / datasize; i++) {
-        data_T in_data = data_pipe::read();
-        res1_T out_data1;
-        res2_T out_data2;
-        res3_T out_data3;
 
-    ClonePack:
-        #pragma unroll
-        for (int j = 0; j < datasize; j++) {
-            out_data1[j] = in_data[j];
-            out_data2[j] = in_data[j];
-            out_data3[j] = in_data[j];
-        }
+    data_T in_data = data_pipe::read();
+    res1_T out_data1;
+    res2_T out_data2;
+    res3_T out_data3;
 
-        res1_pipe::write(out_data1);
-        res2_pipe::write(out_data2);
-        res3_pipe::write(out_data3);
+ClonePack:
+    #pragma unroll
+    for (int j = 0; j < datasize; j++) {
+        out_data1[j] = in_data[j];
+        out_data2[j] = in_data[j];
+        out_data3[j] = in_data[j];
     }
+
+    res1_pipe::write(out_data1);
+    res2_pipe::write(out_data2);
+    res3_pipe::write(out_data3);
 }
 
-template <class data_pipe, class res1_pipe, class res2_pipe, class res3_pipe, class res4_pipe, int N> void clone_stream() {
+template <class data_pipe, class res1_pipe, class res2_pipe, class res3_pipe, class res4_pipe> void clone_stream() {
     using data_T = typename ExtractPipeType<data_pipe>::value_type;
     using res1_T = typename ExtractPipeType<res1_pipe>::value_type;
     using res2_T = typename ExtractPipeType<res2_pipe>::value_type;
     using res3_T = typename ExtractPipeType<res3_pipe>::value_type;
     using res4_T = typename ExtractPipeType<res4_pipe>::value_type;
     constexpr auto datasize = std::tuple_size<data_T>{};
-CloneLoop:
-    [[intel::initiation_interval(1)]] for (int i = 0; i < N / datasize; i++) {
-        data_T in_data = data_pipe::read();
-        res1_T out_data1;
-        res2_T out_data2;
-        res3_T out_data3;
-        res4_T out_data4;
 
-    ClonePack:
-        #pragma unroll
-        for (int j = 0; j < datasize; j++) {
-            out_data1[j] = in_data[j];
-            out_data2[j] = in_data[j];
-            out_data3[j] = in_data[j];
-            out_data4[j] = in_data[j];
-        }
+    data_T in_data = data_pipe::read();
+    res1_T out_data1;
+    res2_T out_data2;
+    res3_T out_data3;
+    res4_T out_data4;
 
-        res1_pipe::write(out_data1);
-        res2_pipe::write(out_data2);
-        res3_pipe::write(out_data3);
-        res4_pipe::write(out_data4);
+ClonePack:
+    #pragma unroll
+    for (int j = 0; j < datasize; j++) {
+        out_data1[j] = in_data[j];
+        out_data2[j] = in_data[j];
+        out_data3[j] = in_data[j];
+        out_data4[j] = in_data[j];
     }
+
+    res1_pipe::write(out_data1);
+    res2_pipe::write(out_data2);
+    res3_pipe::write(out_data3);
+    res4_pipe::write(out_data4);
 }
 
-template <class data_pipe, class res1_pipe, class res2_pipe, class res3_pipe, class res4_pipe, class res5_pipe, int N>
+template <class data_pipe, class res1_pipe, class res2_pipe, class res3_pipe, class res4_pipe, class res5_pipe>
 void clone_stream() {
     using data_T = typename ExtractPipeType<data_pipe>::value_type;
     using res1_T = typename ExtractPipeType<res1_pipe>::value_type;
@@ -102,35 +96,33 @@ void clone_stream() {
     using res4_T = typename ExtractPipeType<res4_pipe>::value_type;
     using res5_T = typename ExtractPipeType<res5_pipe>::value_type;
     constexpr auto datasize = std::tuple_size<data_T>{};
-CloneLoop:
-    [[intel::initiation_interval(1)]] for (int i = 0; i < N / datasize; i++) {
-        data_T in_data = data_pipe::read();
-        res1_T out_data1;
-        res2_T out_data2;
-        res3_T out_data3;
-        res4_T out_data4;
-        res5_T out_data5;
 
-    ClonePack:
-        #pragma unroll
-        for (int j = 0; j < datasize; j++) {
-            out_data1[j] = in_data[j];
-            out_data2[j] = in_data[j];
-            out_data3[j] = in_data[j];
-            out_data4[j] = in_data[j];
-            out_data5[j] = in_data[j];
-        }
+    data_T in_data = data_pipe::read();
+    res1_T out_data1;
+    res2_T out_data2;
+    res3_T out_data3;
+    res4_T out_data4;
+    res5_T out_data5;
 
-        res1_pipe::write(out_data1);
-        res2_pipe::write(out_data2);
-        res3_pipe::write(out_data3);
-        res4_pipe::write(out_data4);
-        res5_pipe::write(out_data5);
+ClonePack:
+    #pragma unroll
+    for (int j = 0; j < datasize; j++) {
+        out_data1[j] = in_data[j];
+        out_data2[j] = in_data[j];
+        out_data3[j] = in_data[j];
+        out_data4[j] = in_data[j];
+        out_data5[j] = in_data[j];
     }
+
+    res1_pipe::write(out_data1);
+    res2_pipe::write(out_data2);
+    res3_pipe::write(out_data3);
+    res4_pipe::write(out_data4);
+    res5_pipe::write(out_data5);
 }
 
 template <class data_pipe, class res1_pipe, class res2_pipe, class res3_pipe, class res4_pipe, class res5_pipe,
-          class res6_pipe, int N>
+          class res6_pipe>
 void clone_stream() {
     using data_T = typename ExtractPipeType<data_pipe>::value_type;
     using res1_T = typename ExtractPipeType<res1_pipe>::value_type;
@@ -140,38 +132,36 @@ void clone_stream() {
     using res5_T = typename ExtractPipeType<res5_pipe>::value_type;
     using res6_T = typename ExtractPipeType<res6_pipe>::value_type;
     constexpr auto datasize = std::tuple_size<data_T>{};
-CloneLoop:
-    [[intel::initiation_interval(1)]] for (int i = 0; i < N / datasize; i++) {
-        data_T in_data = data_pipe::read();
-        res1_T out_data1;
-        res2_T out_data2;
-        res3_T out_data3;
-        res4_T out_data4;
-        res5_T out_data5;
-        res6_T out_data6;
 
-    ClonePack:
-        #pragma unroll
-        for (int j = 0; j < datasize; j++) {
-            out_data1[j] = in_data[j];
-            out_data2[j] = in_data[j];
-            out_data3[j] = in_data[j];
-            out_data4[j] = in_data[j];
-            out_data5[j] = in_data[j];
-            out_data6[j] = in_data[j];
-        }
+    data_T in_data = data_pipe::read();
+    res1_T out_data1;
+    res2_T out_data2;
+    res3_T out_data3;
+    res4_T out_data4;
+    res5_T out_data5;
+    res6_T out_data6;
 
-        res1_pipe::write(out_data1);
-        res2_pipe::write(out_data2);
-        res3_pipe::write(out_data3);
-        res4_pipe::write(out_data4);
-        res5_pipe::write(out_data5);
-        res6_pipe::write(out_data6);
+ClonePack:
+    #pragma unroll
+    for (int j = 0; j < datasize; j++) {
+        out_data1[j] = in_data[j];
+        out_data2[j] = in_data[j];
+        out_data3[j] = in_data[j];
+        out_data4[j] = in_data[j];
+        out_data5[j] = in_data[j];
+        out_data6[j] = in_data[j];
     }
+
+    res1_pipe::write(out_data1);
+    res2_pipe::write(out_data2);
+    res3_pipe::write(out_data3);
+    res4_pipe::write(out_data4);
+    res5_pipe::write(out_data5);
+    res6_pipe::write(out_data6);
 }
 
 template <class data_pipe, class res1_pipe, class res2_pipe, class res3_pipe, class res4_pipe, class res5_pipe,
-          class res6_pipe, class res7_pipe, int N>
+          class res6_pipe, class res7_pipe>
 void clone_stream() {
     using data_T = typename ExtractPipeType<data_pipe>::value_type;
     using res1_T = typename ExtractPipeType<res1_pipe>::value_type;
@@ -182,94 +172,87 @@ void clone_stream() {
     using res6_T = typename ExtractPipeType<res6_pipe>::value_type;
     using res7_T = typename ExtractPipeType<res7_pipe>::value_type;
     constexpr auto datasize = std::tuple_size<data_T>{};
-CloneLoop:
-    [[intel::initiation_interval(1)]] for (int i = 0; i < N / datasize; i++) {
-        data_T in_data = data_pipe::read();
-        res1_T out_data1;
-        res2_T out_data2;
-        res3_T out_data3;
-        res4_T out_data4;
-        res5_T out_data5;
-        res6_T out_data6;
-        res7_T out_data7;
 
-    ClonePack:
-        #pragma unroll
-        for (int j = 0; j < datasize; j++) {
-            out_data1[j] = in_data[j];
-            out_data2[j] = in_data[j];
-            out_data3[j] = in_data[j];
-            out_data4[j] = in_data[j];
-            out_data5[j] = in_data[j];
-            out_data6[j] = in_data[j];
-            out_data7[j] = in_data[j];
-        }
+    data_T in_data = data_pipe::read();
+    res1_T out_data1;
+    res2_T out_data2;
+    res3_T out_data3;
+    res4_T out_data4;
+    res5_T out_data5;
+    res6_T out_data6;
+    res7_T out_data7;
 
-        res1_pipe::write(out_data1);
-        res2_pipe::write(out_data2);
-        res3_pipe::write(out_data3);
-        res4_pipe::write(out_data4);
-        res5_pipe::write(out_data5);
-        res6_pipe::write(out_data6);
-        res6_pipe::write(out_data7);
+ClonePack:
+    #pragma unroll
+    for (int j = 0; j < datasize; j++) {
+        out_data1[j] = in_data[j];
+        out_data2[j] = in_data[j];
+        out_data3[j] = in_data[j];
+        out_data4[j] = in_data[j];
+        out_data5[j] = in_data[j];
+        out_data6[j] = in_data[j];
+        out_data7[j] = in_data[j];
     }
+
+    res1_pipe::write(out_data1);
+    res2_pipe::write(out_data2);
+    res3_pipe::write(out_data3);
+    res4_pipe::write(out_data4);
+    res5_pipe::write(out_data5);
+    res6_pipe::write(out_data6);
+    res6_pipe::write(out_data7);
 }
 
-template <class data_pipe, class res_pipe, int N> void repack_stream() {
+template <class data_pipe, class res_pipe> void repack_stream() {
     using data_T = typename ExtractPipeType<data_pipe>::value_type;
     using res_T = typename ExtractPipeType<res_pipe>::value_type;
     constexpr auto datasize = std::tuple_size<data_T>{};
     constexpr auto ressize = std::tuple_size<res_T>{};
 
     if constexpr (datasize == ressize) {
-        [[intel::initiation_interval(1)]] for (int i = 0; i < N / datasize; i++) {
 
-            [[intel::fpga_memory]] auto in_data = data_pipe::read();
-            [[intel::fpga_memory]] res_T out_data;
+        [[intel::fpga_memory]] auto in_data = data_pipe::read();
+        [[intel::fpga_memory]] res_T out_data;
 
-            #pragma unroll
-            for (int j = 0; j < datasize; j++) {
-                out_data[j] = in_data[j];
-            }
-
-            res_pipe::write(out_data);
+        #pragma unroll
+        for (int j = 0; j < datasize; j++) {
+            out_data[j] = in_data[j];
         }
+
+        res_pipe::write(out_data);
+
     } else if constexpr (datasize > ressize) {
         constexpr unsigned pack_diff = datasize / ressize;
 
-        for (int i = 0; i < N / datasize; i++) {
+        [[intel::fpga_memory]] auto in_data = data_pipe::read();
+        [[intel::fpga_memory]] res_T out_data;
 
-            [[intel::fpga_memory]] auto in_data = data_pipe::read();
-            [[intel::fpga_memory]] res_T out_data;
+        [[intel::initiation_interval(1)]] for (int j = 0; j < pack_diff; j++) {
 
-            [[intel::initiation_interval(1)]] for (int j = 0; j < pack_diff; j++) {
-
-                #pragma unroll
-                for (int k = 0; k < ressize; k++) {
-                    out_data[k] = in_data[j * ressize + k];
-                }
-                res_pipe::write(out_data);
+            #pragma unroll
+            for (int k = 0; k < ressize; k++) {
+                out_data[k] = in_data[j * ressize + k];
             }
+            res_pipe::write(out_data);
         }
+
     } else { // datasize < ressize
         [[intel::fpga_memory]] res_T out_data;
         constexpr unsigned pack_diff = ressize / datasize;
         unsigned pack_cnt = 0;
-        [[intel::initiation_interval(1)]] for (int i = 0; i < N / datasize; i++) {
 
-            [[intel::fpga_memory]] auto in_data = data_pipe::read();
+        [[intel::fpga_memory]] auto in_data = data_pipe::read();
 
-            #pragma unroll
-            for (int j = 0; j < datasize; j++) {
-                out_data[pack_cnt * datasize + j] = in_data[j];
-            }
+        #pragma unroll
+        for (int j = 0; j < datasize; j++) {
+            out_data[pack_cnt * datasize + j] = in_data[j];
+        }
 
-            if (pack_cnt == pack_diff - 1) {
-                res_pipe::write(out_data);
-                pack_cnt = 0;
-            } else {
-                pack_cnt++;
-            }
+        if (pack_cnt == pack_diff - 1) {
+            res_pipe::write(out_data);
+            pack_cnt = 0;
+        } else {
+            pack_cnt++;
         }
     }
 }


### PR DESCRIPTION
# Description

This removes the unused feature of clone stream and repack for oneAPI. Generally with oneAPI we don't support reading in multiple inputs as one.

The reason this is draft is because it was part of an attempt to figure out the failures in `test_stream_clone.py::test_multi_clone[oneAPI]`, but this doesn't seem to fix them.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Other - remove unused feature

## Tests

Want to see the behavior on the standard pytests, to see if there are additional failures.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
