### PR TITLE
rm fxpmath dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dynamic = [ "version" ]
-dependencies = [ "fxpmath", "h5py", "numpy", "pydigitalwavetools==1.1", "pyyaml", "quantizers" ]
+dependencies = [ "h5py", "numpy", "pydigitalwavetools==1.1", "pyyaml", "quantizers" ]
 
 optional-dependencies.da = [ "da4ml>=0.2.1,<=0.4" ]
 optional-dependencies.doc = [

--- a/test/pytest/test_auto_precision.py
+++ b/test/pytest/test_auto_precision.py
@@ -261,10 +261,10 @@ def test_auto_precision_dense(keras_model_dense, data_1d, io_type, backend):
     "val, expected_width",
     [
         (0, 1),
-        (-1024, 2),
+        (-1024, 1),
         (1024, 1),
         (0.03125, 1),
-        (-0.03125, 2),
+        (-0.03125, 1),
         (1.25, 3),
         (-1.25, 4),
         (1.1, 8),


### PR DESCRIPTION
# Description

Remove dependency of #1139 on fxpmath, which generates a warning when pip installing for using outdated `setup.cfg`.

## Type of change

- [x] Housekeeping

## Tests

Inherits from #1139

## Checklist

- [x] all