### PR TITLE
allow partial config def

### DIFF
--- a/hls4ml/converters/__init__.py
+++ b/hls4ml/converters/__init__.py
@@ -152,7 +152,7 @@ def _check_hls_config(config, hls_config):
 
 def _check_model_config(model_config):
     model_config = model_config or {}
-    model_config.setdefault('Precision', 'ap_fixed<16,6>')
+    model_config.setdefault('Precision', 'fixed<16,6>')
     model_config.setdefault('ReuseFactor', 1)
     return model_config
 


### PR DESCRIPTION
# Description

This PR allows partial definition of `hls_config` without explicit `Precision` and `ReuseFactor` when not needed; they will take the same default values when no config is passed.

## Type of change

- [x] chore

## Tests

n/a

## Checklist

- [x] all