### PR TITLE
Fix stable softmax exp_table indexing sign-bit inefficiency

### DIFF
--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -141,7 +141,6 @@ template <class data_T, unsigned table_size> inline float softmax_real_val_from_
 template <class data_T, unsigned table_size> inline unsigned softmax_idx_from_real_val_unsigned(data_T x) {
     // Slice the top N bits to get an index into the table
     static constexpr int N = ceillog2(table_size); // number of address bits for table
-
     // skip sign bit because inputs are guaranteed nonnegative
     ap_uint<N> y = x(x.width - 2, x.width - N - 1);    // slice the top N bits of input
     return (unsigned)y(N - 1, 0);

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -138,10 +138,12 @@ template <class data_T, unsigned table_size> inline float softmax_real_val_from_
     return (float)x;
 }
 
-template <class data_T, unsigned table_size> inline unsigned softmax_idx_from_real_val(data_T x) {
+template <class data_T, unsigned table_size> inline unsigned softmax_idx_from_real_val_unsigned(data_T x) {
     // Slice the top N bits to get an index into the table
     static constexpr int N = ceillog2(table_size); // number of address bits for table
-    ap_uint<N> y = x(x.width - 1, x.width - N);    // slice the top N bits of input
+
+    // skip sign bit because inputs are guaranteed nonnegative
+    ap_uint<N> y = x(x.width - 2, x.width - N - 1);    // slice the top N bits of input
     return (unsigned)y(N - 1, 0);
 }
 
@@ -254,7 +256,7 @@ void softmax_stable(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice]
     typename CONFIG_T::inv_inp_t exp_sum(0);
     for (unsigned i = 0; i < CONFIG_T::n_slice; i++) {
         #pragma HLS unroll
-        unsigned x = softmax_idx_from_real_val<typename CONFIG_T::inp_norm_t, CONFIG_T::exp_table_size>(d_xi_xmax[i]);
+        unsigned x = softmax_idx_from_real_val_unsigned<typename CONFIG_T::inp_norm_t, CONFIG_T::exp_table_size>(d_xi_xmax[i]);
         exp_res[i] = exp_table[x];
     }
 


### PR DESCRIPTION
Fix stable softmax LUT indexing to avoid wasting the sign bit for nonnegative normalized inputs.

# Description

Problem:-

the stable softmax implementation computes x_max - x_i, which is guaranteed to be nonnegative, however, the existing LUT indexing helper slices the sign bit as part of the exp_table address generation, reducing effective LUT utilization and precision.

Fix:-

Introduce a specialized unsigned lookup indexing helper for stable softmax inputs and use it only in the stable softmax path.,

this preserves existing behavior for latency and legacy implementations while improving LUT address utilization for stable softmax.