### PR TITLE
vivado/vitis support sample broadcasting merge ops

### DIFF
--- a/hls4ml/backends/vivado/passes/merge_templates.py
+++ b/hls4ml/backends/vivado/passes/merge_templates.py
@@ -5,6 +5,7 @@ from hls4ml.model.layers import Concatenate, Dot, Merge
 # Merge templates
 
 merge_config_template = """struct config{index} : nnet::merge_config {{
+    static const unsigned n_elem = {n_elem};
     static const unsigned n_elem1 = {n_elem1};
     static const unsigned n_elem2 = {n_elem2};
     static const unsigned reuse_factor = {reuse};
@@ -24,7 +25,10 @@ class MergeConfigTemplate(LayerConfigTemplate):
         params = self._default_config_params(node)
         params['n_elem1'] = node.get_input_variable(node.inputs[0]).size_cpp()
         params['n_elem2'] = node.get_input_variable(node.inputs[1]).size_cpp()
-
+        params['n_elem'] = max(params['n_elem1'], params['n_elem2'])
+        io_type = node.model.config.get_config_value('IOType')
+        if io_type != 'io_parallel':
+            assert params['n_elem1'] == params['n_elem2'], 'broadcasting merge not supported non-io_parallel'
         return self.template.format(**params)
 
 

--- a/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_merge.h
@@ -35,52 +35,46 @@ struct concat_config {
 };
 
 template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void add(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem]) {
+void add(input1_T data1[CONFIG_T::n_elem1], input2_T data2[CONFIG_T::n_elem2], res_T res[CONFIG_T::n_elem]) {
     #pragma HLS PIPELINE
 
-    const unsigned n_elem = CONFIG_T::n_elem1 > CONFIG_T::n_elem2 ? CONFIG_T::n_elem1 : CONFIG_T::n_elem2;
-    for (int ii = 0; ii < n_elem; ii++) {
+    for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
         res[ii] = data1[ii % CONFIG_T::n_elem1] + data2[ii % CONFIG_T::n_elem2];
     }
 }
 
 template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void subtract(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem]) {
+void subtract(input1_T data1[CONFIG_T::n_elem1], input2_T data2[CONFIG_T::n_elem2], res_T res[CONFIG_T::n_elem]) {
     #pragma HLS PIPELINE
 
-    const unsigned n_elem = CONFIG_T::n_elem1 > CONFIG_T::n_elem2 ? CONFIG_T::n_elem1 : CONFIG_T::n_elem2;
     for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
         res[ii] = data1[ii % CONFIG_T::n_elem1] - data2[ii % CONFIG_T::n_elem2];
     }
 }
 
 template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void multiply(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem]) {
+void multiply(input1_T data1[CONFIG_T::n_elem1], input2_T data2[CONFIG_T::n_elem2], res_T res[CONFIG_T::n_elem]) {
     #pragma HLS PIPELINE
 
-    const unsigned n_elem = CONFIG_T::n_elem1 > CONFIG_T::n_elem2 ? CONFIG_T::n_elem1 : CONFIG_T::n_elem2;
     for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
         res[ii] = data1[ii % CONFIG_T::n_elem1] * data2[ii % CONFIG_T::n_elem2];
     }
 }
 
 template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void average(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem]) {
+void average(input1_T data1[CONFIG_T::n_elem1], input2_T data2[CONFIG_T::n_elem2], res_T res[CONFIG_T::n_elem]) {
     #pragma HLS PIPELINE
 
-    const unsigned n_elem = CONFIG_T::n_elem1 > CONFIG_T::n_elem2 ? CONFIG_T::n_elem1 : CONFIG_T::n_elem2;
     for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
         res[ii] = (data1[ii % CONFIG_T::n_elem1] + data2[ii % CONFIG_T::n_elem2]) * ap_ufixed<1, 0>(0.5);
     }
 }
 
 template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void maximum(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem]) {
+void maximum(input1_T data1[CONFIG_T::n_elem1], input2_T data2[CONFIG_T::n_elem2], res_T res[CONFIG_T::n_elem]) {
     #pragma HLS PIPELINE
 
-    const unsigned n_elem = CONFIG_T::n_elem1 > CONFIG_T::n_elem2 ? CONFIG_T::n_elem1 : CONFIG_T::n_elem2;
     for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
-
         res[ii] = (data1[ii % CONFIG_T::n_elem1] > data2[ii % CONFIG_T::n_elem2])
                       ? static_cast<res_T>(data1[ii % CONFIG_T::n_elem1])
                       : static_cast<res_T>(data2[ii % CONFIG_T::n_elem2]);
@@ -88,9 +82,9 @@ void maximum(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem],
 }
 
 template <class input1_T, class input2_T, class res_T, typename CONFIG_T>
-void minimum(input1_T data1[CONFIG_T::n_elem], input2_T data2[CONFIG_T::n_elem], res_T res[CONFIG_T::n_elem]) {
+void minimum(input1_T data1[CONFIG_T::n_elem1], input2_T data2[CONFIG_T::n_elem2], res_T res[CONFIG_T::n_elem]) {
     #pragma HLS PIPELINE
-    const unsigned n_elem = CONFIG_T::n_elem1 > CONFIG_T::n_elem2 ? CONFIG_T::n_elem1 : CONFIG_T::n_elem2;
+
     for (int ii = 0; ii < CONFIG_T::n_elem; ii++) {
         res[ii] = (data1[ii % CONFIG_T::n_elem1] < data2[ii % CONFIG_T::n_elem2])
                       ? static_cast<res_T>(data1[ii % CONFIG_T::n_elem1])


### PR DESCRIPTION
# Description

Allow add/subtract/mul/avg/... between tensors of shape `(a, b, c)` and `(1, c)` or `(c,)` or `(1, b, c)` (must match the last dimensions) in vivado/vitis backends. Illegal operations still fail silently like what they do now.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Tests


## Checklist

- [x] all
