### PR TITLE
fix(keras_v3): route depthwise Conv1D/2D (groups == channels) to depthwise codegen

### DIFF
--- a/hls4ml/converters/keras_v3/conv.py
+++ b/hls4ml/converters/keras_v3/conv.py
@@ -137,6 +137,26 @@ class ConvHandler(KerasV3LayerHandler):
             config['depthwise_data'] = kernel
             config['pointwise_data'] = self.load_weight(layer, 'pointwise_kernel')
             config['depth_multiplier'] = layer.depth_multiplier
+        elif isinstance(layer, BaseConv) and getattr(layer, 'groups', 1) > 1:
+            # A grouped convolution with groups == in_channels and one filter per channel
+            # (depth_multiplier == 1) is a depthwise convolution. Keras stores its kernel as
+            # (*kernel_size, 1, n_chan); reshape it to the (*kernel_size, n_chan, 1) layout the
+            # depthwise codegen expects and emit it as a DepthwiseConv. Without this a grouped
+            # Conv falls through to the dense branch below and is silently miscomputed.
+            #
+            # Other grouped shapes have no correct hls4ml kernel: general grouping
+            # (1 < groups < in_channels) has no implementation, and depthwise with
+            # depth_multiplier > 1 is unsupported by the depthwise kernels (true for a native
+            # DepthwiseConv too). Reject them rather than emit a wrong result.
+            n_chan, n_filt = config['n_chan'], config['n_filt']
+            if layer.groups != n_chan or n_filt != n_chan:
+                raise NotImplementedError(
+                    'Grouped convolution is only supported as depthwise (groups == in_channels == filters); '
+                    f'layer {layer.name} has groups={layer.groups}, in_channels={n_chan}, filters={n_filt}.'
+                )
+            config['class_name'] = f'DepthwiseConv{len(ker_px_shape)}D'
+            config['depthwise_data'] = kernel.reshape(*kernel.shape[:-2], n_chan, 1)
+            config['depth_multiplier'] = 1
         elif isinstance(layer, BaseConv):
             config['weight_data'] = kernel
 

--- a/hls4ml/converters/keras_v3/conv.py
+++ b/hls4ml/converters/keras_v3/conv.py
@@ -138,16 +138,9 @@ class ConvHandler(KerasV3LayerHandler):
             config['pointwise_data'] = self.load_weight(layer, 'pointwise_kernel')
             config['depth_multiplier'] = layer.depth_multiplier
         elif isinstance(layer, BaseConv) and getattr(layer, 'groups', 1) > 1:
