### PR TITLE
Fix updating dynamic optimizer flows

### DIFF
--- a/hls4ml/model/flow/flow.py
+++ b/hls4ml/model/flow/flow.py
@@ -62,10 +62,10 @@ class DynamicFlow(Flow):
         return optimizers
 
     def _add_optimizer(self, opt_name):
-        self._added_optimizers.put(opt_name)
+        self._added_optimizers.add(opt_name)
 
     def _remove_optimizer(self, opt_name):
-        self._removed_optimizers.put(opt_name)
+        self._removed_optimizers.add(opt_name)
 
 
 flow_map = {}

--- a/test/pytest/test_flows.py
+++ b/test/pytest/test_flows.py
@@ -119,3 +119,11 @@ def test_flows(tester):
     expected = tester.expected_pass_order
     observed = tester.observed_pass_order
     assert success, f'Tester {i} fails: expected ({expected}), observed ({observed})'
+
+
+
+
+def test_update_dynamic_flow():
+    dynamic_flow = hls4ml.model.flow.register_flow('TestDynamicFlowUpdate', lambda: ['A', 'B'])
+    hls4ml.model.flow.update_flow(dynamic_flow, add_optimizers=['C'], remove_optimizers=['A'])
+    assert set(hls4ml.model.flow.get_flow(dynamic_flow).optimizers) == {'B', 'C'}

--- a/test/pytest/test_flows.py
+++ b/test/pytest/test_flows.py
@@ -121,8 +121,6 @@ def test_flows(tester):
     assert success, f'Tester {i} fails: expected ({expected}), observed ({observed})'
 
 
-
-
 def test_update_dynamic_flow():
     dynamic_flow = hls4ml.model.flow.register_flow('TestDynamicFlowUpdate', lambda: ['A', 'B'])
     hls4ml.model.flow.update_flow(dynamic_flow, add_optimizers=['C'], remove_optimizers=['A'])


### PR DESCRIPTION
# Description

Fixes dynamic flow updates by using the correct `set.add()`API when recording added or removed optimizers.

Previously, calling update_flow() on a callable-backed flow raised an AttributeError because dynamic flow attempted to call `set.put()`. Callable backed flows are used for dynamic optimizer/template flow registration, so this broke flow customization for those flows.

Also adds a focused regression test covering add/remove behavior for a dynamic flow.

## Type of change
Bug fix 

## Tests
 i added a regression test in `test/pytest/test_flows.py` for updating a dynamic flow.

Test command;
```bash
pytest test/pytest/test_flows.py -q