### PR TITLE
use int16 instead

### DIFF
--- a/hls4ml/backends/vivado/passes/distributed_arithmetic.py
+++ b/hls4ml/backends/vivado/passes/distributed_arithmetic.py
@@ -40,8 +40,8 @@ def _get_input_kif(node: Layer):
         Is, Fs = _Is - Ks, _Bs - _Is
         Ks, Is, Fs = Ks[0], Is[0], Fs[0]  # remove batch dimension
     else:
-        Ks = np.ones(inp_shape, dtype=np.int8)
-        Is = Fs = np.full(inp_shape, 126, dtype=np.int8)
+        Ks = np.ones(inp_shape, dtype=np.int16)
+        Is = Fs = np.full(inp_shape, 126, dtype=np.int16)
 
     _k, _B, _I = result_t.signed, result_t.width, result_t.integer
     _k, _i, _f = _k, _I - _k, _B - _I

--- a/hls4ml/converters/keras_v3/hgq2/_base.py
+++ b/hls4ml/converters/keras_v3/hgq2/_base.py
@@ -29,9 +29,9 @@ def extract_fixed_quantizer_config(q, tensor: 'KerasTensor', is_input: bool) -> 
     k, B, I = ops.convert_to_numpy(k), ops.convert_to_numpy(B), ops.convert_to_numpy(I)  # noqa: E741
     I = np.where(B > 0, I, 0)  # noqa: E741 # type: ignore
 
-    k = np.broadcast_to(k.astype(np.int8), (1,) + shape)  # type: ignore
-    B = np.broadcast_to(B.astype(np.int8), (1,) + shape)  # type: ignore
-    I = np.broadcast_to(I.astype(np.int8), (1,) + shape)  # noqa: E741
+    k = np.broadcast_to(k.astype(np.int16), (1,) + shape)  # type: ignore
+    B = np.broadcast_to(B.astype(np.int16), (1,) + shape)  # type: ignore
+    I = np.broadcast_to(I.astype(np.int16), (1,) + shape)  # noqa: E741
 
     overflow_mode: str = internal_q.overflow_mode
     round_mode: str = internal_q.round_mode

--- a/hls4ml/utils/qinterval.py
+++ b/hls4ml/utils/qinterval.py
@@ -9,7 +9,7 @@ from hls4ml.utils.einsum_utils import EinsumRecipe, parse_einsum
 
 
 def _minimal_f(array: np.ndarray):
-    _low, _high = np.full(array.shape, -32, dtype=np.int8), np.full(array.shape, 32, dtype=np.int8)
+    _low, _high = np.full(array.shape, -32, dtype=np.int16), np.full(array.shape, 32, dtype=np.int16)
     while np.any(_low < _high - 1):
         _mid = (_low + _high) // 2
         scaled = array * 2.0**_mid
@@ -32,7 +32,7 @@ def minimal_kif(array: np.ndarray):
     """
     f = _minimal_f(array)
     with np.errstate(divide='ignore', invalid='ignore'):
-        i = np.ceil(np.log2(np.maximum(array + 2.0**-f, -array))).astype(np.int8)
+        i = np.ceil(np.log2(np.maximum(array + 2.0**-f, -array))).astype(np.int16)
     k = array < 0
     null_mask = array == 0
     i, f = np.where(null_mask, 0, i), np.where(null_mask, 0, f)
@@ -234,10 +234,10 @@ class QIntervalArray(_QIntervalArray):
         return v
 
     def to_kif(self):
-        f = -np.log2(self.delta).astype(np.int8)
+        f = -np.log2(self.delta).astype(np.int16)
 
         with np.errstate(divide='ignore', invalid='ignore'):
-            i = np.ceil(np.log2(np.maximum(self.max + 2.0**-f, -self.min))).astype(np.int8)
+            i = np.ceil(np.log2(np.maximum(self.max + 2.0**-f, -self.min))).astype(np.int16)
         k = self.min < 0
         null_mask = (self.max == 0) & (self.min == 0)
         i, f = np.where(null_mask, 0, i), np.where(null_mask, 0, f)


### PR DESCRIPTION
# Description

Fix weird corner cases where bitwidth overflows in `bit_exact` flow. 

The issue can only be trigger by an ill-defined model. However, as the overflows masks the correct error message, users may be confused.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] all