### PR TITLE
Uniform test root path

### DIFF
--- a/test/pytest/test_keras_v3_api.py
+++ b/test/pytest/test_keras_v3_api.py
@@ -498,7 +498,7 @@ def test_reused_layer(backend, io_type):
     _ = model([inp1, inp1])
 
     hls_config = {'Model': {'Precision': 'ap_fixed<32,8>', 'ReuseFactor': 1}}
-    output_dir = str(test_root_path / f'hls4mlprj_keras_v3_api_conv1d_{backend}_{io_type}')
+    output_dir = str(test_root_path / f'hls4mlprj_keras_v3_api_reused_{backend}_{io_type}')
 
     model_hls = hls4ml.converters.convert_from_keras_model(
         model, backend=backend, io_type=io_type, hls_config=hls_config, output_dir=output_dir


### PR DESCRIPTION
# Description

The keras v3 api tests currently put all the results in the `/tmp` directory, unlike every other test. This PR just makes it uniform,  putting the results in `Path(__file__).parent`.

I also added v3 to the folder name to not conflict with the v2 versions of the tests.

## Type of change

- [x] Other (Specify) - housekeeping

## Tests


**Test Configuration**:

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
