### PR TITLE
Backend predict hook

### DIFF
--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -913,7 +913,7 @@ class ModelGraph(Serializable):
             return backend.predict(self, x, *args, **kwargs)
 
         return self._predict(x)
-        
+
     def trace(self, x):
         print(f'Recompiling {self.config.get_project_name()} with tracing')
         self.config.trace_output = True


### PR DESCRIPTION
Move the existing C-simulation logic into an internal `_predict()` method and update the public `predict()` API to optionally dispatch to a backend-provided `predict()` implementation. For example, this might be useful for external backends (e.g., AIE) to implement accelerator-specific execution while preserving the standard hls4ml prediction interface.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- yes all
