### PR TITLE
Bump upload-artifact version

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build SDist and Wheel
       run: pipx run build --sdist --wheel
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         path: dist/*.*
 

--- a/.github/workflows/test-sphinx.yml
+++ b/.github/workflows/test-sphinx.yml
@@ -22,6 +22,6 @@ jobs:
       with:
         pre-build-command: "git config --system --add safe.directory '*'"
         docs-folder: "docs/"
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         path: docs/_build/html


### PR DESCRIPTION
Replacement for #1410, which is once again breaking the mirroring to gitlab...