### PR TITLE
Issue #184 fix - Propagate options to Vitis HLS

### DIFF
--- a/hls4ml/writer/vitis_writer.py
+++ b/hls4ml/writer/vitis_writer.py
@@ -56,6 +56,14 @@ class VitisWriter(VivadoWriter):
         dstpath = f'{model.config.get_output_dir()}/build_opt.tcl'
         copyfile(srcpath, dstpath)
 
+    def write_build_prj_override(self, model):
+        filedir = Path(__file__).parent
+
+        # build_prj.tcl
+        srcpath = (filedir / '../templates/vitis/build_prj.tcl').resolve()
+        dstpath = f'{model.config.get_output_dir()}/build_prj.tcl'
+        copyfile(srcpath, dstpath)
+
     def write_hls(self, model):
         """
         Write the HLS project. Calls the steps from VivadoWriter, adapted for Vitis
@@ -63,5 +71,6 @@ class VitisWriter(VivadoWriter):
         super().write_hls(model)
         self.write_nnet_utils_overrides(model)
         self.write_board_script_override(model)
+        self.write_build_prj_override(model)
         self.write_build_opts(model)
         self.write_tar(model)


### PR DESCRIPTION
# Description

> :memo: Fixes build options not being propagated to Vitis HLS
>
> * Essentially, this PR fixes a bug which essentially caused the Vitis backend to use the build_prj.tcl from Vivado backend, by not overwriting the Vivado file in the writer.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

> :memo: Can be confirmed that it works correctly by running issue #184 

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
