### PR TITLE
Fix: Incorrect input type placeholder used in vivado_accelerator_writer

### DIFF
--- a/hls4ml/writer/vivado_accelerator_writer.py
+++ b/hls4ml/writer/vivado_accelerator_writer.py
@@ -179,7 +179,7 @@ class VivadoAcceleratorWriter(VivadoWriter):
                             + 'ctype[j] = typename {input_t}::value_type(in[i * {input_t}::size + j].data);\n'
                         )
                         newline += (
-                            indent + indent + indent + 'is_last |= (in[i * input_t::size + j].last == 1)? true : false;\n'
+                            indent + indent + indent + 'is_last |= (in[i * {input_t}::size + j].last == 1)? true : false;\n'
                         )
                     else:
                         newline += (


### PR DESCRIPTION
# Description

Currently, `VivadoAcceleratorWriter` uses placeholders to interpolate the value of `input_t` in the AXI wrapper. There is one instance where this interpolation instead uses the literal value `input_t`; if a model results in an input type that _isn't_ called `input_t` (e.g., `input_layer_t`), then compilation fails.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

This issue manifested when generating a HGQ2 model (a `keras.Sequential` wrapping a few conv and dense latyers) using the VivadoAccelerator backend; the fix has been verified using the same model which generated the error for me in the first place. With apologies, I am insufficiently familiar with the internals of hls4ml at this time to create a tight test case and add it to your pytests with this PR. If this requirement is mandatory, I'd be happy to take a pointer on where to get started with crafting such a test - but this change feels minor enough that perhaps it isn't strictly required?

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