-            # A grouped convolution with groups == in_channels and one filter per channel
-            # (depth_multiplier == 1) is a depthwise convolution. Keras stores its kernel as
-            # (*kernel_size, 1, n_chan); reshape it to the (*kernel_size, n_chan, 1) layout the
-            # depthwise codegen expects and emit it as a DepthwiseConv. Without this a grouped
-            # Conv falls through to the dense branch below and is silently miscomputed.
-            #
-            # Other grouped shapes have no correct hls4ml kernel: general grouping
-            # (1 < groups < in_channels) has no implementation, and depthwise with
-            # depth_multiplier > 1 is unsupported by the depthwise kernels (true for a native
-            # DepthwiseConv too). Reject them rather than emit a wrong result.
+            # groups == in_channels == filters is a depthwise conv; reshape the kernel from
+            # (*kernel_size, 1, n_chan) to the (*kernel_size, n_chan, 1) depthwise layout.
+            # Other grouped shapes have no hls4ml kernel and are rejected.
             n_chan, n_filt = config['n_chan'], config['n_filt']
             if layer.groups != n_chan or n_filt != n_chan:
                 raise NotImplementedError(

--- a/test/pytest/test_depthwise_via_groups.py
+++ b/test/pytest/test_depthwise_via_groups.py
@@ -1,0 +1,97 @@
+"""Depthwise Conv1D / Conv2D expressed as a grouped convolution (groups == channels).
+
+A Keras ``Conv1D`` / ``Conv2D`` with ``groups == in_channels`` is a depthwise
+convolution, but the keras_v3 ``ConvHandler`` routed it to the dense Conv path,
+loading the (k, 1, n_chan) depthwise kernel into a dense matmul and silently
+producing wrong output. It is now reshaped to the depthwise layout and emitted as
+a ``DepthwiseConv``. General grouped convolutions (1 < groups < in_channels) and
+depth_multiplier > 1 have no correct hls4ml kernel and are rejected with a clear
+error rather than silently miscomputed.
+"""
+
+from pathlib import Path
+
+import keras
+import numpy as np
+import pytest
+
+if keras.__version__ < '3.0':
+    pytest.skip('Only applicable to the Keras 3 (keras_v3) converter', allow_module_level=True)
+
+from keras.layers import Conv1D, Conv2D, Input  # noqa: E402
+
+import hls4ml  # noqa: E402
+
+test_root_path = Path(__file__).parent
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis'])
+@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
+@pytest.mark.parametrize('padding', ['same', 'valid', 'causal'])
+def test_depthwise1d_via_groups(test_case_id, backend, io_type, padding):
+    """Conv1D(groups == channels) must be emitted as DepthwiseConv1D and match Keras."""
+    n_chan = 4
+    X = np.random.rand(10, 16, n_chan)
+    X = np.round(X * 2**10) * 2**-10  # exact on the fixed-point grid
+    model = keras.Sequential([Input((16, n_chan)), Conv1D(n_chan, 3, padding=padding, groups=n_chan, name='gc')])
+    model.compile()
+
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='fixed<32,12>', backend=backend
+    )
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
+    )
+    # Routed to the depthwise implementation, not a dense Conv1D (which produced garbage pre-fix).
+    assert hls_model.graph['gc'].class_name == 'DepthwiseConv1D'
+    hls_model.compile()
+
+    y_keras = model.predict(X, verbose=0)
+    y_hls = hls_model.predict(X).reshape(y_keras.shape)
+    np.testing.assert_allclose(y_hls, y_keras, rtol=1e-2, atol=0.01)
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis'])
+@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
+def test_depthwise2d_via_groups(test_case_id, backend, io_type):
+    """Conv2D(groups == channels) must be emitted as DepthwiseConv2D and match Keras."""
+    n_chan = 4
+    X = np.random.rand(10, 8, 8, n_chan)
+    X = np.round(X * 2**10) * 2**-10
+    model = keras.Sequential([Input((8, 8, n_chan)), Conv2D(n_chan, (3, 3), padding='same', groups=n_chan, name='gc')])
+    model.compile()
+
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='fixed<32,12>', backend=backend
+    )
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
+    )
+    assert hls_model.graph['gc'].class_name == 'DepthwiseConv2D'
+    hls_model.compile()
+
+    y_keras = model.predict(X, verbose=0)
+    y_hls = hls_model.predict(X).reshape(y_keras.shape)
+    np.testing.assert_allclose(y_hls, y_keras, rtol=1e-2, atol=0.01)
+
+
+@pytest.mark.parametrize(
+    'n_chan, filters, groups',
+    [(4, 4, 2), (8, 8, 4), (4, 8, 4)],
+    ids=['grouped_2of4', 'grouped_4of8', 'depth_multiplier_2'],
+)
+def test_unsupported_grouped_conv_raises(test_case_id, n_chan, filters, groups):
+    """General grouped convs and depth_multiplier > 1 have no correct hls4ml kernel and
+    must raise at conversion rather than be emitted as a (wrong) dense or depthwise conv."""
+    model = keras.Sequential([Input((16, n_chan)), Conv1D(filters, 3, padding='same', groups=groups, name='gc')])
+    model.compile()
+    output_dir = str(test_root_path / test_case_id)
+    # The keras_v3 ConvHandler runs during model parsing (config_from_keras_model already
+    # invokes it), so the rejection surfaces as soon as the model is parsed.
+    with pytest.raises(NotImplementedError):
+        config = hls4ml.utils.config_from_keras_model(model, granularity='name')
+        hls4ml.converters.convert_from_keras_model(
+            model, hls_config=config, output_dir=output_dir, backend='Vitis', io_type='io_parallel'
+        )

