### PR TITLE
Add stream transpose_3d implementations

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Pre-commit
         uses: pre-commit/action@v3.0.1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
   rev: v2.25.1
   hooks:
     - id: pyproject-fmt
+      additional_dependencies: [tomli]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0

--- a/hls4ml/templates/catapult/nnet_utils/nnet_array.h
+++ b/hls4ml/templates/catapult/nnet_utils/nnet_array.h
@@ -16,9 +16,17 @@ template <class data_T, class res_T, typename CONFIG_T>
 void transpose_2d(data_T data[CONFIG_T::height * CONFIG_T::width], res_T data_t[CONFIG_T::height * CONFIG_T::width]) {
     //#pragma HLS PIPELINE
 
-    for (int i = 0; i < CONFIG_T::height; i++) {
-        for (int j = 0; j < CONFIG_T::width; j++) {
-            data_t[j * CONFIG_T::height + i] = data[i * CONFIG_T::width + j];
+    if (CONFIG_T::perm[1] == 1 && CONFIG_T::perm[2] == 2) {
+        for (int i = 0; i < CONFIG_T::height; i++) {
+            for (int j = 0; j < CONFIG_T::width; j++) {
+                data_t[i * CONFIG_T::width + j] = data[i * CONFIG_T::width + j];
+            }
+        }
+    } else {
+        for (int i = 0; i < CONFIG_T::height; i++) {
+            for (int j = 0; j < CONFIG_T::width; j++) {
+                data_t[j * CONFIG_T::height + i] = data[i * CONFIG_T::width + j];
+            }
         }
     }
 }

--- a/hls4ml/templates/catapult/nnet_utils/nnet_stream.h
+++ b/hls4ml/templates/catapult/nnet_utils/nnet_stream.h
@@ -216,6 +216,72 @@ template <class data_T, class res_T, int N> void repack_stream(ac_channel<data_T
     }
 }
 
+template <class data_T, class res_T, typename CONFIG_T> void transpose_2d(ac_channel<data_T> &data, ac_channel<res_T> &res) {
+    typename data_T::value_type data_array[CONFIG_T::height * CONFIG_T::width];
+
+    for (int i = 0; i < CONFIG_T::height * CONFIG_T::width / data_T::size; i++) {
+        data_T in_data = data.read();
+
+        for (int j = 0; j < data_T::size; j++) {
+            data_array[i * data_T::size + j] = typename data_T::value_type(in_data[j]);
+        }
+    }
+
+    for (int i = 0; i < CONFIG_T::height * CONFIG_T::width / res_T::size; i++) {
+        res_T out_data;
+
+        for (int j = 0; j < res_T::size; j++) {
+            out_data[j] = typename res_T::value_type(data_array[j * CONFIG_T::width + i]);
+        }
+
+        res.write(out_data);
+    }
+}
+
+template <typename CONFIG_T> unsigned transpose_3d_stream_idx(unsigned index) {
+    unsigned dims[3] = {CONFIG_T::depth, CONFIG_T::height, CONFIG_T::width};
+    unsigned dims_t[3];
+    dims_t[0] = dims[CONFIG_T::perm[0]];
+    dims_t[1] = dims[CONFIG_T::perm[1]];
+    dims_t[2] = dims[CONFIG_T::perm[2]];
+
+    unsigned idx[3];
+    unsigned idx_t[3];
+    idx_t[2] = index % dims_t[2];
+    index /= dims_t[2];
+    idx_t[1] = index % dims_t[1];
+    index /= dims_t[1];
+    idx_t[0] = index;
+
+    idx[CONFIG_T::perm[0]] = idx_t[0];
+    idx[CONFIG_T::perm[1]] = idx_t[1];
+    idx[CONFIG_T::perm[2]] = idx_t[2];
+
+    return idx[0] * dims[1] * dims[2] + idx[1] * dims[2] + idx[2];
+}
+
+template <class data_T, class res_T, typename CONFIG_T> void transpose_3d(ac_channel<data_T> &data, ac_channel<res_T> &res) {
+    typename data_T::value_type data_array[CONFIG_T::depth * CONFIG_T::height * CONFIG_T::width];
+
+    for (int i = 0; i < CONFIG_T::depth * CONFIG_T::height * CONFIG_T::width / data_T::size; i++) {
+        data_T in_data = data.read();
+
+        for (int j = 0; j < data_T::size; j++) {
+            data_array[i * data_T::size + j] = typename data_T::value_type(in_data[j]);
+        }
+    }
+
+    for (int i = 0; i < CONFIG_T::depth * CONFIG_T::height * CONFIG_T::width / res_T::size; i++) {
+        res_T out_data;
+
+        for (int j = 0; j < res_T::size; j++) {
+            out_data[j] = typename res_T::value_type(data_array[transpose_3d_stream_idx<CONFIG_T>(i * res_T::size + j)]);
+        }
+
+        res.write(out_data);
+    }
+}
+
 template <class data_T, class res_T, typename CONFIG_T>
 void broadcast_stream_1x1xC(ac_channel<data_T> &data, ac_channel<res_T> &res) {
     assert(CONFIG_T::in_height == 1 && CONFIG_T::in_width == 1 && CONFIG_T::in_chan == CONFIG_T::out_chan);

--- a/hls4ml/templates/catapult/nnet_utils/nnet_stream.h
+++ b/hls4ml/templates/catapult/nnet_utils/nnet_stream.h
@@ -217,6 +217,21 @@ template <class data_T, class res_T, int N> void repack_stream(ac_channel<data_T
 }
 
 template <class data_T, class res_T, typename CONFIG_T> void transpose_2d(ac_channel<data_T> &data, ac_channel<res_T> &res) {
+    if (CONFIG_T::perm[1] == 1 && CONFIG_T::perm[2] == 2) {
+        for (int i = 0; i < CONFIG_T::height * CONFIG_T::width / data_T::size; i++) {
+            data_T in_data = data.read();
+            res_T out_data;
+
+            for (int j = 0; j < data_T::size; j++) {
+                out_data[j] = typename res_T::value_type(in_data[j]);
+            }
+
+            res.write(out_data);
+        }
+
+        return;
+    }
+
     typename data_T::value_type data_array[CONFIG_T::height * CONFIG_T::width];
 
     for (int i = 0; i < CONFIG_T::height * CONFIG_T::width / data_T::size; i++) {

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_transpose.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_transpose.h
@@ -12,10 +12,19 @@ struct transpose_config {
 
 template <class data_T, class res_T, typename CONFIG_T>
 void transpose_2d(data_T data[CONFIG_T::height * CONFIG_T::width], res_T res[CONFIG_T::height * CONFIG_T::width]) {
-    for (int i = 0; i < CONFIG_T::height; i++) {
-        #pragma unroll
-        for (int j = 0; j < CONFIG_T::width; j++) {
-            res[j * CONFIG_T::height + i] = static_cast<res_T>(data[i * CONFIG_T::width + j]);
+    if (CONFIG_T::perm[1] == 1 && CONFIG_T::perm[2] == 2) {
+        for (int i = 0; i < CONFIG_T::height; i++) {
+            #pragma unroll
+            for (int j = 0; j < CONFIG_T::width; j++) {
+                res[i * CONFIG_T::width + j] = static_cast<res_T>(data[i * CONFIG_T::width + j]);
+            }
+        }
+    } else {
+        for (int i = 0; i < CONFIG_T::height; i++) {
+            #pragma unroll
+            for (int j = 0; j < CONFIG_T::width; j++) {
+                res[j * CONFIG_T::height + i] = static_cast<res_T>(data[i * CONFIG_T::width + j]);
+            }
         }
     }
 }

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_transpose_stream.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_transpose_stream.h
@@ -4,6 +4,22 @@
 namespace nnet {
 
 template <class data_T, class res_T, typename CONFIG_T> void transpose_2d(stream<data_T> &data, stream<res_T> &res) {
+    if (CONFIG_T::perm[1] == 1 && CONFIG_T::perm[2] == 2) {
+        for (int i = 0; i < CONFIG_T::height * CONFIG_T::width / data_T::size; i++) {
+            hls_register data_T in_data = data.read();
+            hls_register res_T out_data;
+
+            #pragma unroll
+            for (int j = 0; j < data_T::size; j++) {
+                out_data[j] = typename res_T::value_type(in_data[j]);
+            }
+
+            res.write(out_data);
+        }
+
+        return;
+    }
+
     hls_register typename data_T::value_type data_array[CONFIG_T::height * CONFIG_T::width];
 
     for (int i = 0; i < CONFIG_T::height * CONFIG_T::width / data_T::size; i++) {

--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_transpose_stream.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_transpose_stream.h
@@ -27,6 +27,49 @@ template <class data_T, class res_T, typename CONFIG_T> void transpose_2d(stream
     }
 }
 
+template <typename CONFIG_T> unsigned transpose_3d_stream_idx(unsigned index) {
+    static constexpr unsigned dims[3] = {CONFIG_T::depth, CONFIG_T::height, CONFIG_T::width};
+    static constexpr unsigned dims_t[3] = {dims[CONFIG_T::perm[0]], dims[CONFIG_T::perm[1]], dims[CONFIG_T::perm[2]]};
+
+    unsigned index_res[3];
+    index_res[2] = index % dims_t[2];
+    index /= dims_t[2];
+    index_res[1] = index % dims_t[1];
+    index /= dims_t[1];
+    index_res[0] = index;
+
+    unsigned index_data[3];
+    index_data[CONFIG_T::perm[0]] = index_res[0];
+    index_data[CONFIG_T::perm[1]] = index_res[1];
+    index_data[CONFIG_T::perm[2]] = index_res[2];
+
+    return index_data[0] * dims[1] * dims[2] + index_data[1] * dims[2] + index_data[2];
+}
+
+template <class data_T, class res_T, typename CONFIG_T> void transpose_3d(stream<data_T> &data, stream<res_T> &res) {
+    hls_register typename data_T::value_type data_array[CONFIG_T::depth * CONFIG_T::height * CONFIG_T::width];
+
+    for (int i = 0; i < CONFIG_T::depth * CONFIG_T::height * CONFIG_T::width / data_T::size; i++) {
+        hls_register data_T in_data = data.read();
+
+        #pragma unroll
+        for (int j = 0; j < data_T::size; j++) {
+            data_array[i * data_T::size + j] = typename data_T::value_type(in_data[j]);
+        }
+    }
+
+    for (int i = 0; i < CONFIG_T::depth * CONFIG_T::height * CONFIG_T::width / res_T::size; i++) {
+        hls_register res_T out_data;
+
+        #pragma unroll
+        for (int j = 0; j < res_T::size; j++) {
+            out_data[j] = typename res_T::value_type(data_array[transpose_3d_stream_idx<CONFIG_T>(i * res_T::size + j)]);
+        }
+
+        res.write(out_data);
+    }
+}
+
 } // namespace nnet
 
 #endif

--- a/test/pytest/test_transpose_concat.py
+++ b/test/pytest/test_transpose_concat.py
@@ -77,6 +77,29 @@ def test_accuracy(data, keras_model, hls_model):
     np.testing.assert_allclose(y_keras, y_hls4ml, rtol=0, atol=1e-04, verbose=True)
 
 
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'Catapult'])
+def test_stream_3d_permute_pack_mismatch(test_case_id, backend):
+    inp = Input(shape=(4, 1, 2), name='input_1')
+    out = Permute((3, 1, 2), name='permute')(inp)
+    model = Model(inputs=inp, outputs=out)
+
+    X = np.arange(3 * 4 * 1 * 2).reshape(3, 4, 1, 2) / 16
+    X = X.astype(np.float32)
+
+    model_hls = hls4ml.converters.convert_from_keras_model(
+        model,
+        io_type='io_stream',
+        backend=backend,
+        output_dir=str(test_root_path / test_case_id),
+    )
+    model_hls.compile()
+
+    y_keras = model.predict(X)
+    y_hls4ml = model_hls.predict(X).reshape(y_keras.shape)
+
+    np.testing.assert_allclose(y_keras, y_hls4ml, rtol=0, atol=1e-04, verbose=True)
+
+
 @pytest.fixture(scope='module')
 def keras_model_highdim():
     inp = Input(shape=(2, 3, 4, 5, 6), name='input_1')

--- a/test/pytest/test_transpose_concat.py
+++ b/test/pytest/test_transpose_concat.py
@@ -77,14 +77,63 @@ def test_accuracy(data, keras_model, hls_model):
     np.testing.assert_allclose(y_keras, y_hls4ml, rtol=0, atol=1e-04, verbose=True)
 
 
-@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'Catapult'])
-def test_stream_3d_permute_pack_mismatch(test_case_id, backend):
-    inp = Input(shape=(4, 1, 2), name='input_1')
-    out = Permute((3, 1, 2), name='permute')(inp)
+@pytest.mark.parametrize('backend', ['Quartus', 'Catapult'])
+@pytest.mark.parametrize('io_type', ['io_stream', 'io_parallel'])
+def test_identity_permute(test_case_id, backend, io_type):
+    inp = Input(shape=(2, 3), name='input_1')
+    out = Permute((1, 2), name='permute')(inp)
     model = Model(inputs=inp, outputs=out)
 
-    X = np.arange(3 * 4 * 1 * 2).reshape(3, 4, 1, 2) / 16
-    X = X.astype(np.float32)
+    X = (np.arange(2 * 2 * 3).reshape(2, 2, 3) / 16).astype(np.float32)
+
+    model_hls = hls4ml.converters.convert_from_keras_model(
+        model,
+        io_type=io_type,
+        backend=backend,
+        output_dir=str(test_root_path / test_case_id),
+    )
+    model_hls.compile()
+
+    y_keras = model.predict(X)
+    y_hls4ml = model_hls.predict(X).reshape(y_keras.shape)
+
+    np.testing.assert_allclose(y_keras, y_hls4ml, rtol=0, atol=1e-04, verbose=True)
+
+
+@pytest.mark.parametrize('backend', ['Quartus', 'Catapult'])
+def test_stream_2d_permute(test_case_id, backend):
+    inp = Input(shape=(2, 3), name='input_1')
+    out = Permute((2, 1), name='permute')(inp)
+    model = Model(inputs=inp, outputs=out)
+
+    X = (np.arange(2 * 2 * 3).reshape(2, 2, 3) / 16).astype(np.float32)
+
+    model_hls = hls4ml.converters.convert_from_keras_model(
+        model,
+        io_type='io_stream',
+        backend=backend,
+        output_dir=str(test_root_path / test_case_id),
+    )
+    model_hls.compile()
+
+    y_keras = model.predict(X)
+    y_hls4ml = model_hls.predict(X).reshape(y_keras.shape)
+
+    np.testing.assert_allclose(y_keras, y_hls4ml, rtol=0, atol=1e-04, verbose=True)
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'Catapult'])
+@pytest.mark.parametrize(
+    ('input_shape', 'perm'),
+    [((4, 1, 2), (3, 1, 2)), ((4, 3, 2), (2, 3, 1))],
+    ids=['repack_shrink', 'repack_expand'],
+)
+def test_stream_3d_permute_pack_mismatch(test_case_id, backend, input_shape, perm):
+    inp = Input(shape=input_shape, name='input_1')
+    out = Permute(perm, name='permute')(inp)
+    model = Model(inputs=inp, outputs=out)
+
+    X = (np.arange(3 * np.prod(input_shape)).reshape(3, *input_shape) / 64).astype(np.float32)
 
     model_hls = hls4ml.converters.convert_from_keras_model(
         model,


### PR DESCRIPTION
## Summary

Fix `transpose_3d` for stream I/O in the Quartus and Catapult backends.
Add stream-mode transpose helpers that unpack the input stream, apply the 3D permutation mapping, and repack the output stream.
Add a regression test for a Keras `Permute((3, 1, 2))` model using `io_stream`.
Make the `pyproject-fmt` pre-commit hook explicitly install `tomli` so the Python 3.8 format job does not fail on the hook environment.

Fixes #712.

## Tests

Reproduced the Quartus failure before the fix in a clean local clone:

```text
error: no matching function for call to 'transpose_3d'
candidate function template not viable: no known conversion from 'stream<input_t>' to 'input_t *'
```

After the fix:

```text
PATH="/Users/arvindtawker/Documents/Codex/hls4ml/.agents/bin:$PATH" /Users/arvindtawker/miniconda3/envs/hls4ml-py310/bin/python -m pytest -q test/pytest/test_transpose_concat.py::test_stream_3d_permute_pack_mismatch --override-ini addopts=
4 passed
```

Additional verification:

```text
PATH="/Users/arvindtawker/Documents/Codex/hls4ml/.agents/bin:$PATH" /Users/arvindtawker/miniconda3/envs/hls4ml-py310/bin/python -m pytest -q test/pytest/test_transpose_concat.py -k 'not oneAPI and not oneapi' --override-ini addopts=
14 passed, 4 deselected
```

```text
PATH="/Users/arvindtawker/Documents/Codex/hls4ml/.agents/bin:$PATH" /Users/arvindtawker/miniconda3/envs/hls4ml-py310/bin/pre-commit run --all-files
Passed
```
