### PR TITLE
docs(readme): make hls4ml logo clickable and update badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-   <img src="https://github.com/fastmachinelearning/fastmachinelearning.github.io/raw/master/images/hls4ml_logo.svg" alt="hls4ml" width="400"/>
-</p>
+<p align="center"><a href="https://github.com/fastmachinelearning/fastmachinelearning.github.io"><img src="https://fastmachinelearning.org/hls4ml/_images/hls4ml_logo.png" alt="hls4ml" width="400"/></a></p>
 
-[![DOI](https://zenodo.org/badge/108329371.svg)](https://zenodo.org/badge/latestdoi/108329371)
+
+[![DOI](https://img.shields.io/badge/DOI-Zenodo-blue)](https://zenodo.org/records/19134628)
 [![License](https://img.shields.io/badge/License-Apache_2.0-red.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Documentation Status](https://github.com/fastmachinelearning/hls4ml/actions/workflows/build-sphinx.yml/badge.svg)](https://fastmachinelearning.org/hls4ml)
 [![PyPI version](https://badge.fury.io/py/hls4ml.svg)](https://badge.fury.io/py/hls4ml)


### PR DESCRIPTION
# Description

This PR updates the README to improve the rendering and usability of project assets.

Changes include:

* Making the hls4ml logo clickable and linking it to the fastmachinelearning.github.io repository.
* Updating the logo image source to a reliably rendered image.
* Fixing broken or outdated badge/image links in the README.
* Improving badge and image rendering consistency on GitHub.

Dependencies:

* No additional dependencies are required.

## Type of change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] Documentation update
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] A new research paper code implementation
* [ ] Other (Specify)

## Tests

Verified the changes by:

1. Previewing the README on GitHub.
2. Confirming that the hls4ml logo renders correctly.
3. Confirming that clicking the logo redirects to the intended repository.
4. Verifying that the updated badges and links resolve correctly.

**Test Configuration**:

* GitHub README renderer
* Web browser

## Checklist

* [x] I have read the guidelines for contributing.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
* [ ] I have installed and run `pre-commit` on the files I edited or added.
* [ ] I have added tests that prove my fix is effective or that my feature works.
