### PR TITLE
Fix testbench data serialization

### DIFF
--- a/hls4ml/utils/serialization.py
+++ b/hls4ml/utils/serialization.py
@@ -59,12 +59,15 @@ def serialize_model(model, file_path):
         with open(config_path, 'w') as config_file:
             json.dump(config_dict, config_file, indent=4)
 
-        if config_dict.get('InputData', None) is not None:
-            tb_data_src_path = Path(config_dict['InputData'])
+        model_config = config_dict['config']
+
+        if model_config.get('InputData') is not None:
+            tb_data_src_path = Path(model_config['InputData'])
             tb_data_dst_path = dest_path / ('input_data_tb' + tb_data_src_path.suffix)
             tb_data_dst_path.write_bytes(tb_data_src_path.read_bytes())
-        if config_dict.get('OutputPredictions', None) is not None:
-            tb_data_src_path = Path(config_dict['OutputPredictions'])
+
+        if model_config.get('OutputPredictions') is not None:
+            tb_data_src_path = Path(model_config['OutputPredictions'])
             tb_data_dst_path = dest_path / ('output_data_tb' + tb_data_src_path.suffix)
             tb_data_dst_path.write_bytes(tb_data_src_path.read_bytes())
 

--- a/test/pytest/test_serialization.py
+++ b/test/pytest/test_serialization.py
@@ -1,3 +1,4 @@
+import tarfile
 from pathlib import Path
 
 import numpy as np
@@ -68,6 +69,90 @@ def test_save_load__model(test_case_id, io_type, backend):
     y_clone = hls_model_clone.predict(X)
 
     np.testing.assert_equal(y_original, y_clone)
+
+
+@pytest.mark.parametrize('backend', ['Vitis'])
+@pytest.mark.parametrize(
+    'input_configured,output_configured',
+    [
+        pytest.param(True, True, id='both'),
+        pytest.param(True, False, id='input-only'),
+        pytest.param(False, True, id='output-only'),
+        pytest.param(False, False, id='neither'),
+    ],
+)
+def test_save_load_testbench_data(test_case_id, backend, input_configured, output_configured):
+    input_shape = (8, 8, 3)
+
+    keras_model = qkeras_model(input_shape)
+
+    config = hls4ml.utils.config.config_from_keras_model(
+        keras_model, granularity='name', backend=backend, default_precision='fixed<16,6>'
+    )
+
+    for layer in config['LayerName']:
+        if layer.startswith('Softmax'):
+            config['LayerName'][layer]['Implementation'] = 'legacy'
+
+    out_dir = test_root_path / test_case_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    input_data = np.linspace(0, 1, num=2 * np.prod(input_shape), dtype=np.float32).reshape((2, *input_shape))
+    output_predictions = np.arange(10, dtype=np.float32).reshape((2, 5))
+    input_path = out_dir / 'input_data.npy'
+    output_path = out_dir / 'output_predictions.npy'
+    np.save(input_path, input_data)
+    np.save(output_path, output_predictions)
+
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        keras_model,
+        output_dir=str(out_dir / 'original'),
+        io_type='io_parallel',
+        backend=backend,
+        hls_config=config,
+    )
+    if input_configured:
+        hls_model.config.config['InputData'] = str(input_path)
+    if output_configured:
+        hls_model.config.config['OutputPredictions'] = str(output_path)
+
+    fml_path = out_dir / 'qkeras_model.fml'
+    hls_model.save(fml_path)
+
+    with tarfile.open(fml_path, mode='r:gz') as archive:
+        archive_members = {member.name for member in archive.getmembers()}
+
+    expected_members = set()
+    if input_configured:
+        expected_members.add('input_data_tb.npy')
+    if output_configured:
+        expected_members.add('output_data_tb.npy')
+
+    testbench_members = {'input_data_tb.npy', 'output_data_tb.npy'}
+    missing_members = expected_members - archive_members
+    unexpected_members = (testbench_members - expected_members) & archive_members
+    assert not missing_members, (
+        f'Missing testbench data files {sorted(missing_members)} from saved model archive; '
+        f'archive members: {sorted(archive_members)}'
+    )
+    assert not unexpected_members, (
+        f'Unexpected testbench data files {sorted(unexpected_members)} in saved model archive; '
+        f'archive members: {sorted(archive_members)}'
+    )
+
+    reload_dir = out_dir / 'reload'
+    reload_dir.mkdir(exist_ok=True)
+    hls_model_clone = hls4ml.converters.load_saved_model(fml_path, output_dir=reload_dir)
+
+    if input_configured:
+        restored_input_path = Path(hls_model_clone.config.config['InputData'])
+        np.testing.assert_array_equal(np.load(restored_input_path), input_data)
+    else:
+        assert hls_model_clone.config.config.get('InputData') is None
+    if output_configured:
+        restored_output_path = Path(hls_model_clone.config.config['OutputPredictions'])
+        np.testing.assert_array_equal(np.load(restored_output_path), output_predictions)
+    else:
+        assert hls_model_clone.config.config.get('OutputPredictions') is None
 
 
 @pytest.mark.parametrize('backend', ['Vitis'])  # Disabling OneAPI for now excessive run time


### PR DESCRIPTION
# Description

Fix testbench data serialization when saving an hls4ml model.

`serialize_model()` was checking `InputData` and `OutputPredictions` at the wrong configuration level. These entries are stored inside the nested model configuration.

As a result, configured testbench input data and output predictions could be omitted from the saved model. This change corrects the configuration lookup so that the corresponding testbench data files are included when configured.

Regression tests were added for input data only, output predictions only, both, and neither.

No new dependencies are introduced.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Regression tests were added in `test/pytest/test_serialization.py` covering:

- input data only
- output predictions only
- both input data and output predictions
- neither input data nor output predictions

After rebasing onto the latest `upstream/main`, the following command was run:

`pre-commit run --files hls4ml/utils/serialization.py test/pytest/test_serialization.py`

All pre-commit checks passed.

The serialization test file was also run on Geneosis. Some backend-dependent tests could not complete because the environment did not provide the required Catapult/oneAPI toolchains (`icpx` was unavailable), and a QONNX example-model file was unavailable. These were environment limitations unrelated to this serialization change.

**Test Configuration**:

- Geneosis
- Conda environment
- Branch rebased onto latest `upstream/main`

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.