### PR TITLE
make ap_{fixed|int}_special.h work on the mac

### DIFF
--- a/hls4ml/templates/vivado/ap_types/ap_fixed_special.h
+++ b/hls4ml/templates/vivado/ap_types/ap_fixed_special.h
@@ -27,10 +27,10 @@
 #endif
 // FIXME AP_AUTOCC cannot handle many standard headers, so declare instead of
 // include.
-// #include <complex>
-namespace std {
-template<typename _Tp> class complex;
-}
+#include <complex>
+// namespace std {
+// template<typename _Tp> class complex;
+// }
 
 /*
   TODO: Modernize the code using C++11/C++14

--- a/hls4ml/templates/vivado/ap_types/ap_int_special.h
+++ b/hls4ml/templates/vivado/ap_types/ap_int_special.h
@@ -27,10 +27,10 @@
 #endif
 // FIXME AP_AUTOCC cannot handle many standard headers, so declare instead of
 // include.
-// #include <complex>
-namespace std {
-template<typename _Tp> class complex;
-}
+#include <complex>
+// namespace std {
+// template<typename _Tp> class complex;
+// }
 
 /*
   TODO: Modernize the code using C++11/C++14


### PR DESCRIPTION
# Description

Currently `ap_int_special.h` and `ap_fixed_special.h` cause issues on a Mac with the default toolchain because `complex` is ambiguous. This fix always takes the standard complex header. We just have to make sure it doesn't break things for other setups. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

This should be transparent to all the pytests. It has been tested locally on a mac.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
