### PR TITLE
ADD parsing class for rnn layers in keras V3

### DIFF
--- a/hls4ml/converters/keras/recurrent.py
+++ b/hls4ml/converters/keras/recurrent.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from hls4ml.converters.keras_v2_to_hls import (
     KerasModelReader,
     KerasNestedFileReader,
@@ -40,6 +42,13 @@ def parse_rnn_layer(keras_layer, input_names, input_shapes, data_reader):
     layer['weight_data'], layer['recurrent_weight_data'], layer['bias_data'] = get_weights_data(
         data_reader, layer['name'], ['kernel', 'recurrent_kernel', 'bias']
     )
+
+    if layer['bias_data'] is None:
+        d_out = layer['bias_data'].shape[-1]
+        if 'GRU' in layer['class_name']:
+            layer['bias_data'] = np.zeros((2, d_out), dtype=np.float32)
+        else:
+            layer['bias_data'] = np.zeros((d_out,), dtype=np.float32)
 
     if 'GRU' in layer['class_name']:
         layer['apply_reset_gate'] = 'after' if keras_layer['config']['reset_after'] else 'before'

--- a/hls4ml/converters/keras_v3/recurrent.py
+++ b/hls4ml/converters/keras_v3/recurrent.py
@@ -31,7 +31,6 @@ class RecurentHandler(KerasV3LayerHandler):
 
         layer_config = layer.get_config()
         layer_dict = {'config': layer_config, 'class_name': layer.__class__.__name__}
-        module = layer.__module__
 
         class IsolatedLayerReader:
             def get_weights_data(self, layer_name, var_name):
@@ -44,13 +43,11 @@ class RecurentHandler(KerasV3LayerHandler):
         reader = IsolatedLayerReader()
         input_shapes = [list(t.shape) for t in in_tensors]
         input_names = [t.name for t in in_tensors]
-        output_names = [t.name for t in out_tensors]
 
-        config, _ = parse_rnn_layer(layer_dict, input_names, input_shapes, reader)
-        config['module'] = module
-        config['input_keras_tensor_names'] = input_names
-        config['input_shape'] = input_shapes
-        config['output_keras_tensor_names'] = output_names
+        config = {}
+        config.update(self.default_config)
+        layer_config, _ = parse_rnn_layer(layer_dict, input_names, input_shapes, reader)
+        config.update(layer_config)
 
         return (config,)
 

--- a/hls4ml/converters/keras_v3/recurrent.py
+++ b/hls4ml/converters/keras_v3/recurrent.py
@@ -1,7 +1,7 @@
 import typing
 from collections.abc import Sequence
 
-from hls4ml.converters.keras.recurrent import parse_rnn_layer
+import numpy as np
 
 from ._base import KerasV3LayerHandler, register
 
@@ -9,8 +9,7 @@ if typing.TYPE_CHECKING:
     import keras
     from keras import KerasTensor
 
-rnn_layers = ['SimpleRNN', 'LSTM', 'GRU']
-weight_dict = {'kernel': 'weight', 'recurrent_kernel': 'recurrent_weight', 'bias': 'bias'}
+rnn_layers = ('SimpleRNN', 'LSTM', 'GRU')
 
 
 @register
@@ -27,29 +26,50 @@ class RecurentHandler(KerasV3LayerHandler):
         in_tensors: Sequence['KerasTensor'],
         out_tensors: Sequence['KerasTensor'],
     ):
-        import numpy as np
+        import keras
 
-        layer_config = layer.get_config()
-        layer_dict = {'config': layer_config, 'class_name': layer.__class__.__name__}
+        if layer.return_state:
+            raise Exception(f'return_state=True is not supported for {layer.__class__} layer.')
 