--- a/test/pytest/test_depthwise_via_groups.py
+++ b/test/pytest/test_depthwise_via_groups.py
@@ -1,13 +1,4 @@
-"""Depthwise Conv1D / Conv2D expressed as a grouped convolution (groups == channels).
-
-A Keras ``Conv1D`` / ``Conv2D`` with ``groups == in_channels`` is a depthwise
-convolution, but the keras_v3 ``ConvHandler`` routed it to the dense Conv path,
-loading the (k, 1, n_chan) depthwise kernel into a dense matmul and silently
-producing wrong output. It is now reshaped to the depthwise layout and emitted as
-a ``DepthwiseConv``. General grouped convolutions (1 < groups < in_channels) and
-depth_multiplier > 1 have no correct hls4ml kernel and are rejected with a clear
-error rather than silently miscomputed.
-"""
+"""Test Conv1D/Conv2D with groups == channels is emitted as DepthwiseConv."""
 
 from pathlib import Path
 
@@ -29,10 +20,9 @@ test_root_path = Path(__file__).parent
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
 @pytest.mark.parametrize('padding', ['same', 'valid', 'causal'])
 def test_depthwise1d_via_groups(test_case_id, backend, io_type, padding):
-    """Conv1D(groups == channels) must be emitted as DepthwiseConv1D and match Keras."""
     n_chan = 4
     X = np.random.rand(10, 16, n_chan)
-    X = np.round(X * 2**10) * 2**-10  # exact on the fixed-point grid
+    X = np.round(X * 2**10) * 2**-10
     model = keras.Sequential([Input((16, n_chan)), Conv1D(n_chan, 3, padding=padding, groups=n_chan, name='gc')])
     model.compile()
 
@@ -43,7 +33,6 @@ def test_depthwise1d_via_groups(test_case_id, backend, io_type, padding):
     hls_model = hls4ml.converters.convert_from_keras_model(
         model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
     )
-    # Routed to the depthwise implementation, not a dense Conv1D (which produced garbage pre-fix).
     assert hls_model.graph['gc'].class_name == 'DepthwiseConv1D'
     hls_model.compile()
 
@@ -55,7 +44,6 @@ def test_depthwise1d_via_groups(test_case_id, backend, io_type, padding):
 @pytest.mark.parametrize('backend', ['Vivado', 'Vitis'])
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
 def test_depthwise2d_via_groups(test_case_id, backend, io_type):
-    """Conv2D(groups == channels) must be emitted as DepthwiseConv2D and match Keras."""
     n_chan = 4
     X = np.random.rand(10, 8, 8, n_chan)
     X = np.round(X * 2**10) * 2**-10
@@ -83,13 +71,10 @@ def test_depthwise2d_via_groups(test_case_id, backend, io_type):
     ids=['grouped_2of4', 'grouped_4of8', 'depth_multiplier_2'],
 )
 def test_unsupported_grouped_conv_raises(test_case_id, n_chan, filters, groups):
-    """General grouped convs and depth_multiplier > 1 have no correct hls4ml kernel and
-    must raise at conversion rather than be emitted as a (wrong) dense or depthwise conv."""
+    """Unsupported grouped convs must raise instead of producing wrong results."""
     model = keras.Sequential([Input((16, n_chan)), Conv1D(filters, 3, padding='same', groups=groups, name='gc')])
     model.compile()
     output_dir = str(test_root_path / test_case_id)
