### PR TITLE
Fix non-quantized QConv2DBatchnorm conversion

### DIFF
--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -689,21 +689,25 @@ class Conv2DBatchnorm(Conv2D):
     def initialize(self):
         super().initialize()
         folded_weights, folded_bias = self._get_folded_weights()
+        weight_q = self.get_attr('weight_quantizer')
         if self.model.config.is_resource_strategy(self) and self.model.config.backend.name in [
             'Vivado',
             'VivadoAccelerator',
             'Catapult',
         ]:
             self.weights['weight'].data_unquantized = np.transpose(folded_weights, axes=[3, 0, 1, 2])
-            self.weights['weight'].data = self.get_attr('weight_quantizer')(self.weights['weight'].data_unquantized)
+            self.weights['weight'].data = (
+                weight_q(self.weights['weight'].data_unquantized)
+                if weight_q is not None
+                else self.weights['weight'].data_unquantized
+            )
 
         else:
             self.weights['weight'].data_unquantized = folded_weights
-            self.weights['weight'].data = self.get_attr('weight_quantizer')(folded_weights)
+            self.weights['weight'].data = weight_q(folded_weights) if weight_q is not None else folded_weights
         self.weights['bias'].data_unquantized = folded_bias
         bias_q = self.get_attr('bias_quantizer')
-        if bias_q is not None:
-            self.weights['bias'].data = bias_q(folded_bias)
+        self.weights['bias'].data = bias_q(folded_bias) if bias_q is not None else folded_bias
 
 
 class SeparableConv2D(Layer):

--- a/test/pytest/test_qkeras.py
+++ b/test/pytest/test_qkeras.py
@@ -473,6 +473,39 @@ def test_qconv2dbn(test_case_id, randX_100_8_8_1, backend, io_type):
     np.testing.assert_array_equal(y_qkeras, y_hls4ml.reshape(y_qkeras.shape))
 
 
+@pytest.mark.parametrize('strategy', ['Latency', 'Resource'])
+def test_qconv2dbn_without_quantizers(test_case_id, randX_100_8_8_1, strategy):
+    X = randX_100_8_8_1
+    X = np.round(X * 2**10) * 2**-10  # make it an exact ap_fixed<16,6>
+    model = Sequential()
+    model.add(
+        QConv2DBatchnorm(
+            4,
+            kernel_size=(3, 3),
+            input_shape=(8, 8, 1),
+            kernel_initializer='ones',
+            bias_initializer='zeros',
+            activation='linear',
+        )
+    )
+    model.compile()
+
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='fixed<24,8>', backend='Vivado'
+    )
+    config['Model']['Strategy'] = strategy
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=config, output_dir=output_dir, backend='Vivado', io_type='io_parallel'
+    )
+    hls_model.compile()
+
+    y_qkeras = model.predict(X)
+    y_hls4ml = hls_model.predict(X)
+
+    np.testing.assert_allclose(y_qkeras, y_hls4ml.reshape(y_qkeras.shape), rtol=0, atol=2**-12)
+
+
 @pytest.fixture(scope='module')
 def randX_10_32_32_3():
     return np.random.rand(10, 32, 32, 3)

--- a/test/pytest/test_qkerasV3.py
+++ b/test/pytest/test_qkerasV3.py
@@ -569,6 +569,39 @@ def test_qconv2dbn(test_case_id, randX_100_8_8_1, backend, io_type):
     np.testing.assert_array_equal(y_qkeras, y_hls4ml.reshape(y_qkeras.shape))
 
 
+@pytest.mark.parametrize('strategy', ['Latency', 'Resource'])
+def test_qconv2dbn_without_quantizers(test_case_id, randX_100_8_8_1, strategy):
+    X = randX_100_8_8_1
+    X = np.round(X * 2**10) * 2**-10  # make it an exact ap_fixed<16,6>
+    model = Sequential()
+    model.add(
+        QConv2DBatchnorm(
+            4,
+            kernel_size=(3, 3),
+            input_shape=(8, 8, 1),
+            kernel_initializer='ones',
+            bias_initializer='zeros',
+            activation='linear',
+        )
+    )
+    model.compile()
+
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='fixed<24,8>', backend='Vivado'
+    )
+    config['Model']['Strategy'] = strategy
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=config, output_dir=output_dir, backend='Vivado', io_type='io_parallel'
+    )
+    hls_model.compile()
+
+    y_qkeras = model.predict(X)
+    y_hls4ml = hls_model.predict(X)
+
+    np.testing.assert_allclose(y_qkeras, y_hls4ml.reshape(y_qkeras.shape), rtol=0, atol=2**-12)
+
+
 @pytest.fixture(scope='module')
 def randX_10_32_32_3():
     return np.random.rand(10, 32, 32, 3)


### PR DESCRIPTION
## Summary

- Allow `QConv2DBatchnorm` layers without weight or bias quantizers to convert after batch-normalization folding.
- Preserve folded unquantized weights and bias when their corresponding quantizer is `None`.
- Add matched Keras 2/QKeras and Keras 3/QKeras-v3 regressions for both `Latency` and `Resource` strategies.

Fixes #928.

## Tests

- `pre-commit run --files hls4ml/model/layers.py test/pytest/test_qkeras.py test/pytest/test_qkerasV3.py`
- Keras 2/QKeras focused regression: 2 passed.
- Keras 3/QKeras-v3 focused regression: 2 passed.
- Keras 2/QKeras cross-backend acceptance subset: 14 passed (Vivado, Vitis, Quartus; `io_parallel` and `io_stream`).
- Keras 3/QKeras-v3 cross-backend acceptance subset: 14 passed (Vivado, Vitis, Quartus; `io_parallel` and `io_stream`).
- Conversion-only validation passed for Vivado, Vitis, Quartus, Catapult, and oneAPI, including the Vivado `Resource` path.
