### PR TITLE
update namespace pytest, make model weights not be all zeros

### DIFF
--- a/test/pytest/test_writer_config.py
+++ b/test/pytest/test_writer_config.py
@@ -14,7 +14,7 @@ test_root_path = Path(__file__).parent
 @pytest.fixture(scope='module')
 def keras_model():
     model = Sequential()
-    model.add(Dense(10, kernel_initializer='zeros', use_bias=False, input_shape=(15,)))
+    model.add(Dense(10, input_shape=(15,)))
     model.compile()
     return model
 
@@ -24,11 +24,11 @@ def keras_model():
 @pytest.mark.parametrize('namespace', [None, 'test_namespace'])
 def test_namespace(keras_model, namespace, io_type, backend):
 
-    use_namespace = namespace is None
+    use_namespace = namespace is not None
     config = hls4ml.utils.config_from_keras_model(keras_model, granularity='name')
     odir = str(test_root_path / f'hls4mlprj_namespace_{use_namespace}_{backend}_{io_type}')
     hls_model = hls4ml.converters.convert_from_keras_model(
-        keras_model, hls_config=config, io_type=io_type, output_dir=odir, backend=backend
+        keras_model, hls_config=config, io_type=io_type, output_dir=odir, namespace=namespace, backend=backend
     )
     hls_model.compile()  # It's enough that the model compiles
 


### PR DESCRIPTION
# Description

The pytest for namespaces actually did not actually set namespaces. This is pytest bug-fix. I also made the default model not have all 0 weights, which could potentially hide problems

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Other (Specify)  - test fix

## Tests

This updates already existing tests that were not making the appropriate test.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
