### PR TITLE
Bump supported Vitis version

### DIFF
--- a/docs/intro/setup.rst
+++ b/docs/intro/setup.rst
@@ -68,7 +68,7 @@ To run FPGA synthesis, installation of following tools is required:
 
 * Xilinx Vivado HLS 2020.1 for synthesis for Xilinx FPGAs using the ``Vivado`` backend. Older versions may work, but use at your own risk.
 
-* Vitis HLS 2022.2 or newer is required for synthesis for Xilinx FPGAs using the ``Vitis`` backend.
+* Vitis HLS 2023.1 or newer is required for synthesis for Xilinx FPGAs using the ``Vitis`` backend.
 
 * Intel Quartus 20.1 to 21.4 for the synthesis for Intel/Altera FPGAs using the ``Quartus`` backend.
 


### PR DESCRIPTION
Since the switch to use `vitis-run` as the executable in the Vitis backend, Vitis 2022.2 is no longer supported. However, that change has never been reflected in the docs. This PR bumps the Vitis release number in the docs as the simplest way to clean up the situation. Alternatively, we could revisit a fall-back to the older executable name as had been proposed a while ago in https://github.com/fastmachinelearning/hls4ml/pull/1493 if there is enough desire to keep supported this older Vitis release. 

## Type of change


- [x] Documentation update

## Tests

No test 

**Test Configuration**:

## Checklist

- [x] All 
