### PR TITLE
Fixing Assertion error when reshape follows Input layer in HGQ models

### DIFF
--- a/hls4ml/model/optimizer/__init__.py
+++ b/hls4ml/model/optimizer/__init__.py
@@ -73,6 +73,7 @@ register_flow(
         'fuse_batch_normalization',
         'replace_multidimensional_dense_with_conv',
         'enforce_proxy_model_embedded_config',
+        'absorb_reshape_into_input',
         'bit_exact',
         'fuse_fixed_point_quantizer',
         'fix_input_precision',

--- a/hls4ml/model/optimizer/passes/absorb_reshape.py
+++ b/hls4ml/model/optimizer/passes/absorb_reshape.py
@@ -1,0 +1,28 @@
+from hls4ml.model.layers import Input, Reshape
+from hls4ml.model.optimizer import OptimizerPass
+
+
+class AbsorbReshapeIntoInput(OptimizerPass):
+    def match(self, node):
+        # Looking for a Reshape layer whose input is an Input layer
+        if isinstance(node, Reshape):
+            inp_node = node.get_input_node()
+            if isinstance(inp_node, Input):
+                return True
+        return False
+
+    def transform(self, model, node):
+        # node == Reshape layer that matched
+        inp_node = node.get_input_node()
+        out_nodes = node.get_output_nodes()
+        if len(out_nodes) > 1:
+            raise Exception('Reshape node has multiple outputs')
+
+        target_shape = node.get_attr('target_shape')
+
+        input_output_var = inp_node.get_output_variable()
+        input_output_var.shape = target_shape
+
+        model.remove_node(node)
+
+        return True  # because we modified the graph


### PR DESCRIPTION
# Description
Fixes #1364
> :memo: Summary of the change
>
> * Added a new optimizer pass that modifies the model graph, effectively connecting the input node of reshape node to the output node.
> * This is to fix the assertion error when reshape follows input layer in Highly granular quantization (HGQ) models

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

> :memo: Details to reproduce the error mentioned in Issue: [https://github.com/fastmachinelearning/hls4ml/issues/1364](#1364)

**Test Configuration**:

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
