### PR TITLE
Allow reshape/transpose after inputs for hgq2

### DIFF
--- a/hls4ml/converters/keras_v3/merge.py
+++ b/hls4ml/converters/keras_v3/merge.py
@@ -39,7 +39,8 @@ class MergeHandler(KerasV3LayerHandler):
         match cls_name:
             case 'Concatenate':
                 rank = len(output_shape)
-                class_name = f'Concatenate{rank}d'
+                class_name = 'Concatenate'
+                op = f'Concatenate{rank}d'
                 config['axis'] = layer.axis
             case 'Dot':
                 msg = (

--- a/hls4ml/model/optimizer/passes/hgq_proxy_model.py
+++ b/hls4ml/model/optimizer/passes/hgq_proxy_model.py
@@ -6,7 +6,7 @@ from warnings import warn
 import numpy as np
 
 from hls4ml.model.attributes import Attribute, TypeAttribute, WeightAttribute
-from hls4ml.model.layers import Activation, Layer, Reshape, register_layer
+from hls4ml.model.layers import Activation, Layer, Reshape, Transpose, register_layer
 from hls4ml.model.optimizer import OptimizerPass, register_pass
 from hls4ml.model.types import FixedPrecisionType, UnspecifiedPrecisionType
 
@@ -100,7 +100,7 @@ class FuseFixedPointQuantizer(OptimizerPass):
         node.attributes['result_t'].precision = precision
         node.attributes['_result_t_propagated'] = True
 
-        if not isinstance(node, Reshape):
+        if not isinstance(node, (Reshape, Transpose)):
             return node
 
         inp_layer = get_input_layers(node)[0]


### PR DESCRIPTION
# Description

Allows any number of reshape / flatten / concatenate after the input before quantizers for hgq2 models.

On top of and includes #1338, fixes #1364, supersedes #1365

## Type of change

- [x] mitigation for unexpected edge cases 

## Tests

n/a

**Test Configuration**:

- [x] all