### PR TITLE
Avoid layer with name `out_something` crashing conversion

### DIFF
--- a/hls4ml/model/attributes.py
+++ b/hls4ml/model/attributes.py
@@ -175,7 +175,7 @@ class AttributeDict(MutableMapping):
             self.layer.model.register_output_variable(key, value)
             self.attributes['result_t'] = value.type
             if key in self._expected_attributes and key in self.layer.outputs:
-                key = 'out_' + key
+                key = '__hls4ml_reserved_out_' + key
         elif isinstance(value, WeightVariable):
             self.attributes[key + '_t'] = value.type
 
@@ -229,16 +229,16 @@ class VariableMapping(AttributeMapping):
         super().__init__(attributes, TensorVariable)
 
     def __getitem__(self, key):
-        if 'out_' + key in self.attributes:
-            return self.attributes['out_' + key]
+        if '__hls4ml_reserved_out_' + key in self.attributes:
+            return self.attributes['__hls4ml_reserved_out_' + key]
         else:
             return self.attributes[key]
 
     def __iter__(self):
         precision_keys = [k for k, v in self.attributes.items() if isinstance(v, self.clazz)]
         for key in precision_keys:
-            if key.startswith('out_'):
-                yield key[len('out_') :]
+            if key.startswith('__hls4ml_reserved_out_'):
+                yield key[len('__hls4ml_reserved_out_') :]
             else:
                 yield key
         super().__iter__()


### PR DESCRIPTION
# Description

Currently, if a layer is named `out_something`, the generated firmware will be unsynthesizable due to a naming conflict. The program checks for the prefix `out_` for special variables, which was unprotected and may come from user defined layer names and let the writer writing the same definition twice (`out_something` and `something` will be two keys in attrs, but `VariableMapping` strips off the `out_` prefix and the writer iterates twice on it) 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests


## Checklist

- [x] all
