### PR TITLE
Respect skipped optimizers in flows

### DIFF
--- a/hls4ml/model/graph.py
+++ b/hls4ml/model/graph.py
@@ -15,7 +15,7 @@ import numpy.ctypeslib as npc
 from hls4ml.backends import get_backend
 from hls4ml.model.flow import get_flow
 from hls4ml.model.layers import Layer, layer_map
-from hls4ml.model.optimizer import get_available_passes, optimize_model
+from hls4ml.model.optimizer import optimize_model
 from hls4ml.model.types import Serializable
 from hls4ml.utils.string_utils import convert_to_snake_case
 
@@ -247,19 +247,14 @@ class HLSConfig(Serializable):
         if self.flows is None:
             self.flows = [self.backend.get_default_flow()]
 
-        # TODO this is now effectively broken
         self.optimizers = hls_config.get('Optimizers')
+        self.skip_optimizers = hls_config.get('SkipOptimizers')
         if 'SkipOptimizers' in hls_config:
             if self.optimizers is not None:
                 raise Exception('Invalid optimizer configuration, please use either "Optimizers" or "SkipOptimizers".')
-            skip_optimizers = hls_config.get('SkipOptimizers')
-            selected_optimizers = get_available_passes()
-            for opt in skip_optimizers:
-                try:
-                    selected_optimizers.remove(opt)
-                except ValueError:
-                    pass
-            self.optimizers = selected_optimizers
+            self.skip_optimizers = self._as_list(self.skip_optimizers)
+        elif self.optimizers is not None:
+            self.optimizers = self._as_list(self.optimizers)
 
         model_cfg = hls_config.get('Model')
         if model_cfg is not None:
@@ -315,6 +310,23 @@ class HLSConfig(Serializable):
             for layer_name, layer_cfg in layer_name_cfg.items():
                 self.parse_name_config(layer_name, layer_cfg)
 
