### PR TITLE
Add input layer to profiling plots (fixes #404)

### DIFF
--- a/test/pytest/test_profiling_input_layer.py
+++ b/test/pytest/test_profiling_input_layer.py
@@ -1,0 +1,140 @@
+"""Tests for input layer inclusion in profiling plots (Issue #404).
+
+Verifies that profiling activations include the distribution of input data
+and that activation type overlays cover input variable precisions.
+"""
+
+import numpy as np
+import pytest
+
+keras = pytest.importorskip('keras')
+
+import hls4ml  # noqa: E402
+from hls4ml.model.profiling import (  # noqa: E402
+    _normalize_input_data,
+    activation_types_hlsmodel,
+    activations_keras,
+)
+
+# ---------------------------------------------------------------------------
+# Tests for _normalize_input_data helper
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeInputData:
+    """Tests for the private _normalize_input_data helper."""
+
+    def test_single_ndarray(self):
+        X = np.random.rand(10, 5)
+        result = _normalize_input_data(X, ['my_input'])
+        assert len(result) == 1
+        assert result[0][0] == 'my_input'
+        np.testing.assert_array_equal(result[0][1], X)
+
+    def test_list_of_ndarrays(self):
+        a, b = np.random.rand(10, 5), np.random.rand(10, 3)
+        result = _normalize_input_data([a, b], ['in1', 'in2'])
+        assert len(result) == 2
+        assert result[0][0] == 'in1'
+        assert result[1][0] == 'in2'
+        np.testing.assert_array_equal(result[0][1], a)
+        np.testing.assert_array_equal(result[1][1], b)
+
+    def test_dict_of_ndarrays(self):
+        a, b = np.random.rand(10, 5), np.random.rand(10, 3)
+        X = {'in1': a, 'in2': b}
+        result = _normalize_input_data(X, ['in1', 'in2'])
+        assert len(result) == 2
+        assert result[0][0] == 'in1'
+        assert result[1][0] == 'in2'
+        np.testing.assert_array_equal(result[0][1], a)
+        np.testing.assert_array_equal(result[1][1], b)
+
+    def test_dict_respects_input_names_order(self):
+        """Keys present in input_names but missing from X are skipped."""
+        a = np.random.rand(10, 5)
+        result = _normalize_input_data({'in1': a}, ['in1', 'in2'])
+        assert len(result) == 1
+        assert result[0][0] == 'in1'
+
+
+# ---------------------------------------------------------------------------
+# Tests for activations_keras including input distribution
+# ---------------------------------------------------------------------------
+
+
+class TestActivationsKerasIncludesInput:
+    """activations_keras must prepend the input distribution."""
+
+    def test_input_in_summary_format(self):
+        inputs = keras.Input(shape=(10,), name='fc1_input')
+        x = keras.layers.Dense(5, name='dense1')(inputs)
+        model = keras.Model(inputs=inputs, outputs=x)
+
+        X = np.random.rand(50, 10).astype(np.float32) + 0.1
+
+        data = activations_keras(model, X, fmt='summary', plot='boxplot')
+        weights = [entry['weight'] for entry in data]
+
+        assert 'fc1_input' in weights, 'Input distribution missing from activations'
+        assert weights[0] == 'fc1_input', 'Input should be the first entry'
+
+    def test_input_in_longform_format(self):
+        inputs = keras.Input(shape=(10,), name='fc1_input')
+        x = keras.layers.Dense(5, name='dense1')(inputs)
+        model = keras.Model(inputs=inputs, outputs=x)
+
+        X = np.random.rand(50, 10).astype(np.float32) + 0.1
+
+        data = activations_keras(model, X, fmt='longform', plot='boxplot')
+        unique_weights = list(dict.fromkeys(data['weight'].tolist()))
+
+        assert 'fc1_input' in unique_weights, 'Input distribution missing from longform activations'
+        assert unique_weights[0] == 'fc1_input', 'Input should appear first in longform data'
+
+
+# ---------------------------------------------------------------------------
+# Tests for activation_types_hlsmodel including input variable types
+# ---------------------------------------------------------------------------
+
+
+class TestActivationTypesIncludesInput:
+    """activation_types_hlsmodel must include input variable precisions."""
+
+    def test_input_type_present(self, tmp_path):
+        inputs = keras.Input(shape=(10,), name='fc1_input')
+        x = keras.layers.Dense(5, name='dense1')(inputs)
+        model = keras.Model(inputs=inputs, outputs=x)
+
+        config = hls4ml.utils.config_from_keras_model(model, granularity='name')
+        hls_model = hls4ml.converters.convert_from_keras_model(
+            model,
+            hls_config=config,
+            output_dir=str(tmp_path / 'hls4ml_prj'),
+            backend='Vivado',
+        )
+
+        types_df = activation_types_hlsmodel(hls_model)
+
+        assert 'fc1_input' in types_df['layer'].values, 'Input variable type missing from activation_types_hlsmodel'
+
+    def test_input_type_has_valid_range(self, tmp_path):
+        """The input type row should have finite low/high bounds."""
+        inputs = keras.Input(shape=(10,), name='fc1_input')
+        x = keras.layers.Dense(5, name='dense1')(inputs)
+        model = keras.Model(inputs=inputs, outputs=x)
+
+        config = hls4ml.utils.config_from_keras_model(model, granularity='name')
+        hls_model = hls4ml.converters.convert_from_keras_model(
+            model,
+            hls_config=config,
+            output_dir=str(tmp_path / 'hls4ml_prj'),
+            backend='Vivado',
+        )
+
+        types_df = activation_types_hlsmodel(hls_model)
+        input_row = types_df[types_df['layer'] == 'fc1_input']
+
+        assert len(input_row) == 1, 'Expected exactly one row for fc1_input'
+        assert np.isfinite(input_row['low'].iloc[0])
+        assert np.isfinite(input_row['high'].iloc[0])


### PR DESCRIPTION
# Description

Fixes #404 by including input layer distribution and precision overlay in profiling plots.

**Problem:** Profiling plots showed all layers except the input. The `activations_keras`, `activations_torch`, and `activations_hlsmodel` functions all skipped input data, and `activation_types_hlsmodel` had no input tick label to anchor the type overlay to.

**Solution:** Added two private helper functions (`_normalize_input_data` and `_add_input_distributions`) and updated four existing functions to prepend input distributions before processing layer activations. The type overlay now explicitly includes input variable precisions from `model.get_input_variables()`.

**Dependencies:** None - uses existing numpy operations and follows the same vectorized pattern as existing layer processing.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Implementation Details

### New helpers

```python
def _normalize_input_data(X, input_names):
    """Return list of (name, ndarray) pairs from X, respecting input_names order."""
    if isinstance(X, dict):
        return [(n, np.asarray(X[n])) for n in input_names if n in X]
    if isinstance(X, (list, tuple)):
        return [(n, np.asarray(a)) for n, a in zip(input_names, X)]
    return [(input_names[0], np.asarray(X))]


def _add_input_distributions(data, X, input_names, fmt='longform', plot='boxplot'):
    """Prepend input-data distribution entries to *data* (modified in place)."""
    for name, arr in _normalize_input_data(X, input_names):
        print(f'   {name}')
        y = arr.flatten()
        y = abs(y[y != 0])  # Same pattern as existing layer processing
        if len(y) == 0:
            print(f'Input data for {name} contains only zeros, ignoring.')
            continue
        if fmt == 'longform':
            data['x'].extend(y.tolist())
            data['weight'].extend([name] * len(y))
        elif fmt == 'summary':
            data.append(array_to_summary(y, fmt=plot))
            data[-1]['weight'] = name
```

### Updated functions

**`activations_keras`**: Prepends input distribution by collecting `InputLayer` names
```python
input_names = [layer.name for layer in model.layers if isinstance(layer, keras.layers.InputLayer)]
if input_names:
    _add_input_distributions(data, X, input_names, fmt=fmt, plot=plot)
```

**`activations_torch`**: Prepends input distribution before converting X to tensor

**`activations_hlsmodel`**: Prepends input distribution and handles multi-input X formats (ndarray/list/dict) for trace

**`activation_types_hlsmodel`**: Explicitly adds input variable precisions with O(1) duplicate checking
```python
input_var_names = set()
for input_var in model.get_input_variables():
    T = input_var.type.precision
    W, I, F, S = ap_fixed_WIFS(T)
    data['layer'].append(input_var.name)
    data['low'].append(-F)
    data['high'].append(I - 1 if S else I)
    input_var_names.add(input_var.name)

for layer in model.get_layers():
    if layer.name in input_var_names:
        continue  # Skip duplicates
    # ... rest unchanged
```

### Why the ordering works

`boxplot(fmt='summary')` calls `data.reverse()` before plotting. Input entries are prepended first, so after reversal they appear at the top (highest y-position). Type overlay matches by layer name, so both the distribution tick and precision rectangle align automatically.

## Tests

**New tests** (`test/pytest/test_profiling_input_layer.py`):
- Unit tests for `_normalize_input_data` helper (single input, multi-input list, multi-input dict)
- Integration tests for `activations_keras` (summary and longform formats)
- Integration tests for `activation_types_hlsmodel` (presence and valid precision bounds)

**Test execution:**
```bash
# New tests (8 tests)
pytest test/pytest/test_profiling_input_layer.py -v
# Result: 8 passed in 2.38s

# Existing profiling tests (32 tests)
pytest test/pytest/test_keras_v3_profiling.py test/pytest/test_pytorch_profiler.py -v
# Result: 32 passed, 1 skipped (pre-existing), 0 regressions
```

**Test Configuration**:
- Python 3.12.12
- pytest 9.0.2
- keras 3.10+
- torch 2.10.0
- tensorflow 2.19.1
- All tests run with `-p no:randomly` to avoid unrelated qonnx seed issues

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Additional Notes

- **No breaking changes**: All public function signatures unchanged
- **No new dependencies**: Uses existing numpy, pandas, matplotlib
- **Performance**: O(n) vectorized operations, O(1) duplicate checking with set
- **Compatibility**: Works for Keras, PyTorch, and HLS ModelGraph; handles single-input and multi-input models
- **Pre-commit**: All 17 hooks passed (ruff, ruff-format, flake8, pyupgrade, trailing whitespace, etc.)