### PR TITLE
fix: fallback to `vitis_hls` for Vitis <= 2022.2 (fixes #1436)

### DIFF
--- a/docs/intro/setup.rst
+++ b/docs/intro/setup.rst
@@ -68,7 +68,8 @@ To run FPGA synthesis, installation of following tools is required:
 
 * Xilinx Vivado HLS 2020.1 for synthesis for Xilinx FPGAs using the ``Vivado`` backend. Older versions may work, but use at your own risk.
 
-* Vitis HLS 2022.2 or newer is required for synthesis for Xilinx FPGAs using the ``Vitis`` backend.
+* Vitis HLS is required for synthesis for Xilinx FPGAs using the ``Vitis`` backend.
+  ``vitis-run`` (Vitis ≥ 2023.1) is used when available; older versions using ``vitis_hls`` (Vitis ≤ 2022.2) are supported as a fallback.
 
 * Intel Quartus 20.1 to 21.4 for the synthesis for Intel/Altera FPGAs using the ``Quartus`` backend.
 

--- a/docs/intro/status.rst
+++ b/docs/intro/status.rst
@@ -89,7 +89,7 @@ Other feature notes:
 
   - Vivado HLS 2020.1. Older versions may work, but use at your own risk.
   - Intel HLS versions 20.1 to 21.4, versions > 21.4 have not been tested.
-  - Vitis HLS versions 2022.2 to 2024.1. Versions > 2024.1 are less tested.
+  - Vitis HLS versions ≤ 2022.2 (via ``vitis_hls``) and 2023.1 to 2024.1 (via ``vitis-run``). Versions > 2024.1 are less tested.
   - Catapult HLS versions 2024.1_1 to 2024.2
   - oneAPI versions 2024.1 to 2025.0. Any future versions are known to not work.
 

--- a/hls4ml/backends/vitis/vitis_backend.py
+++ b/hls4ml/backends/vitis/vitis_backend.py
@@ -119,9 +119,17 @@ class VitisBackend(VivadoBackend):
         log_to_stdout=True,
     ):
         if 'linux' in sys.platform:
-            found_vrun = os.system('command -v vitis-run > /dev/null') == 0
-            if not found_vrun:
-                raise Exception('Vitis installation not found. Make sure "vitis-run" is on PATH.')
+            if shutil.which('vitis-run'):
+                build_command = 'vitis-run --tcl build_prj.tcl --mode hls'
+            elif shutil.which('vitis_hls'):
+                build_command = 'vitis_hls -f build_prj.tcl'
+            else:
+                raise Exception(
+                    'Vitis installation not found. Make sure "vitis-run" (Vitis ≥ 2023.1) '
+                    'or "vitis_hls" (Vitis ≤ 2022.2) is on PATH.'
+                )
+        else:
+            build_command = 'vitis-run --tcl build_prj.tcl --mode hls'
 
         build_opts = (
             'array set opt {\n'
@@ -139,8 +147,6 @@ class VitisBackend(VivadoBackend):
         tcl_path = Path(model.config.get_output_dir()) / 'build_opt.tcl'
         with open(tcl_path, 'w') as file:
             file.write(build_opts)
-
-        build_command = 'vitis-run --tcl build_prj.tcl --mode hls'
 
         output_dir = model.config.get_output_dir()
         stdout_log = os.path.join(output_dir, 'build_stdout.log')

--- a/test/pytest/test_vitis_legacy_build.py
+++ b/test/pytest/test_vitis_legacy_build.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_build_falls_back_to_vitis_hls(tmp_path):
+    """vitis_hls used when vitis-run absent (issue #1463). Fails on main, passes on branch."""
+    from hls4ml.backends.vitis.vitis_backend import VitisBackend
+
+    model = MagicMock()
+    model.config.get_output_dir.return_value = str(tmp_path)
+    model.config.get_project_name.return_value = 'test'
+
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured['cmd'] = cmd
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate.return_value = (None, None)
+        return proc
+
+    with (
+        patch('sys.platform', 'linux'),
+        patch('shutil.which', side_effect=lambda c: None if c == 'vitis-run' else '/usr/bin/vitis_hls'),
+        patch('subprocess.Popen', side_effect=fake_popen),
+        patch('hls4ml.backends.vitis.vitis_backend.parse_vivado_report', return_value={}),
+    ):
+        VitisBackend.__new__(VitisBackend).build(model)
+
+    assert captured['cmd'] == 'vitis_hls -f build_prj.tcl'
+
+
+def test_build_raises_when_neither_found(tmp_path):
+    """Exception raised when neither vitis-run nor vitis_hls is on PATH."""
+    from hls4ml.backends.vitis.vitis_backend import VitisBackend
+
+    model = MagicMock()
+    model.config.get_output_dir.return_value = str(tmp_path)
+
+    with patch('sys.platform', 'linux'), patch('shutil.which', return_value=None):
+        with pytest.raises(Exception, match='vitis_hls'):
+            VitisBackend.__new__(VitisBackend).build(model)


### PR DESCRIPTION
# Description

PR #1327 migrated the Vitis backend from `vitis_hls -f build_prj.tcl` to
`vitis-run --tcl build_prj.tcl --mode hls`. The `vitis-run` command was
introduced in Vitis 2023.1 and is not available in older toolchains (≤ 2022.2),
causing `hls4ml.build()` to always raise `"Vitis installation not found"` on
those versions.

This fix detects which command is available at runtime via `shutil.which` and
falls back to `vitis_hls -f build_prj.tcl` when `vitis-run` is absent.
The `build_prj.tcl` template uses only classic HLS APIs (`open_project`,
`csynth_design`, etc.) and reads options from `build_opt.tcl` via `source` —
both compatible with all Vitis versions.

Fixes #1463.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Tests

Two unit tests added in `test/pytest/test_vitis_legacy_build.py`:

- `test_build_falls_back_to_vitis_hls`: mocks `shutil.which` to return `None`
  for `vitis-run` and a valid path for `vitis_hls`; asserts that `subprocess.Popen`
  is called with `vitis_hls -f build_prj.tcl`. This test **fails on `main`** and
  passes on this branch.
- `test_build_raises_when_neither_found`: asserts that an exception is raised
  when neither command is found.

```bash
pytest test/pytest/test_vitis_legacy_build.py -v
```

**Test Configuration**:
- Python 3.12
- pytest 8.3.5
- no HLS tool required (suprocess mocked)

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
