### PR TITLE
Fix typo in extension documentation 

### DIFF
--- a/docs/advanced/extension.rst
+++ b/docs/advanced/extension.rst
@@ -55,7 +55,7 @@ We can define the equivalent layer in hls4ml ``HReverse``, which inherits from `
 
 A parser for the Keras to HLS converter is also required.
 This parser reads the attributes of the Keras layer instance and populates a dictionary of attributes for the hls4ml layer.
-It also returns a list of output shapes (one sjape for each output).
+It also returns a list of output shapes (one shape for each output).
 In this case, there a single output with the same shape as the input.
 
 .. code-block:: Python


### PR DESCRIPTION
# Description

Fixed a small typo in docs.

## Type of change

- [x] Documentation update

## Tests

No code changes were made.

**Test Configuration**:

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
