### PR TITLE
remove warning that is not needed since it does not signify a failure

### DIFF
--- a/hls4ml/model/optimizer/passes/move_scales.py
+++ b/hls4ml/model/optimizer/passes/move_scales.py
@@ -180,7 +180,6 @@ class BiasDownAdd(OptimizerPass):
             model.insert_node(new_node)
             return True
         else:
-            warnings.warn('Failed to propagate quantization bias down Add node; model probably not suppored.', stacklevel=1)
             return False
 
 


### PR DESCRIPTION
# Description

There is a warning issued when a scaling (or rescaling) cannot be moved, which is triggered in many valid models that are converted fine. Therefore, it is better to remove the warning, since it may confuse users.

## Type of change
- [x] Other (Specify):  remove a too-often hit warning that is not necessary bad.

## Tests

Should have no effect because it is just a warning

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
