### PR TITLE
Fix stream cloning for oneAPI and reshape handling for pytorch

### DIFF
--- a/hls4ml/backends/fpga/passes/repack_stream.py
+++ b/hls4ml/backends/fpga/passes/repack_stream.py
@@ -51,7 +51,7 @@ class ReshapeStream(OptimizerPass):
         # do not run optimizer pass for a flatten layer (1 output dimension)
         if not isinstance(node, Reshape):
             return False
-        return len(node.get_output_variable().shape) > 1 or node.name in node.model.outputs
+        return len(node.get_output_variable().shape) > 1 or node.outputs[0] in node.model.outputs
 
     def transform(self, model, node):
         if model.config.get_config_value('IOType') != 'io_stream':

--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -26,6 +26,9 @@ def parse_reshape_layer(operation, layer_name, input_names, input_shapes, node, 
                 cl.remove(-1)
                 layer['target_shape'][i] = int(size / np.prod(cl))
 
+    # remove the batch dimension
+    layer['target_shape'] = layer['target_shape'][1:]
+
     output_shape = input_shapes[0][:1] + layer['target_shape']
 
     return layer, output_shape

--- a/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_stream.h
+++ b/hls4ml/templates/oneapi/firmware/nnet_utils/nnet_stream.h
@@ -211,7 +211,7 @@ CloneLoop:
         res4_pipe::write(out_data4);
         res5_pipe::write(out_data5);
         res6_pipe::write(out_data6);
-        res6_pipe::write(out_data7);
+        res7_pipe::write(out_data7);
     }
 }
 

--- a/test/pytest/test_pytorch_api.py
+++ b/test/pytest/test_pytorch_api.py
@@ -867,12 +867,7 @@ def test_view(backend, io_type):
 
     hls_model.compile()
 
-    # reshape hls prediction to channels last, then transpose, then reshape
-    # to match .view
-    hls_prediction = np.reshape(
-        np.transpose(np.reshape(hls_model.predict(X_input), (n_batch, size_in, n_out)), (0, 2, 1)),
-        (n_batch, size_in * n_out),
-    )
+    hls_prediction = hls_model.predict(X_input)
 
     rtol = 0
     atol = 5.0e-2


### PR DESCRIPTION
# Description

This is a replacement of #1306, incorporating the bug fixes, but backing out removing the sizes. I think we do actually need to pass the size.

The bug fixes that are included here are:

- For oneAPI when cloning 7 streams, previously the data meant for the 7th stream was sent to the 6th stream.
- The multi-clone test would have random mismatches. This makes it more stable.
- The handling of reshape (`view`) for PyTorch did not handle the batch dimension correctly.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

The existing tests should verify that this works. Without this some fail.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
