### PR TITLE
Route Pytorch Conv1D/2D with groups == channels to depthwise conv

### DIFF
--- a/hls4ml/converters/pytorch/convolution.py
+++ b/hls4ml/converters/pytorch/convolution.py
@@ -1,5 +1,10 @@
 from hls4ml.converters.pytorch_to_hls import pytorch_handler
-from hls4ml.converters.utils import compute_padding_1d_pytorch, compute_padding_2d_pytorch, parse_data_format
+from hls4ml.converters.utils import (
+    compute_padding_1d_pytorch,
+    compute_padding_2d_pytorch,
+    is_depthwise_conv,
+    parse_data_format,
+)
 
 
 @pytorch_handler('Conv1d')
@@ -13,7 +18,18 @@ def parse_conv1d_layer(operation, layer_name, input_names, input_shapes, node, c
     layer['class_name'] = 'Conv1D'
     layer['data_format'] = 'channels_first'  # Pytorch default (can't change)
 
-    layer['weight_data'] = class_object.weight.data.numpy()
+    if is_depthwise_conv(class_object):
+        layer['class_name'] = 'DepthwiseConv1D'
+        layer['depthwise_data'] = (
+            class_object.weight.data.numpy().reshape(  # (n_chan, depth_mult, spatial) -> (depth_mult, n_chan, spatial)
+                1,
+                class_object.in_channels,
+                *class_object.kernel_size,
+            )
+        )
+        layer['depth_multiplier'] = 1
+    else:
+        layer['weight_data'] = class_object.weight.data.numpy()
     if class_object.bias is not None:
         layer['bias_data'] = class_object.bias.data.numpy()
     else:
@@ -58,7 +74,18 @@ def parse_conv2d_layer(operation, layer_name, input_names, input_shapes, node, c
     layer['class_name'] = 'Conv2D'
     layer['data_format'] = 'channels_first'  # Pytorch default (can't change)
 
-    layer['weight_data'] = class_object.weight.data.numpy()
+    if is_depthwise_conv(class_object):
+        layer['class_name'] = 'DepthwiseConv2D'
+        layer['depthwise_data'] = (
+            class_object.weight.data.numpy().reshape(  # (n_chan, depth_mult, spatial) -> (depth_mult, n_chan, spatial)
+                1,
+                class_object.in_channels,
+                *class_object.kernel_size,
+            )
+        )
+        layer['depth_multiplier'] = 1
+    else:
+        layer['weight_data'] = class_object.weight.data.numpy()
     if class_object.bias is not None:
         layer['bias_data'] = class_object.bias.data.numpy()
     else:

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from hls4ml.converters.utils import is_depthwise_conv
 from hls4ml.model import ModelGraph
 from hls4ml.utils.dependency import requires
 
@@ -278,8 +279,8 @@ def parse_pytorch_model(config, verbose=True):
             if 'Conv' in pytorch_class:
                 if not class_object.padding_mode == 'zeros':
                     raise Exception('Padding modes other than "zeros" not implemented yet')
-                if not class_object.groups == 1:
-                    raise Exception('Non-default options for groups not implemented yet')
+                if not (class_object.groups == 1 or is_depthwise_conv(class_object)):
+                    raise Exception('Non-default options for groups outside of depthwise convolution not implemented yet')
 
             # Process the layer
             layer, output_shape = layer_handlers[pytorch_class](

--- a/hls4ml/converters/utils.py
+++ b/hls4ml/converters/utils.py
@@ -291,6 +291,22 @@ def compute_padding_2d_pytorch(
     return (out_height, out_width, pad_top, pad_bottom, pad_left, pad_right)
 
 
+def is_depthwise_conv(class_object):
+    """Checks if a given convolutional layer is a depthwise convolution.
+
+    Args:
+        class_object: The convolutional layer to check.
+    Returns:
+        bool: True if the layer is a depthwise convolution, False otherwise.
+    """
+    groups = getattr(class_object, 'groups', 1)
+    return (
+        groups > 1
+        and groups == getattr(class_object, 'in_channels', 1)
+        and groups == getattr(class_object, 'out_channels', 1)
+    )
+
+
 class IsolatedLayerReader:
     def __init__(self, layer):
         self.layer = layer

--- a/test/pytest/test_depthconv1d_pytorch.py
+++ b/test/pytest/test_depthconv1d_pytorch.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+import hls4ml
+
+test_root_path = Path(__file__).parent
+
+padds_options = [0, 1]
+strides_options = [(1), (2)]
+kernel_options = [(2), (3)]
+bias_options = [False]
+rf_options = [1, 4, 6]  # each rf corresponds to one of the three cases of depthwise resource for io_stream
+input_size_options = [4]
+
+
+@pytest.mark.parametrize('padds', padds_options)
+@pytest.mark.parametrize('strides', strides_options)
+@pytest.mark.parametrize('kernels', kernel_options)
+@pytest.mark.parametrize('bias', bias_options)
+@pytest.mark.parametrize(
+    'backend, io_type, strategy',
+    [
+        ('Vivado', 'io_parallel', 'latency'),
+        ('Vitis', 'io_parallel', 'latency'),
+        ('Vivado', 'io_stream', 'latency'),
+        ('Vitis', 'io_stream', 'latency'),
+        ('Vivado', 'io_stream', 'resource'),
+        ('Vitis', 'io_stream', 'resource'),
+        ('Catapult', 'io_stream', 'latency'),
+    ],
+)
+@pytest.mark.parametrize('rf', rf_options)
+@pytest.mark.parametrize('input_size', input_size_options)
+def test_depthconv1d_pytorch(test_case_id, padds, strides, kernels, bias, io_type, backend, strategy, rf, input_size):
+    model = nn.Sequential(
+        nn.Conv1d(
+            in_channels=input_size,
+            out_channels=input_size,
+            kernel_size=kernels,
+            stride=strides,
+            padding=padds,
+            groups=input_size,  # depthwise convolution
+            bias=bias,
+        ),
+    )
+    model.eval()
+
+    input_shape = (input_size, 16)
+    X_input = np.random.rand(100, *input_shape)  # (batch_size, channels, width)
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    if io_type == 'io_stream':
+        X_input = np.ascontiguousarray(X_input.transpose(0, 2, 1))
+        channels_last_conversion = 'internal'
+        transpose_outputs = False
+    else:
+        channels_last_conversion = 'full'
+        transpose_outputs = True
+
+    config = hls4ml.utils.config_from_pytorch_model(
+        model,
+        input_shape=input_shape,
+        default_precision='ap_fixed<32,8>',
+        channels_last_conversion=channels_last_conversion,
+        transpose_outputs=transpose_outputs,
+    )
+
+    config['Model']['Strategy'] = strategy
+    config['Model']['ReuseFactor'] = rf
+
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_pytorch_model(
+        model, hls_config=config, output_dir=output_dir, io_type=io_type, backend=backend
+    )
+    assert all(layer.class_name == 'DepthwiseConv1D' for layer in hls_model.get_layers() if 'Conv' in layer.class_name), (
+        'depthwise conv must map to DepthwiseConv1D'
+    )
+    hls_model.compile()
+    hls_prediction = hls_model.predict(X_input)
+    if io_type == 'io_stream':
+        channels_last_shape = pytorch_prediction.transpose(0, 2, 1).shape
+        hls_prediction = hls_prediction.reshape(channels_last_shape).transpose(0, 2, 1)
+    else:
+        hls_prediction = hls_prediction.reshape(pytorch_prediction.shape)
+
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=0.001)

--- a/test/pytest/test_depthconv2d_pytorch.py
+++ b/test/pytest/test_depthconv2d_pytorch.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+import hls4ml
+
+test_root_path = Path(__file__).parent
+
+padds_options = [0, 1]
+strides_options = [(1), (2)]
+kernel_options = [(2), (3)]
+bias_options = [False]
+rf_options = [1, 4, 6]  # each rf corresponds to one of the three cases of depthwise resource for io_stream
+input_size_options = [4]
+
+
+@pytest.mark.parametrize('padds', padds_options)
+@pytest.mark.parametrize('strides', strides_options)
+@pytest.mark.parametrize('kernels', kernel_options)
+@pytest.mark.parametrize('bias', bias_options)
+@pytest.mark.parametrize(
+    'backend, io_type, strategy',
+    [
+        ('Vivado', 'io_parallel', 'latency'),
+        ('Vitis', 'io_parallel', 'latency'),
+        ('Vivado', 'io_stream', 'latency'),
+        ('Vitis', 'io_stream', 'latency'),
+        ('Vivado', 'io_stream', 'resource'),
+        ('Vitis', 'io_stream', 'resource'),
+        ('Catapult', 'io_stream', 'latency'),
+    ],
+)
+@pytest.mark.parametrize('rf', rf_options)
+@pytest.mark.parametrize('input_size', input_size_options)
+def test_depthconv2d_pytorch(test_case_id, padds, strides, kernels, bias, io_type, backend, strategy, rf, input_size):
+    model = nn.Sequential(
+        nn.Conv2d(
+            in_channels=input_size,
+            out_channels=input_size,
+            kernel_size=kernels,
+            stride=strides,
+            padding=padds,
+            groups=input_size,  # depthwise convolution
+            bias=bias,
+        ),
+    )
+    model.eval()
+
+    input_shape = (input_size, 16, 16)
+    X_input = np.random.rand(100, *input_shape)  # (batch_size, channels, height, width)
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    if io_type == 'io_stream':
+        X_input = np.ascontiguousarray(X_input.transpose(0, 2, 3, 1))
+        channels_last_conversion = 'internal'
+        transpose_outputs = False
+    else:
+        channels_last_conversion = 'full'
+        transpose_outputs = True
+
+    config = hls4ml.utils.config_from_pytorch_model(
+        model,
+        input_shape=input_shape,
+        default_precision='ap_fixed<32,8>',
+        channels_last_conversion=channels_last_conversion,
+        transpose_outputs=transpose_outputs,
+    )
+
+    config['Model']['Strategy'] = strategy
+    config['Model']['ReuseFactor'] = rf
+
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_pytorch_model(
+        model, hls_config=config, output_dir=output_dir, io_type=io_type, backend=backend
+    )
+    assert all(layer.class_name == 'DepthwiseConv2D' for layer in hls_model.get_layers() if 'Conv' in layer.class_name), (
+        'depthwise conv must map to DepthwiseConv2D'
+    )
+    hls_model.compile()
+    hls_prediction = hls_model.predict(X_input)
+    if io_type == 'io_stream':
+        channels_last_shape = pytorch_prediction.transpose(0, 2, 3, 1).shape
+        hls_prediction = hls_prediction.reshape(channels_last_shape).transpose(0, 3, 1, 2)
+    else:
+        hls_prediction = hls_prediction.reshape(pytorch_prediction.shape)
+
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=0.001)


### PR DESCRIPTION
# Description

Similar to the Keras issue solved in #1486, Pytorch Conv1D/2D where `groups == in_channels == out_channels` is not routed to the correct `DepthwiseConv` codegen path. Since Pytorch doesn't have a built-in `DepthwiseConv` layer, the only way I know to express this operation is to change a standard Conv `groups` to match `in_channels` and `out_channels`, which the [pytorch_to_hls.py](https://github.com/fastmachinelearning/hls4ml/pull/1524/changes#diff-82a428368f1c4c25ffb26b10b22135f84e62942791bfc69130d4a75cd23f71c4L281-L282) converter strictly rejects.

This patch relaxes the condition in `pytorch_to_hls.py` to include `groups > 1 and groups == in_channels == out_channels` as a valid configuration, then routes to the correct `DepthwiseConv1D/2D` graph layer inside [convolution.py](https://github.com/fastmachinelearning/hls4ml/pull/1524/changes#diff-9b7aac72a4fd464866e3d102c4479389a262ffc6cd311f59a66e56fecb17133aR21-R32) and reshapes to `(depth_multiplier, n_chan, *kernel_size)` with `depth_multiplier = 1` for the depthwise conv.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Added two tests:

- `test/pytest/test_depthconv1d_pytorch.py`
- `test/pytest/test_depthconv2d_pytorch.py`

Both are similar to the existing `test_depthconv1d.py` and `test_depthconv2d.py`, with code adapted from `test_pytorch_api.py` for Pytorch compatibility. Vivado and Vitis tests passed, but I don't have Catapult installed in my system to verify its backend.

**Test Configuration**:

Same pytest configuration as the existing `test_depthconv1d.py` and `test_depthconv2d.py` respectively.

`pytest test/pytest/test_depthconv*d_pytorch.py`

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
