### PR TITLE
Fix parsing einsum with a single input

### DIFF
--- a/hls4ml/converters/pytorch/core.py
+++ b/hls4ml/converters/pytorch/core.py
@@ -166,7 +166,10 @@ def parse_einsum_layer(operation, layer_name, input_names, input_shapes, node, c
 
     layer = {}
 
-    if len(input_names) != 2:
+    if len(input_names) == 1:
+        input_names += input_names
+        input_shapes += input_shapes
+    elif len(input_names) > 2:
         raise Exception('Only einsum operations with two inputs are supported')
     layer['class_name'] = 'Einsum'
     layer['name'] = layer_name


### PR DESCRIPTION
# Description

Fixes parsing torch models that use only a single input (twice) to einsum (for example `torch.einsum("ij,ij->i", x, x)`. Observed in Francesco's work on flows. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Added a test in `test_pytorch_api.py` where the other `einsum` tests reside.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