-        class IsolatedLayerReader:
-            def get_weights_data(self, layer_name, var_name):
-                assert layer_name == layer.name, f'Processing {layer.name}, but handler tried to read {layer_name}'
-                for w in layer.weights:
-                    if var_name in w.name:
-                        return np.array(w)
-                return None
+        config = {
+            'direction': 'forward',
+            'return_sequences': layer.return_sequences,
+            'return_state': layer.return_state,
+            'time_major': False,
+            'n_timesteps': in_tensors[0].shape[1],
+            'n_in': in_tensors[0].shape[2],
+            'n_out': layer.units,
+        }
 
-        reader = IsolatedLayerReader()
-        input_shapes = [list(t.shape) for t in in_tensors]
-        input_names = [t.name for t in in_tensors]
+        config['weight_data'] = self.load_weight(layer.cell, 'kernel')
+        config['recurrent_weight_data'] = self.load_weight(layer.cell, 'recurrent_kernel')
 
-        config = {}
-        config.update(self.default_config)
-        layer_config, _ = parse_rnn_layer(layer_dict, input_names, input_shapes, reader)
-        config.update(layer_config)
+        if layer.use_bias:
+            if isinstance(layer, keras.layers.GRU):
+                bias = self.load_weight(layer.cell, 'bias')
+                config['bias_data'] = bias[0]
+                config['recurrent_bias_data'] = bias[1]
+            else:
+                config['bias_data'] = self.load_weight(layer.cell, 'bias')
+        else:
+            d_out = config['weight_data'].shape[-1]
+            config['bias_data'] = np.zeros((d_out,), dtype=np.float32)
+            if isinstance(layer, keras.layers.GRU):
+                config['recurrent_bias_data'] = np.zeros((d_out,), dtype=np.float32)
 
-        return (config,)
+        if isinstance(layer, keras.layers.GRU):
+            config['apply_reset_gate'] = 'after' if layer.reset_after else 'before'
+
+        if hasattr(layer, 'activation'):
+            config['activation'] = layer.activation.__name__
+        if hasattr(layer, 'recurrent_activation'):
+            config['recurrent_activation'] = layer.recurrent_activation.__name__
+
+        _config = {}
+        _config.update(self.default_config)
+        _config.update(config)
+
+        return (_config,)
 
 
 @register
@@ -80,16 +100,14 @@ class BidirectionalHandler(KerasV3LayerHandler):
             assert class_name in rnn_layers or class_name[1:] in rnn_layers
 
         config = {}
-        config['name'] = layer.name
-        config['class_name'] = layer.__class__.__name__
 
         config['direction'] = 'bidirectional'
         config['return_sequences'] = layer.return_sequences
         config['return_state'] = layer.return_state
-        config['time_major'] = getattr(layer, 'time_major', False)
-        # TODO Should we handle time_major?
-        if config['time_major']:
-            raise Exception('Time-major format is not supported by hls4ml')
+        config['time_major'] = False
+
+        if config['return_state']:
+            raise Exception(f'return_state=True is not supported for {layer.__class__} layer.')
 
         config['n_timesteps'] = in_tensors[0].shape[1]
         config['n_in'] = in_tensors[0].shape[2]
@@ -101,27 +119,31 @@ class BidirectionalHandler(KerasV3LayerHandler):
             config[f'{direction}_class_name'] = rnn_layer.__class__.__name__
             if hasattr(rnn_layer, 'activation'):
                 config[f'{direction}_activation'] = rnn_layer.activation.__name__
-            if 'SimpleRNN' not in rnn_layer.__class__.__name__:
+            if hasattr(rnn_layer, 'recurrent_activation'):
                 config[f'{direction}_recurrent_activation'] = rnn_layer.recurrent_activation.__name__
 
-            config[f'{direction}_data_format'] = getattr(rnn_layer, 'data_format', 'channels_last')
-            if hasattr(rnn_layer, 'epsilon'):
-                config[f'{direction}_epsilon'] = rnn_layer.epsilon
+            # config[f'{direction}_data_format'] = getattr(rnn_layer, 'data_format', 'channels_last')
             if hasattr(rnn_layer, 'use_bias'):
                 config[f'{direction}_use_bias'] = rnn_layer.use_bias
 
