### PR TITLE
fix(vivado): Derive softmax layer config name from activation attribute

### DIFF
--- a/hls4ml/backends/vivado/passes/core_templates.py
+++ b/hls4ml/backends/vivado/passes/core_templates.py
@@ -347,7 +347,7 @@ class SoftmaxFunctionTemplate(FunctionCallTemplate):
         use_multidim = node.get_attr('n_inner', 1) > 1 or node.get_attr('n_outer', 1) > 1
         use_multidim = use_multidim and node.model.config.get_config_value('IOType') == 'io_parallel'
         params['activation'] = 'softmax' if not use_multidim else 'softmax_multidim'
-        params['config'] = f'softmax_config{node.index}'
+        params['config'] = '{}_config{}'.format(node.get_attr('activation'), node.index)
 
         return self.template.format(**params)
 

--- a/test/pytest/test_softmax.py
+++ b/test/pytest/test_softmax.py
@@ -19,6 +19,7 @@ def generate_data(input_shape):
     return np.clip(d, -32, 31)
 
 
+@pytest.mark.parametrize('softmax_impl', ['activation', 'standalone'])
 @pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'Catapult'])
 @pytest.mark.parametrize('strategy', ['stable', 'latency', 'argmax'])
 @pytest.mark.parametrize(
@@ -35,10 +36,15 @@ def generate_data(input_shape):
         ('16,6', (8, 8, 3), '18,8', 'io_stream', False),
     ],
 )
-def test_softmax(test_case_id, backend, strategy, generate_data, input_bits, input_shape, table_bits, io_type, custom_accum):
+def test_softmax(
+    test_case_id, softmax_impl, backend, strategy, generate_data, input_bits, input_shape, table_bits, io_type, custom_accum
+):
     X = generate_data
     model = tf.keras.models.Sequential()
-    model.add(tf.keras.layers.Activation(input_shape=input_shape, activation='softmax', name='softmax'))
+    if softmax_impl == 'activation':
+        model.add(tf.keras.layers.Activation(input_shape=input_shape, activation='softmax', name='softmax'))
+    else:
+        model.add(tf.keras.layers.Softmax(input_shape=input_shape, name='softmax'))
     model.compile()
 
     table_type = f'fixed<{table_bits}, RND, SAT>'
@@ -73,12 +79,16 @@ def test_softmax(test_case_id, backend, strategy, generate_data, input_bits, inp
     assert acc_hls4ml >= 0.98
 
 
+@pytest.mark.parametrize('softmax_impl', ['activation', 'standalone'])
 @pytest.mark.parametrize('backend', ['Vivado', 'Vitis', 'Quartus', 'Catapult'])
 @pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
-def test_softmax_skipped(test_case_id, backend, io_type):
+def test_softmax_skipped(test_case_id, softmax_impl, backend, io_type):
     X = np.random.rand(100, 10)
     dense = tf.keras.layers.Dense(14, input_shape=(10,), name='dense')
-    softmax = tf.keras.layers.Activation(activation='softmax', name='softmax')
+    if softmax_impl == 'activation':
+        softmax = tf.keras.layers.Activation(activation='softmax', name='softmax')
+    else:
+        softmax = tf.keras.layers.Softmax(name='softmax')
     model = tf.keras.models.Sequential([dense, softmax])
     model.compile()
 


### PR DESCRIPTION
# Description

Vivado (and Vitis, since it reuses the same pass) backend's [SoftmaxFunctionTemplate](https://github.com/fastmachinelearning/hls4ml/pull/1525/changes#diff-1a336295812dd32985b9a2ec1568fff8dc88d94b9cb5266c44f144e6b009d180L350) hardcodes the generated config struct name as lowercase `softmax_config{index}`, while [SoftmaxConfigTemplate](https://github.com/fastmachinelearning/hls4ml/pull/1525/changes#diff-1a336295812dd32985b9a2ec1568fff8dc88d94b9cb5266c44f144e6b009d180L300) derives it from the layer's `activation` attribute. For standalone `keras.layers.Softmax` in Keras v2, that attribute is `'Softmax'` (capital), so the generated `parameters.h` declares `Softmax_config{index}` but `myproject.cpp` calls `softmax_config{index}`, generating uncompilable code.

`Activation('softmax')` and inlined `Dense(..., activation='softmax')` work since they carry the lowercase attribute. A simple fix for the standalone `Softmax` is to make `SoftmaxFunctionTemplate` derive the config name from the same attribute as `SoftmaxConfigTemplate`. This matches how Quartus and Catapult backends handle softmax, and how all the other activations are named. Keras v3 seems unaffected, since it always sets the attribute to lowercase `'softmax'`, regardless of how softmax is called.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Extended `test/pytest/test_softmax.py`.

Both `test_softmax` and `test_softmax_skipped` take a new `softmax_impl` parametrization (`['activation', 'standalone']`) that builds the softmax op with either `keras.layers.Activation('softmax')` or `keras.layers.Softmax`, respectively. Before the `SoftmaxFunctionTemplate` fix, the `standalone` cases would fail on the Vivado backend at C++ compile time with an undeclared `softmax_config{index}`.

After the suggested fix, both paths pass. Quartus and Catapult were unaffected, as their function templates already derive the config name from the layer attribute.

**Test Configuration**:

Similar pytest configuration as the existing `test_softmax.py` tests, with the added `softmax_impl` parametrization.

`pytest test/pytest/test_softmax.py`

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
