### PR TITLE
Add (in)equality operators for nnet array

### DIFF
--- a/hls4ml/templates/catapult/nnet_utils/nnet_types.h
+++ b/hls4ml/templates/catapult/nnet_utils/nnet_types.h
@@ -32,7 +32,9 @@ template <typename T, unsigned N> struct array {
     }
 
     bool operator==(const array &other) const {
-        assert(N == other.size && "Array sizes must match.");
+        if (N != other.size) {
+            return false;
+        }
 
         for (unsigned i = 0; i < N; i++) {
             if (data[i] != other[i]) {

--- a/hls4ml/templates/catapult/nnet_utils/nnet_types.h
+++ b/hls4ml/templates/catapult/nnet_utils/nnet_types.h
@@ -30,6 +30,20 @@ template <typename T, unsigned N> struct array {
         }
         return *this;
     }
+
+    bool operator==(const array &other) const {
+        assert(N == other.size && "Array sizes must match.");
+
+        for (unsigned i = 0; i < N; i++) {
+            if (data[i] != other[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool operator!=(const array &other) const { return !(*this == other); }
 };
 
 // Generic lookup-table implementation, for use in approximations of math functions

--- a/hls4ml/templates/vivado/nnet_utils/nnet_types.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_types.h
@@ -32,7 +32,9 @@ template <typename T, unsigned N> struct array {
     }
 
     bool operator==(const array &other) const {
-        assert(N == other.size && "Array sizes must match.");
+        if (N != other.size) {
+            return false;
+        }
 
         for (unsigned i = 0; i < N; i++) {
             if (data[i] != other[i]) {

--- a/hls4ml/templates/vivado/nnet_utils/nnet_types.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_types.h
@@ -36,16 +36,14 @@ template <typename T, unsigned N> struct array {
 
         for (unsigned i = 0; i < N; i++) {
             if (data[i] != other[i]) {
-              return false;
+                return false;
             }
         }
-        
+
         return true;
     }
 
-    bool operator!=(const array &other) const {
-      return !(*this == other);
-    }
+    bool operator!=(const array &other) const { return !(*this == other); }
 };
 
 // Generic lookup-table implementation, for use in approximations of math functions

--- a/hls4ml/templates/vivado/nnet_utils/nnet_types.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_types.h
@@ -30,6 +30,22 @@ template <typename T, unsigned N> struct array {
         }
         return *this;
     }
+
+    bool operator==(const array &other) const {
+        assert(N == other.size && "Array sizes must match.");
+
+        for (unsigned i = 0; i < N; i++) {
+            if (data[i] != other[i]) {
+              return false;
+            }
+        }
+        
+        return true;
+    }
+
+    bool operator!=(const array &other) const {
+      return !(*this == other);
+    }
 };
 
 // Generic lookup-table implementation, for use in approximations of math functions


### PR DESCRIPTION
Adds (in)equality operators for `nnet::array`. 

Primarily this is intended for use in unit testing so my tests are limited to compiling and running code using through gcc.

As such the rtl that is generated is probably not very fast. 

I could optimise this with a fold or similar if need be.