-            for w in rnn_layer.weights:
-                name = w.name.replace('kernel', 'weight') if 'kernel' in w.name else w.name
-                config[f'{direction}_{name}_data'] = keras.ops.convert_to_numpy(w)
+            config[f'{direction}_weight_data'] = self.load_weight(rnn_layer.cell, 'kernel')
+            config[f'{direction}_recurrent_weight_data'] = self.load_weight(rnn_layer.cell, 'recurrent_kernel')
 
-            if 'GRU' in rnn_layer.__class__.__name__:
+            if rnn_layer.use_bias:
+                if isinstance(rnn_layer.cell, keras.layers.GRU):
+                    bias = self.load_weight(rnn_layer.cell, 'bias')
+                    config[f'{direction}_bias_data'] = bias[0]
+                    config[f'{direction}_recurrent_bias_data'] = bias[1]
+                else:
+                    config[f'{direction}_bias_data'] = self.load_weight(rnn_layer.cell, 'bias')
+            else:
+                d_out = config[f'{direction}_weight_data'].shape[-1]
+                config[f'{direction}_bias_data'] = np.zeros(d_out, dtype=np.float32)
+                if isinstance(rnn_layer, keras.layers.GRU):
+                    config[f'{direction}_recurrent_bias_data'] = np.zeros(d_out, dtype=np.float32)
+
+            if isinstance(rnn_layer, keras.layers.GRU):
                 config[f'{direction}_apply_reset_gate'] = 'after' if rnn_layer.reset_after else 'before'
-
-                # biases array is actually a 2-dim array of arrays (bias + recurrent bias)
-                # both arrays have shape: n_units * 3 (z, r, h_cand)
-                biases = config[f'{direction}_bias_data']
-                config[f'{direction}_bias_data'] = biases[0]
-                config[f'{direction}_recurrent_bias_data'] = biases[1]
 
             config[f'{direction}_n_states'] = rnn_layer.units
 
@@ -129,8 +151,5 @@ class BidirectionalHandler(KerasV3LayerHandler):
             config['n_out'] = config['forward_n_states'] + config['backward_n_states']
         else:
             config['n_out'] = config['forward_n_states']
-
-        if config['return_state']:
-            raise Exception('"return_state" of {} layer is not yet supported.')
 
         return config

--- a/hls4ml/converters/keras_v3_to_hls.py
+++ b/hls4ml/converters/keras_v3_to_hls.py
@@ -190,12 +190,9 @@ class KerasV3HandlerDispatcher:
         ret['input_keras_tensor_names'] = input_names
         ret = (ret,)
 
-        recurrent_layers = ['SimpleRNN', 'LSTM', 'GRU', 'QSimpleRNN', 'QLSTM', 'QGRU', 'Bidirectional']
         activation = getattr(layer, 'activation', None)
-        name = layer.name
-        class_name = layer.__class__.__name__
-        if activation not in (keras.activations.linear, None) and class_name not in recurrent_layers:
-            assert isinstance(activation, FunctionType), f'Activation function for layer {name} is not a function'
+        if activation not in (keras.activations.linear, None):
+            assert isinstance(activation, FunctionType), f'Activation function for layer {layer.name} is not a function'
             intermediate_tensor_name = f'{output_names[0]}_activation'
             ret[0]['output_keras_tensor_names'] = (intermediate_tensor_name,)
             act_cls_name = activation.__name__


### PR DESCRIPTION
# Description

This Pull request introduces a parser for recurrent layers in Keras V3, improving the style of the solution implemented in #1310.
Using this new class, it is possible to correctly parse the layers without introducing exceptions for specific layers in [keras_v3_to_hls.py](https://github.com/fastmachinelearning/hls4ml/blob/main/hls4ml/converters/keras_v3_to_hls.py#L197)  
 
## Type of change

- [X] Other: Style improvement

## Tests

This change was tested using unit test in `test/pytest/test_rnn.py`.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
