### PR TITLE
add tensorflow as the KERAS_BACKEND for qkerasV3 tests

### DIFF
--- a/test/pytest/generate_ci_yaml.py
+++ b/test/pytest/generate_ci_yaml.py
@@ -171,7 +171,11 @@ def generate_test_yaml(test_root='.'):
         name = 'qkerasV3'
         test_files = ' '.join([str(path.relative_to(test_root)) for path in batch_paths])
         batch_need_example_model = int(any([qkeras3_need_examples[i] for i in batch_idxs]))
-        diff_yml = yaml.safe_load(template.format(name, '.pytest-qkeras-v3-only', test_files, batch_need_example_model))
+        diff_yml = yaml.safe_load(
+            template_keras3_backend.format(
+                name, '.pytest-qkeras-v3-only', test_files, batch_need_example_model, 'tensorflow'
+            )
+        )
         yml.update(diff_yml)
 
     backend_specific_paths = [path for path in test_root.glob('**/test_*.py') if path.stem in KERAS3_BACKEND_SPECIFIC_LIST]


### PR DESCRIPTION
# Description

This should fix the qkeras3 pytests issues introduced with qkeras_v3==1.2

## Type of change

QKeras v3 1.2 needs to have the `KERAS_BACKEND` environment variable set, so this sets it in the CI. 

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Other (Specify) - CI

## Tests

This is a CI fix so it will only be visible in the CI. Compare with the qkeras3 pytest in #1497.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
