### PR TITLE
remove warning print in oneapi report

### DIFF
--- a/hls4ml/report/oneapi_report.py
+++ b/hls4ml/report/oneapi_report.py
@@ -23,7 +23,6 @@ def _find_projects(hls_dir):
     prjList = glob.glob(os.path.join(hls_dir, '**/*.prj'))
 
     if not prjList:
-        print('No project folders found in target directory!')
         return
 
     if len(prjList) > 1:


### PR DESCRIPTION
# Description

After merging #1340, we inadvertently got a 'No project folders found in target directory!' warning when compiling the library for `hls_model.predict(X)` functionality. There are many ways to make that not appear, but I think this is the simplest, and I do not think it removes too much information if we run into errors in other cases. But let me know if you prefer a different change.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

None really, though one could look at the pytests output log to see the change.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