-    # The keras_v3 ConvHandler runs during model parsing (config_from_keras_model already
-    # invokes it), so the rejection surfaces as soon as the model is parsed.
     with pytest.raises(NotImplementedError):
         config = hls4ml.utils.config_from_keras_model(model, granularity='name')
         hls4ml.converters.convert_from_keras_model(


### PR DESCRIPTION
# Description

I have been converting a network that uses depthwise convolutions and ran into a problem I would like to share, along with the local patch I am using, in case it is useful and to learn whether there is a better way to handle it.

I expressed the depthwise layers as `Conv1D`/`Conv2D` with `groups == in_channels` (which is what Keras produces for a depthwise conv written that way). The model converted and compiled without any error, but the hardware output did not match Keras at all (correlation near zero). After digging in, the cause is in the keras_v3 `ConvHandler`: a grouped `Conv` falls through to the dense Conv branch, so the `(*kernel_size, 1, n_chan)` depthwise kernel is loaded into a dense matmul that expects `(*kernel_size, n_chan, n_chan)` weights. It runs, but it computes the wrong thing. As far as I can tell this is not specific to HGQ, a plain Keras grouped Conv hits it too.

The patch I am proposing detects the depthwise case (`groups == in_channels == filters`, i.e. `depth_multiplier == 1`), reshapes the kernel to the `(*kernel_size, n_chan, 1)` layout the existing depthwise codegen expects, and emits a `DepthwiseConv`. With that change my model matches Keras. For grouped shapes that I could not find a correct hls4ml kernel for, I made it raise `NotImplementedError` at conversion instead of silently producing a wrong result (see Known limitations).

I am not sure this is the best place or the best way to fix it, so I would really appreciate feedback:
- Is routing the grouped Conv to `DepthwiseConv` in the converter the right approach, or is there a preferred pattern in hls4ml for this that I missed?
- Is raising on the unsupported shapes the behavior you want, or would you rather warn, or is there appetite for a real grouped convolution kernel down the line?

I also hit a related issue in the bit_exact precision-propagation pass while doing this, which I opened separately as #1485. This PR is the converter side and is independent: it is enough on its own for a plain Keras depthwise conv, and a quantized (HGQ2) depthwise model needs both. They touch different files and do not conflict.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Known limitations

These are the cases my patch does not handle. I could not find a correct hls4ml kernel for them, so rather than emit a wrong result they now raise `NotImplementedError` at conversion. Happy to revisit any of these if there is a better option:

- `depth_multiplier > 1` (more than one filter per input channel). The depthwise kernels seem to support only a depth multiplier of 1, and I saw the same behavior with a native `DepthwiseConv` (io_parallel asserts, io_stream gives a wrong result), so this looks like a pre-existing limitation rather than something this change introduces.
- General grouped convolutions with `1 < groups < in_channels`. I did not find a grouped convolution kernel in hls4ml.

Two more things I noticed but did not change here, in case they are useful context:

- For a quantized (HGQ2) depthwise model the full path also needs the bit_exact fix in #1485; without it the precision-propagation pass raises before reaching codegen.
- HGQ2 depthwise on `io_stream` is separately blocked by the existing "heterogeneous quantization for activations is only supported with IOType=io_parallel" limitation.

## Tests

Added `test/pytest/test_depthwise_via_groups.py`:

- A grouped `Conv1D`/`Conv2D` with `groups == in_channels` is emitted as `DepthwiseConv1D`/`DepthwiseConv2D` and matches Keras, across the Vivado and Vitis backends, `io_parallel` and `io_stream`, and `same`/`valid`/`causal` padding.
- General grouped convolutions and `depth_multiplier > 1` raise `NotImplementedError`.

I also ran the existing keras_v3 convolution tests to check I did not regress the standard or native depthwise/separable paths:

```
pytest test/pytest/test_depthwise_via_groups.py            # 19 passed
pytest test/pytest/test_keras_v3_api.py -k "conv or depthwise or sepconv"   # Vivado/Vitis: 30 passed
```

**Test Configuration**: Keras 3.14 (torch backend), Python 3.13, g++ csim.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. (not applicable, converter bug fix)
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
