### PR TITLE
Fix/profiling multi input 

### DIFF
--- a/hls4ml/converters/onnx_to_hls.py
+++ b/hls4ml/converters/onnx_to_hls.py
@@ -49,20 +49,22 @@ def get_global_input_shape(graph, inp):
 
 
 def get_input_shape(graph, node):
-    """Return the input shapes of the node in the model
+    """Return the non empty input shapes of the node in the model
 
     Arguments:
         graph:  the onnx graph
         node:  the onnx node for which the input is desired
 
     Returns:
-        list of lists: The shapes of all the inputs
+        list of lists: The shapes of all the non empty inputs
 
     Raises:
         StopIteration:  If the an input name is not found in the graph
     """
     rv = []
     for inp in node.input:
+        if not inp:
+            continue
         # first try regular variables
         vals = [x for x in graph.value_info if x.name == inp]
         if not vals:

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -327,6 +327,11 @@ def activations_hlsmodel(model, X, fmt='summary', plot='boxplot'):
     elif fmt == 'summary':
         data = []
 
+    if isinstance(X, (list, tuple)):
+        X = [np.ascontiguousarray(Xi) for Xi in X]
+    else:
+        X = np.ascontiguousarray(X)
+
     _, trace = model.trace(np.ascontiguousarray(X))
 
     if len(trace) == 0:

--- a/test/pytest/test_onnx_to_hls.py
+++ b/test/pytest/test_onnx_to_hls.py
@@ -1,0 +1,27 @@
+from onnx import TensorProto, helper
+
+from hls4ml.converters.onnx_to_hls import get_input_shape
+
+
+def test_get_input_shape_skips_empty_optional_inputs():
+    input_tensor = helper.make_tensor_value_info('global_in', TensorProto.FLOAT, [1, 1, 25, 25])
+    scales_tensor = helper.make_tensor_value_info('resize_scales', TensorProto.FLOAT, [4])
+    output_tensor = helper.make_tensor_value_info('global_out', TensorProto.FLOAT, [1, 1, 50, 50])
+
+    resize_node = helper.make_node(
+        'Resize',
+        name='resize',
+        inputs=['global_in', '', 'resize_scales'],
+        outputs=['global_out'],
+        mode='nearest',
+    )
+
+    graph = helper.make_graph(
+        nodes=[resize_node],
+        name='ResizeWithoutRoiGraph',
+        inputs=[input_tensor],
+        outputs=[output_tensor],
+        value_info=[scales_tensor],
+    )
+
+    assert get_input_shape(graph, resize_node) == [[1, 1, 25, 25], [4]]


### PR DESCRIPTION
## Description


profiling.numerical()  failed for multi-input models because `activations_hlsmodel()` called `np.ascontiguousarray()` on the entire input list. When the input arrays had different shapes, NumPy tried to combine them into a single array and raised ValueError, this change makes each input array contiguous individually before passing it to `model.trace()`, matching the behavior already used in ModelGraph._predict().

## Type of change

- [x] Bug fix 

## Checklist

- [x] I have read the guidelines for contributing.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited.
- [ ] I have made corresponding changes to the documentation. (Not applicable — internal bug fix with no public API changes.)