### PR TITLE
Add action to close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: "Close Stale Issues"
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs every day at midnight
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: 'enhancement,help wanted,good first issue,keep-open'
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been inactive for 7 days since being marked stale.'
+          days-before-stale: 90
+          days-before-close: 7
+          stale-issue-label: 'stale'


### PR DESCRIPTION
Traditionally, we have kept old issues open for reference. These days however, outdated issues are sometimes picked up and turned into AI pull requests that clutter the repository and are a time sink. 

This PR proposes to add an action that threatens to close an issue as stale after 90 days, with a 7 day grace period to keep it alive. Issues that have been marked as help wanted, good first issues, enhancements, or generally as keep-open, are exempt in the current proposol. 

## Type of change

- [x] Other 

## Tests

No tests

## Checklist

- [x] all