### PR TITLE
Respect WriteTar setting in Catapult writer

### DIFF
--- a/hls4ml/writer/catapult_writer.py
+++ b/hls4ml/writer/catapult_writer.py
@@ -899,7 +899,7 @@ class CatapultWriter(Writer):
                 os.remove(tar_path)
             with tarfile.open(tar_path, mode='w:gz') as archive:
                 archive.add(model.config.get_output_dir(), recursive=True)
-        
+
 
     def write_hls(self, model):
         self.write_output_dir(model)

--- a/hls4ml/writer/catapult_writer.py
+++ b/hls4ml/writer/catapult_writer.py
@@ -893,11 +893,13 @@ class CatapultWriter(Writer):
             model (ModelGraph): the hls4ml model.
         """
 
-        if not os.path.exists(model.config.get_output_dir() + '.tar.gz'):
-            with tarfile.open(model.config.get_output_dir() + '.tar.gz', mode='w:gz') as archive:
+       if model.config.get_writer_config().get('WriteTar', False):
+            tar_path = model.config.get_output_dir() + '.tar.gz'
+            if os.path.exists(tar_path):
+                os.remove(tar_path)
+            with tarfile.open(tar_path, mode='w:gz') as archive:
                 archive.add(model.config.get_output_dir(), recursive=True)
-        else:
-            print('Project .tar.gz archive already exists')
+        
 
     def write_hls(self, model):
         self.write_output_dir(model)

--- a/hls4ml/writer/catapult_writer.py
+++ b/hls4ml/writer/catapult_writer.py
@@ -893,13 +893,12 @@ class CatapultWriter(Writer):
             model (ModelGraph): the hls4ml model.
         """
 
-       if model.config.get_writer_config().get('WriteTar', False):
+        if model.config.get_writer_config().get('WriteTar', False):
             tar_path = model.config.get_output_dir() + '.tar.gz'
             if os.path.exists(tar_path):
                 os.remove(tar_path)
             with tarfile.open(tar_path, mode='w:gz') as archive:
                 archive.add(model.config.get_output_dir(), recursive=True)
-
 
     def write_hls(self, model):
         self.write_output_dir(model)

--- a/test/pytest/test_catapult_writer.py
+++ b/test/pytest/test_catapult_writer.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import pytest
 
 from hls4ml.writer.catapult_writer import CatapultWriter

--- a/test/pytest/test_catapult_writer.py
+++ b/test/pytest/test_catapult_writer.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import pytest
+
+from hls4ml.writer.catapult_writer import CatapultWriter
+
+
+class DummyConfig:
+    def __init__(self, output_dir, write_tar):
+        self.output_dir = str(output_dir)
+        self.writer_config = {'WriteTar': write_tar}
+
+    def get_output_dir(self):
+        return self.output_dir
+
+    def get_writer_config(self):
+        return self.writer_config
+
+
+class DummyModel:
+    def __init__(self, output_dir, write_tar):
+        self.config = DummyConfig(output_dir, write_tar)
+
+
+@pytest.mark.parametrize('write_tar', [True, False])
+def test_catapult_write_tar_respects_writer_config(tmp_path, write_tar):
+    output_dir = tmp_path / 'myproject'
+    output_dir.mkdir()
+    (output_dir / 'marker.txt').write_text('marker')
+
+    CatapultWriter().write_tar(DummyModel(output_dir, write_tar))
+
+    assert Path(f'{output_dir}.tar.gz').exists() == write_tar


### PR DESCRIPTION
# Description

Makes `CatapultWriter` respect the existing `WriterConfig.WriteTar` option.

Other writers only create a `.tar.gz` archive when `WriteTar` is enabled, but `CatapultWriter` always created one unconditionally, this makes catapult behavior consistent with the other writer backends.

This partially addresses #1438 by adding the missing `WriteTar` gate for Catapult.

## Type of change

- [x] Bug fix (non breaking change that fixes an issue)


## Tests

Added a focused regression test for `CatapultWriter.write_tar()`.

**Test Configuration**:

focused writer unit test
No HLS toolchain required

```bash
pytest test/pytest/test_catapult_writer.py -q 

```

## Checklist

* [x] I have read the contribution guidelines.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
* [ ] I have installed and run pre-commit on the files I edited or added.
* [x] I have added tests that demonstrate my fix is effective or that my feature works as intended.

