### PR TITLE
Handle empty optional ONNX inputs in shape parsing

### DIFF
--- a/hls4ml/converters/onnx_to_hls.py
+++ b/hls4ml/converters/onnx_to_hls.py
@@ -49,20 +49,22 @@ def get_global_input_shape(graph, inp):
 
 
 def get_input_shape(graph, node):
-    """Return the input shapes of the node in the model
+    """Return the non empty input shapes of the node in the model
 
     Arguments:
         graph:  the onnx graph
         node:  the onnx node for which the input is desired
 
     Returns:
-        list of lists: The shapes of all the inputs
+        list of lists: The shapes of all the non empty inputs
 
     Raises:
         StopIteration:  If the an input name is not found in the graph
     """
     rv = []
     for inp in node.input:
+        if not inp:
+            continue
         # first try regular variables
         vals = [x for x in graph.value_info if x.name == inp]
         if not vals:

--- a/test/pytest/test_onnx_to_hls.py
+++ b/test/pytest/test_onnx_to_hls.py
@@ -1,0 +1,27 @@
+from onnx import TensorProto, helper
+
+from hls4ml.converters.onnx_to_hls import get_input_shape
+
+
+def test_get_input_shape_skips_empty_optional_inputs():
+    input_tensor = helper.make_tensor_value_info('global_in', TensorProto.FLOAT, [1, 1, 25, 25])
+    scales_tensor = helper.make_tensor_value_info('resize_scales', TensorProto.FLOAT, [4])
+    output_tensor = helper.make_tensor_value_info('global_out', TensorProto.FLOAT, [1, 1, 50, 50])
+
+    resize_node = helper.make_node(
+        'Resize',
+        name='resize',
+        inputs=['global_in', '', 'resize_scales'],
+        outputs=['global_out'],
+        mode='nearest',
+    )
+
+    graph = helper.make_graph(
+        nodes=[resize_node],
+        name='ResizeWithoutRoiGraph',
+        inputs=[input_tensor],
+        outputs=[output_tensor],
+        value_info=[scales_tensor],
+    )
+
+    assert get_input_shape(graph, resize_node) == [[1, 1, 25, 25], [4]]


### PR DESCRIPTION
## Summary

Fixes #1266.

In ONNX, optional inputs that are not provided are represented by an empty string (`""`). For example, a `Resize` node can have inputs like : ['Quant_0_out0', '', 'Resize_0_param0']


where the second entry corresponds to the optional ROI input.

At the moment, `get_input_shape()` attempts to resolve the shape for every input, including the empty placeholder. Since an empty string does not correspond to a valid tensor, this results in,

 RuntimeError: Could not find the shape for input


This change simply skips empty input placeholders while keeping the existing behavior unchanged for valid input names. If a non empty input is missing its shape, the same error is still raised.

## Changes

- Ignore empty input placeholders in `get_input_shape()`.
 - Update the docstring to clarify that shapes are returned only for non empty inputs.
- Add a regression test for a `Resize` node with the optional ROI input omitted.

## Testing

```bash
pytest test/pytest/test_onnx_to_hls.py
```