### PR TITLE
Remove ac_float from oneAPI and throw exception if used

### DIFF
--- a/hls4ml/backends/oneapi/oneapi_backend.py
+++ b/hls4ml/backends/oneapi/oneapi_backend.py
@@ -79,6 +79,7 @@ class OneAPIBackend(FPGABackend):
             'oneapi:fix_softmax_table_size',
             'infer_precision_types',
             'oneapi:process_fixed_point_quantizer_layer',
+            'oneapi:validate_ac_types',
         ]
         optimization_flow = register_flow('optimize', optimization_passes, requires=[init_flow], backend=self.name)
 

--- a/hls4ml/backends/oneapi/passes/feature_check.py
+++ b/hls4ml/backends/oneapi/passes/feature_check.py
@@ -1,0 +1,13 @@
+from hls4ml.model.optimizer import OptimizerPass
+from hls4ml.model.types import FloatPrecisionType
+
+
+class ValidateAcTypes(OptimizerPass):
+    def match(self, node):
+        return True
+
+    def transform(self, model, node):
+        prec_types = [prec_type.precision for prec_type in node.get_layer_precision().values()]
+        prec_types = [prec_type for prec_type in prec_types if isinstance(prec_type, FloatPrecisionType)]
+        if len(prec_types) > 0:
+            raise Exception(f'Layer "{node.name}" uses ac_float types that are not supported in oneAPI')

--- a/hls4ml/templates/oneapi/firmware/defines.h
+++ b/hls4ml/templates/oneapi/firmware/defines.h
@@ -2,7 +2,6 @@
 #define DEFINES_H_
 
 #include <sycl/ext/intel/ac_types/ac_fixed.hpp>
-#include <sycl/ext/intel/ac_types/ac_float.hpp>
 #include <sycl/ext/intel/ac_types/ac_int.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
ac_float seems not to be available in oneAPI. This PR remove the offending include and throws an exception if ac_float is tried to be used with the oneAPI backend. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Tests

Fixes failures of oneAPI pytests. Also tested that the exception is thrown when using ap_float with oneAPI. 

**Test Configuration**:

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
