### PR TITLE
Fix missing return statement in time distributed parser

### DIFF
--- a/hls4ml/converters/keras/recurrent.py
+++ b/hls4ml/converters/keras/recurrent.py
@@ -110,6 +110,7 @@ def parse_time_distributed_layer(keras_layer, input_names, input_shapes, data_re
     layer['output_shape'] = output_shape[1:]  # Remove the batch dimension
     layer['n_time_steps'] = output_shape[1]
 
+    return layer, output_shape
 
 @keras_handler('Bidirectional')
 def parse_bidirectional_layer(keras_layer, input_names, input_shapes, data_reader):


### PR DESCRIPTION
In https://github.com/fastmachinelearning/hls4ml/pull/1310 the `parse_time_distributed_layer` function in the keras V2 parser had it's return statement amputated. This was hidden in the pytests by the clone stream test handing in oneAPI, but it now was revealed in the pytests of https://github.com/fastmachinelearning/hls4ml/pull/1306 where Jovan is fixing those issues. This PR simply fixes that. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Time distributed pytests fail currently, work with this fix. 

## Checklist

All good. 