+    @staticmethod
+    def _as_list(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return list(value)
+
+    def get_flow_optimizers(self, optimizers):
+        if self.optimizers is not None:
+            selected_optimizers = set(self.optimizers)
+            return [opt for opt in optimizers if opt in selected_optimizers]
+        if self.skip_optimizers is not None:
+            skip_optimizers = set(self.skip_optimizers)
+            return [opt for opt in optimizers if opt not in skip_optimizers]
+        return optimizers
+
     def serialize(self):
         state = {}
 
@@ -355,6 +367,7 @@ class HLSConfig(Serializable):
         state['writer_config'] = self.writer_config.copy()
         state['flows'] = self.flows.copy()
         state['optimizers'] = self.optimizers.copy() if self.optimizers is not None else None
+        state['skip_optimizers'] = self.skip_optimizers.copy() if self.skip_optimizers is not None else None
         state['model_bf'] = self.model_bf
 
         return state
@@ -393,6 +406,7 @@ class HLSConfig(Serializable):
         config.writer_config = state['writer_config']
         config.flows = state['flows']
         config.optimizers = state['optimizers']
+        config.skip_optimizers = state.get('skip_optimizers')
         config.model_bf = state['model_bf']
 
         return config
@@ -527,8 +541,9 @@ class ModelGraph(Serializable):
             if sub_flow not in applied_flows.keys():
                 self._apply_sub_flow(sub_flow, applied_flows)
 
-        if len(flow.optimizers) > 0:
-            applied_passes = optimize_model(self, flow.optimizers)
+        optimizers = self.config.get_flow_optimizers(flow.optimizers)
+        if len(optimizers) > 0:
+            applied_passes = optimize_model(self, optimizers)
         else:
             applied_passes = set()
         applied_flows[flow.name] = applied_passes

--- a/test/pytest/test_flows.py
+++ b/test/pytest/test_flows.py
@@ -51,9 +51,11 @@ DummyFlowBReqA = hls4ml.model.flow.register_flow('BReqA', ['B'], requires=[Dummy
 DummyFlowCReqBReqA = hls4ml.model.flow.register_flow('CReqBReqA', ['C'], requires=[DummyFlowBReqA])
 
 
-def dummy_flow_model():
+def dummy_flow_model(hls_config=None):
     layers = [{'class_name': 'Input', 'name': 'layer0_input', 'input_shape': [1]}]
     config = {'HLSConfig': {'Model': {'Precision': 'ap_fixed<32,16>', 'ReuseFactor': 1}, 'Flows': []}}
+    if hls_config is not None:
+        config['HLSConfig'].update(hls_config)
     model = hls4ml.model.ModelGraph.from_layer_list(config, layers)
     return model
 
@@ -125,3 +127,38 @@ def test_update_dynamic_flow():
     dynamic_flow = hls4ml.model.flow.register_flow('TestDynamicFlowUpdate', lambda: ['A', 'B'])
     hls4ml.model.flow.update_flow(dynamic_flow, add_optimizers=['C'], remove_optimizers=['A'])
     assert set(hls4ml.model.flow.get_flow(dynamic_flow).optimizers) == {'B', 'C'}
+
+
+def test_skip_optimizers_filters_flow_passes():
+    model = dummy_flow_model({'SkipOptimizers': ['A']})
+    model.test_flow_passes = []
+
+    model.apply_flow(DummyFlowAB)
+
+    assert model.test_flow_passes == ['B']
+    assert model._applied_flows[-1][DummyFlowAB] == {'B'}
+
+
+def test_optimizers_filters_flow_passes():
+    model = dummy_flow_model({'Optimizers': ['B']})
+    model.test_flow_passes = []
+
+    model.apply_flow(DummyFlowAB)
+
+    assert model.test_flow_passes == ['B']
+    assert model._applied_flows[-1][DummyFlowAB] == {'B'}
+
+
+def test_empty_optimizers_disables_flow_passes():
+    model = dummy_flow_model({'Optimizers': []})
+    model.test_flow_passes = []
+
+    model.apply_flow(DummyFlowAB)
+
+    assert model.test_flow_passes == []
+    assert model._applied_flows[-1][DummyFlowAB] == set()
+
+
+def test_optimizers_and_skip_optimizers_are_mutually_exclusive():
+    with pytest.raises(Exception, match='Invalid optimizer configuration'):
+        dummy_flow_model({'Optimizers': ['A'], 'SkipOptimizers': ['B']})

--- a/test/pytest/test_pointwiseconv.py
+++ b/test/pytest/test_pointwiseconv.py
@@ -160,3 +160,27 @@ def test_pointwise_config(test_case_id, strategy):
     hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir)
     # Model will fail to compile if strategy was set incorrectly
     hls_model.compile()
+
+
+def test_skip_pointwise_optimizer(tmp_path):
+    model = tf.keras.models.Sequential()
+    model.add(
+        Conv1D(
+            filters=4,
+            kernel_size=(1,),
+            input_shape=(8, 3),
+            use_bias=False,
+            name='pointwise1d',
+        )
+    )
+    model.compile(optimizer='adam', loss='mse')
+
+    config = hls4ml.utils.config_from_keras_model(model, granularity='name', backend='Vivado')
+    config['SkipOptimizers'] = ['vivado:optimize_pointwise_conv']
+
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=config, output_dir=str(tmp_path), io_type='io_parallel', backend='Vivado'
+    )
+
+    assert [node.class_name for node in hls_model.graph.values()] == ['Input', 'Conv1D']
+    assert 'vivado:optimize_pointwise_conv' not in hls_model._applied_flows[0]['vivado:optimize']


### PR DESCRIPTION
## Summary

Fix `SkipOptimizers` and `Optimizers` so they apply to optimizer passes run through flows.
Add flow-level regression coverage for skipped, selected, empty, and mutually exclusive optimizer configuration.
Add a Keras pointwise Conv1D regression test for the issue path.

## Root Cause

`SkipOptimizers` previously built `HLSConfig.optimizers` from the global pass registry, but normal conversion runs optimizers from flow definitions.
As a result, flow-owned passes such as `vivado:optimize_pointwise_conv` still ran even when users listed them in `SkipOptimizers`.

## Validation

- `python -m pytest test/pytest/test_flows.py -q --randomly-seed=42 --randomly-dont-reorganize --randomly-dont-reset-seed`
- `python -m pytest 'test/pytest/test_pointwiseconv.py::test_skip_pointwise_optimizer' -q --randomly-seed=42 --randomly-dont-reorganize --randomly-dont-reset-seed`
- `python -m compileall hls4ml/model/graph.py test/pytest/test_flows.py test/pytest/test_pointwiseconv.py`
- `python -m pre_commit run --files hls4ml/model/graph.py test/pytest/test_flows.py test/pytest/test_pointwiseconv.py`

Fixes #1128
