### PR TITLE
fix: Increase inverse softmax LUT resolution to reduce argmax flips (closes #1512)

### DIFF
--- a/hls4ml/converters/keras_v3/hgq2/softmax.py
+++ b/hls4ml/converters/keras_v3/hgq2/softmax.py
@@ -82,6 +82,13 @@ class QSoftmaxHandler(QLayerHandler):
         exp_table_t = fixed_quantizer_to_hls4ml_t(exp_oq)
         inv_table_t = fixed_quantizer_to_hls4ml_t(inv_oq)
         inv_inp_t = fixed_quantizer_to_hls4ml_t(inv_iq)
+        # Ensure sufficient LUT resolution for the inverse table to avoid argmax flips.
+        # The default width may be too small (e.g., 8 bits) for large input ranges,
+        # causing approximation errors that preserve normalization but flip the argmax.
+        if inv_inp_t.width < 16:
+            inv_inp_t = FixedPrecisionType(16, inv_inp_t.integer, signed=inv_inp_t.signed,
+                                          rounding_mode=inv_inp_t.rounding_mode,
+                                          saturation_mode=inv_inp_t.saturation_mode)
         exp_scale = layer.input_scaler
 
         inv_table_size = 2**inv_inp_t.width

--- a/hls4ml/converters/keras_v3/hgq2/softmax.py
+++ b/hls4ml/converters/keras_v3/hgq2/softmax.py
@@ -86,9 +86,13 @@ class QSoftmaxHandler(QLayerHandler):
         # The default width may be too small (e.g., 8 bits) for large input ranges,
         # causing approximation errors that preserve normalization but flip the argmax.
         if inv_inp_t.width < 16:
-            inv_inp_t = FixedPrecisionType(16, inv_inp_t.integer, signed=inv_inp_t.signed,
-                                          rounding_mode=inv_inp_t.rounding_mode,
-                                          saturation_mode=inv_inp_t.saturation_mode)
+            inv_inp_t = FixedPrecisionType(
+                16,
+                inv_inp_t.integer,
+                signed=inv_inp_t.signed,
+                rounding_mode=inv_inp_t.rounding_mode,
+                saturation_mode=inv_inp_t.saturation_mode,
+            )
         exp_scale = layer.input_scaler
 
         inv_table_size = 2**inv_inp_t.width


### PR DESCRIPTION
## What
In hls4ml 1.3.0, converting models with a softmax output layer to HLS can cause a large fraction of argmax classification decisions to differ from the float32 reference, despite correctly normalized probabilities (Σp = 1). The issue is traced to the softmax LUT approximation in the QSoftmax converter, which for some weight distributions has insufficient resolution in the inverse (1/exp) table.

## Fix
Ensure that the input fixed-point precision for the inverse table has at least 16 bits of total width, which provides sufficient LUT entries to accurately represent exp(-x) across a wide range of inputs. The patch modifies the QSoftmaxHandler to upgrade the inverse table input precision to at least 16 bits when the original width is smaller. This is a minimal change that affects only the LUT resolution and should reduce argmax flips without breaking normalization.

Closes #1512