### PR TITLE
Fix BramFactor co-sim and enable it for io_parallel

### DIFF
--- a/hls4ml/templates/vivado/myproject_test.cpp
+++ b/hls4ml/templates/vivado/myproject_test.cpp
@@ -23,6 +23,8 @@ size_t trace_type_size = sizeof(double);
 int main(int argc, char **argv) {
     // hls-fpga-machine-learning insert namespace
 
+    // hls-fpga-machine-learning insert load weights
+
     // load input data from text file
     std::ifstream fin("tb_data/tb_input_features.dat");
     // load predictions from text file

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -220,6 +220,8 @@ class VivadoWriter(Writer):
                     newline += indent + '#pragma HLS INTERFACE ap_vld port={},{} \n'.format(
                         ','.join(all_inputs), ','.join(all_outputs)
                     )
+                    if all_brams:
+                        newline += indent + '#pragma HLS INTERFACE bram port={} \n'.format(','.join(all_brams))
                     newline += pipeline_pragma
 
                 if io_type == 'io_stream':
@@ -585,6 +587,14 @@ class VivadoWriter(Writer):
                 newline = line
                 for bram in model_brams:
                     newline += f'#include "firmware/weights/{bram.name}.h"\n'
+
+            elif '// hls-fpga-machine-learning insert load weights' in line:
+                newline = line
+                if model_brams and model.config.get_writer_config()['WriteWeightsTxt']:
+                    for bram in model_brams:
+                        newline += indent + 'nnet::load_weights_from_txt<{}, {}>({}, "{}.txt");\n'.format(
+                            bram.type.name, bram.data_length, bram.name, bram.name
+                        )
 
             elif '// hls-fpga-machine-learning insert data' in line:
                 newline = line


### PR DESCRIPTION
# Description

External BRAM weights (`BramFactor`) failed C/RTL co-simulation, and io_parallel never emitted an interface pragma for the weight ports. Fixes #1326. See discussion #1324.

### Problems

1. Wrong co-sim output (all io_types). BRAM weights are top-level ports, so co-sim captures their values at the call boundary. hls4ml loads weights only *inside* the top function, so co-sim drove uninitialized (zero) arrays into the RTL. C-sim was unaffected.
2. io_parallel had no `INTERFACE bram` pragma. It was only emitted for io_stream.

## Type of change


- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

QKeras MLP, Vitis 2025.1, `xcvu13p`, matrix of io_parallel/io_stream × Resource/Latency × RF=1/8. BramFactor full + partial

interface pragma is interface-only, so synthesis (LUT/FF/DSP/BRAM/II) remained identical.


## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
