### PR TITLE
Halt on errors in build_lib.sh for Catapult, Symbolic and Vivado Accelerator

### DIFF
--- a/hls4ml/templates/catapult/build_lib.sh
+++ b/hls4ml/templates/catapult/build_lib.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 CC=g++
 CFLAGS="-O3 -fPIC -std=c++11"

--- a/hls4ml/templates/symbolic/build_lib.sh
+++ b/hls4ml/templates/symbolic/build_lib.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 CC=g++
 CFLAGS="-O3 -fPIC -std=c++11"

--- a/hls4ml/templates/vivado_accelerator/build_lib.sh
+++ b/hls4ml/templates/vivado_accelerator/build_lib.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 CC=g++
 CFLAGS="-O3 -fPIC -std=c++11"


### PR DESCRIPTION
# Description

This PR adds missing `set -e` to `build_lib.sh` scripts for Catapult, Symbolic and Vivado Accelerator.

This allows them to fail early and print informative error messages. For example, is Catapult is not installed, now build script fails with:
```
In file included from firmware/myproject.cpp:3:
firmware/myproject.h:5:10: fatal error: ac_fixed.h: No such file or directory
    5 | #include <ac_fixed.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```

Without `set -e`, build script ignores compilation error, exits with code 0 and hls4ml fails later with more obscure error, e.g.:
```
E           OSError: /home/vasdommes/hls4ml/hls4ml/test/pytest/test_softmax_test_softmax_9,6-input_shape6-18,8-io_parallel-False-argmax-Catapult/firmware/myproject-da364f7b.so: cannot open shared object file: No such file or directory
```

## Type of change

- [x] Other (Specify)
Minor change that improves error logging.

## Tests
**Test Configuration**:
I ran tests as usual, e.g.
```
pytest --randomly-seed=42 --randomly-dont-reorganize --randomly-dont-reset-seed -k 'Catapult or Symbolic or VivadoAccelerator'  test/pytest
```

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
