### PR TITLE
Pooling Template Fix and HGQ2 QPooling Layer Support

### DIFF
--- a/hls4ml/converters/keras_v3/_base.py
+++ b/hls4ml/converters/keras_v3/_base.py
@@ -76,7 +76,7 @@ class KerasV3LayerHandler:
         """
 
         name = layer.name
-        class_name = layer.__class__.__name__
+        class_name = self.default_class_name(layer)
         module = layer.__module__
 
         default_config: DefaultConfig = {
@@ -115,6 +115,9 @@ class KerasV3LayerHandler:
             ret = *ret, act_config
 
         return ret
+
+    def default_class_name(self, layer: 'keras.Layer') -> str:
+        return layer.__class__.__name__
 
     def maybe_get_activation_config(self, layer, out_tensors):
         import keras

--- a/hls4ml/converters/keras_v3/conv.py
+++ b/hls4ml/converters/keras_v3/conv.py
@@ -1,6 +1,5 @@
 import typing
 from collections.abc import Sequence
-from math import ceil
 from typing import Any
 
 from ._base import KerasV3LayerHandler, register
@@ -29,7 +28,7 @@ def gen_conv_config(
         px_out_shape = [1] * len(px_in_shape)
 
     if padding == 'same':
-        n_padding = [ceil(N / n) * n - N for N, n in zip(px_in_shape, ker_px_shape)]
+        n_padding = [N % s + n - s for N, n, s in zip(px_in_shape, ker_px_shape, strides)]
         n_padding0 = [p // 2 for p in n_padding]
         n_padding1 = [p - p0 for p, p0 in zip(n_padding, n_padding0)]
     elif padding == 'valid':

--- a/hls4ml/converters/keras_v3/conv.py
+++ b/hls4ml/converters/keras_v3/conv.py
@@ -1,5 +1,6 @@
 import typing
 from collections.abc import Sequence
+from math import ceil
 from typing import Any
 
 from ._base import KerasV3LayerHandler, register
@@ -28,7 +29,7 @@ def gen_conv_config(
         px_out_shape = [1] * len(px_in_shape)
 
     if padding == 'same':
-        n_padding = [N % s + n - s for N, n, s in zip(px_in_shape, ker_px_shape, strides)]
+        n_padding = [max(ceil(N / s) * s - N + n - s, 0) for N, n, s in zip(px_in_shape, ker_px_shape, strides)]
         n_padding0 = [p // 2 for p in n_padding]
         n_padding1 = [p - p0 for p, p0 in zip(n_padding, n_padding0)]
     elif padding == 'valid':

--- a/hls4ml/converters/keras_v3/hgq2/__init__.py
+++ b/hls4ml/converters/keras_v3/hgq2/__init__.py
@@ -1,3 +1,3 @@
-from . import _base, einsum, multi_head_attention, softmax, unary_lut
+from . import _base, einsum, multi_head_attention, pooling, softmax, unary_lut
 
-__all__ = ['_base', 'einsum', 'multi_head_attention', 'softmax', 'unary_lut']
+__all__ = ['_base', 'einsum', 'multi_head_attention', 'softmax', 'unary_lut', 'pooling']

--- a/hls4ml/converters/keras_v3/hgq2/pooling.py
+++ b/hls4ml/converters/keras_v3/hgq2/pooling.py
@@ -1,0 +1,20 @@
+from ..pooling import PoolingHandler
+from ._base import QLayerHandler, register
+
+
+@register
+class QPoolingHandler(PoolingHandler, QLayerHandler):
+    handles = (
+        'hgq.layers.pooling.QMaxPooling1D',
+        'hgq.layers.pooling.QMaxPooling2D',
+        'hgq.layers.pooling.QMaxPooling3D',
+        'hgq.layers.pooling.QAveragePooling1D',
+        'hgq.layers.pooling.QAveragePooling2D',
+        'hgq.layers.pooling.QAveragePooling3D',
+        'hgq.layers.pooling.QGlobalAveragePooling1D',
+        'hgq.layers.pooling.QGlobalAveragePooling2D',
+        'hgq.layers.pooling.QGlobalAveragePooling3D',
+        'hgq.layers.pooling.QGlobalMaxPooling1D',
+        'hgq.layers.pooling.QGlobalMaxPooling2D',
+        'hgq.layers.pooling.QGlobalMaxPooling3D',
+    )

--- a/hls4ml/model/optimizer/passes/bit_exact.py
+++ b/hls4ml/model/optimizer/passes/bit_exact.py
@@ -463,20 +463,22 @@ def _(layer: Pooling1D | Pooling2D | GlobalPooling1D | GlobalPooling2D):
 
     im2col_shape = *px_shape, ch_in, ch_out  # conv kernel shape
     k_in, i_in, f_in = get_input_kifs(layer)[0]
+    count = np.ones_like(k_in, dtype=np.uint32)
     if isinstance(layer, (Pooling1D, Pooling2D)):
-        k_in, i_in, f_in = pad_arrs(layer, 0, k_in, i_in, f_in)
-    k_in, i_in, f_in = im2col(im2col_shape, k_in, i_in, f_in)
+        k_in, i_in, f_in, count = pad_arrs(layer, 0, k_in, i_in, f_in, count)
+    k_in, i_in, f_in, count = im2col(im2col_shape, k_in, i_in, f_in, count)
     if isinstance(layer, (Pooling1D, Pooling2D)):
-        k_in, i_in, f_in = stride_arrs(layer, k_in, i_in, f_in)
+        k_in, i_in, f_in, count = stride_arrs(layer, k_in, i_in, f_in, count)
 
     k_out = k_in.reshape(*k_in.shape[:-1], -1, ch_in).max(axis=-2).astype(np.int16)
     i_out = i_in.reshape(*i_in.shape[:-1], -1, ch_in).max(axis=-2).astype(np.int16)
     f_out = f_in.reshape(*f_in.shape[:-1], -1, ch_in).max(axis=-2).astype(np.int16)
+    count = count.reshape(*count.shape[:-1], -1, ch_in).sum(axis=-2)
 
     pool_op = layer.attributes['pool_op']
     if pool_op == 'Average':
-        f_add = minimal_kif(np.array(1 / prod(px_shape)))[2]
-        f_out += int(f_add)
+        f_add = minimal_kif(1 / count)[2]
+        f_out += f_add
 
     if isinstance(layer, (GlobalPooling1D, GlobalPooling2D)):
         k_out, i_out, f_out = k_out[0], i_out[0], f_out[0]

--- a/hls4ml/templates/vitis/nnet_utils/nnet_pooling.h
+++ b/hls4ml/templates/vitis/nnet_utils/nnet_pooling.h
@@ -109,7 +109,7 @@ void pooling1d_cl(data_T data[CONFIG_T::n_in * CONFIG_T::n_filt], res_T res[CONF
                     pool[jj] = pad_val<data_T, CONFIG_T::pool_op>();
             }
 
-            int patch_size = CONFIG_T::count_pad ? CONFIG_T::stride_width : overlap_pixel;
+            int patch_size = CONFIG_T::count_pad ? CONFIG_T::pool_width : overlap_pixel;
 
             res[(ii / CONFIG_T::stride_width) * CONFIG_T::n_filt + ff] =
                 pool_op<data_T, CONFIG_T::pool_width, CONFIG_T::pool_op, typename CONFIG_T::accum_t>(pool, patch_size);

--- a/hls4ml/templates/vivado/nnet_utils/nnet_pooling.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_pooling.h
@@ -107,7 +107,7 @@ void pooling1d_cl(data_T data[CONFIG_T::n_in * CONFIG_T::n_filt], res_T res[CONF
                     pool[jj] = pad_val<data_T, CONFIG_T::pool_op>();
             }
 
-            int patch_size = CONFIG_T::count_pad ? CONFIG_T::stride_width : overlap_pixel;
+            int patch_size = CONFIG_T::count_pad ? CONFIG_T::pool_width : overlap_pixel;
 
             res[(ii / CONFIG_T::stride_width) * CONFIG_T::n_filt + ff] =
                 pool_op<data_T, CONFIG_T::pool_width, CONFIG_T::pool_op, typename CONFIG_T::accum_t>(pool, patch_size);


### PR DESCRIPTION
# Description

(This PR includes #1321)

- Fixes pooling layers in io parallel implementation when strides are non-trivial (!= pool_size)
- Fixes keras v3 parser padding computation
- Added QPooling layer support for HGQ2

# Known Issue

- Pooling in io_stream with non-trivial strides could still crash, most likely when strides > pool_size.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Tests

Updated `test_pooling.py`; HGQ2 tests are added in the HGQ2 repo.
(keras v3 tests will not be triggered here anyway; in the future maybe we can directly reuse HGQ2's hls4ml convert tests)

**Test Configuration**:


## Checklist

- [x] all, but no doc