### PR TITLE
Helpers for CMSSW emulation

### DIFF
--- a/hls4ml/backends/vitis/vitis_backend.py
+++ b/hls4ml/backends/vitis/vitis_backend.py
@@ -61,6 +61,7 @@ class VitisBackend(VivadoBackend):
         namespace=None,
         write_weights_txt=True,
         write_tar=False,
+        write_emulation_constants=False,
         tb_output_stream='both',
         **_,
     ):
@@ -76,6 +77,8 @@ class VitisBackend(VivadoBackend):
             write_weights_txt (bool, optional): If True, writes weights to .txt files which speeds up compilation.
                 Defaults to True.
             write_tar (bool, optional): If True, compresses the output directory into a .tar.gz file. Defaults to False.
+            write_emulation_constants (bool, optional): If True, write constants to define.h useful for emulation.
+                Defaults to False.
             tb_output_stream (str, optional): Controls where to write the output. Options are 'stdout', 'file' and 'both'.
                 Defaults to 'both'.
 
@@ -94,6 +97,7 @@ class VitisBackend(VivadoBackend):
             'WriteWeightsTxt': write_weights_txt,
             'WriteTar': write_tar,
             'TBOutputStream': tb_output_stream,
+            'WriteEmulationConstants': write_emulation_constants,
         }
 
         return config

--- a/hls4ml/templates/vivado/firmware/defines.h
+++ b/hls4ml/templates/vivado/firmware/defines.h
@@ -4,14 +4,18 @@
 #include "ap_fixed.h"
 #include "ap_int.h"
 #include "nnet_utils/nnet_types.h"
+#include <array>
 #include <cstddef>
 #include <cstdio>
+#include <tuple>
 
 // hls-fpga-machine-learning insert namespace-start
 
 // hls-fpga-machine-learning insert numbers
 
 // hls-fpga-machine-learning insert layer-precision
+
+// hls-fpga-machine-learning insert emulator-defines
 
 // hls-fpga-machine-learning insert namespace-end
 

--- a/hls4ml/templates/vivado/firmware/myproject.h
+++ b/hls4ml/templates/vivado/firmware/myproject.h
@@ -14,6 +14,8 @@ void myproject(
     // hls-fpga-machine-learning insert header
 );
 
+// hls-fpga-machine-learning insert emulator-defines
+
 // hls-fpga-machine-learning insert namespace-end
 
 #endif

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -377,6 +377,16 @@ class VivadoWriter(Writer):
                 if namespace is not None:
                     newline += '}\n'
 
+            elif '// hls-fpga-machine-learning insert emulator-defines' in line:
+                newline = line
+
+                if model.config.get_writer_config().get('WriteEmulationConstants', False):
+                    input_types = [f'std::array<{v.type.name}, {v.size_cpp()}>' for v in model.get_input_variables()]
+                    output_types = [f'std::array<{v.type.name}, {v.size_cpp()}>' for v in model.get_output_variables()]
+                    input_types_str = ', '.join(input_types)
+                    output_types_str = ', '.join(output_types)
+                    newline += '\n' + f'using inputs_t = std::tuple<{input_types_str}>;'
+                    newline += '\n' + f'using outputs_t = std::tuple<{output_types_str}>;\n'
             else:
                 newline = line
             fout.write(newline)


### PR DESCRIPTION
# Description

These features help in writing CMSSW emulators by providing a standardized way extract the inputs and outputs and call the hls4ml functions. Currently, it is only tested for `io_parallel` and for the Vitis backend. The emulation mode is requires `convert_from_keras_model` or more generally `convert_from_*_model` (though so far only tested with Keras) to have the following parameters set:
```
  namespace='hls4ml_model_emu_v1',
  write_weights_txt=False,
  write_emulation_constants=True,
```
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

Currently only tested manually. Tests to be added.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
