### PR TITLE
convert quant to linear if homogeneous and share src node

### DIFF
--- a/hls4ml/model/optimizer/passes/bit_exact.py
+++ b/hls4ml/model/optimizer/passes/bit_exact.py
@@ -963,7 +963,8 @@ class BitExact(ModelOptimizerPass):
             for k in list(model.graph.keys()):
                 v = model.graph[k]
                 if isinstance(v, Activation) and v.attributes.get('activation') == 'linear':
-                    model.remove_node(v)
+                    if len(get_output_layers(get_input_layers(v)[0])) == 1:
+                        model.remove_node(v)
 
         for node in model.graph.values():
             if node.attributes.get('bit_exact_transformed'):

--- a/hls4ml/model/optimizer/passes/hgq_proxy_model.py
+++ b/hls4ml/model/optimizer/passes/hgq_proxy_model.py
@@ -131,10 +131,18 @@ class FuseFixedPointQuantizer(OptimizerPass):
 
         inp_layer = get_input_layers(node)[0]
         can_fuse = len(get_output_layers(inp_layer)) == 1
+        attributes = copy(node.attributes)
+        attributes['activation'] = 'linear'
+        attributes['table_size'] = -1
+        attributes['table_t'] = FixedPrecisionType(1, 0)
+        attributes['result_t'] = precision
         if not can_fuse:
-            return False
-        self.propagate(inp_layer, precision)
-        model.remove_node(node)
+            linear = Activation(model, node.name, attributes, node.inputs, node.outputs)
+            linear.get_output_variable().type.precision = precision
+            model.replace_node(node, linear)
+        else:
+            self.propagate(inp_layer, precision)
+            model.remove_node(node)
         return True
 
 


### PR DESCRIPTION
# Description

When a node branches into multiple, the subnodes' quantizers can't fuse into the parent one as there is only one result_t., so models like
```python
inp =keras.Input((8,))
x, y = hgq.layers.QDense(8)(inp), hgq.layers.QDense(8)(inp)
model = keras.Model(inputs=inp, outputs=[x, y])
```
can't be used in io_stream mode. This PR fixes that by converting the unfusable quantizer nodes to linear nodes as quantizer.

## Type of change
- [x] Other (Specify)

## Tests

## Checklist

- [x] all