### PR TITLE
Use HGQ's trained softmax lookup tables in the generated HLS

### DIFF
--- a/hls4ml/backends/fpga/passes/hgq_proxy_model.py
+++ b/hls4ml/backends/fpga/passes/hgq_proxy_model.py
@@ -34,7 +34,8 @@ def generate_mask_fn(
     masks = []
     to_fixed = to_acfixed if backend.lower() in ['oneapi', 'quartus'] else to_apfixed
     for idx, (k, b, i) in enumerate(zip(Ks, Bs, Is)):
-        if b == 0:
+        if b <= 0:
+            # b <= 0 means nothing is representable: the channel is a constant zero
             fn = f'out[{idx}] = 0;'
         else:
             fn = f'out[{idx}] = {to_fixed(k, b, i, RND, SAT)}(inp[{idx}]);'

--- a/hls4ml/backends/vivado/passes/core_templates.py
+++ b/hls4ml/backends/vivado/passes/core_templates.py
@@ -250,6 +250,9 @@ activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {config}>({
 param_activ_function_template = (
     'nnet::{activation}<{input_t}, {param_t.name}, {output_t}, {config}>({input}, {param}, {output});'
 )
+softmax_lut_function_template = (
+    'nnet::{activation}<{input_t}, {output_t}, {config}>({input}, {output}, {exp_table}, {inv_table});'
+)
 
 activ_include_list = ['nnet_utils/nnet_activation.h', 'nnet_utils/nnet_activation_stream.h']
 
@@ -348,6 +351,14 @@ class SoftmaxFunctionTemplate(FunctionCallTemplate):
         use_multidim = use_multidim and node.model.config.get_config_value('IOType') == 'io_parallel'
         params['activation'] = 'softmax' if not use_multidim else 'softmax_multidim'
         params['config'] = '{}_config{}'.format(node.get_attr('activation'), node.index)
+
+        # HGQ2 softmax carries its trained tables as weights; every other softmax lets the
+        # HLS code build them at runtime.
+        if 'exp_table' in node.weights and 'inv_table' in node.weights:
+            params['activation'] += '_lut'
+            params['exp_table'] = node.get_weights('exp_table').name
+            params['inv_table'] = node.get_weights('inv_table').name
+            return softmax_lut_function_template.format(**params)
 
         return self.template.format(**params)
 

--- a/hls4ml/backends/vivado/passes/hgq_softmax_tables.py
+++ b/hls4ml/backends/vivado/passes/hgq_softmax_tables.py
@@ -1,0 +1,68 @@
+from warnings import warn
+
+from hls4ml.model.layers import Layer, Softmax
+from hls4ml.model.optimizer import OptimizerPass
+from hls4ml.model.types import FixedPrecisionType
+
+
+class MaterializeSoftmaxTables(OptimizerPass):
+    """Turn HGQ's trained softmax exp/reciprocal lookup tables into weight arrays.
+
+    Without this the generated C++ rebuilds both tables at runtime from std::exp and 1/x
+    (nnet::init_exp_table / nnet::init_invert_table), which does not reproduce HGQ's own
+    quantized values. QSoftmaxHandler stashes the builders as _exp_table_fn / _inv_table_fn;
+    both take the (k, i, f) of the type the C++ addresses the table with, which is known only
+    here: for the latency implementation it is the softmax input precision, decided by
+    bit_exact. This pass therefore runs after bit_exact and before transform_types.
+    """
+
+    def match(self, node: Layer):
+        # Keyed on the stash rather than on the layer type: only the HGQ frontend leaves it,
+        # and it must always be removed again, being a callable no saved model can hold.
+        return isinstance(node, Softmax) and '_exp_table_fn' in node.attributes
+
+    def transform(self, model, node: Layer):
+        exp_table_fn = node.attributes.pop('_exp_table_fn')
+        inv_table_fn = node.attributes.pop('_inv_table_fn')
+
+        impl = node.get_attr('implementation')
+        if impl not in ('latency', 'stable'):
+            return False  # argmax and legacy use no lookup table
+
+        # The exp table is indexed by the normalized input (x_max - x) for the stable
+        # implementation and by the layer input itself for the latency one. Reading the
+        # element precision off the variable is only unambiguous because this runs before
+        # transform_types wraps io_stream variables.
+        if impl == 'stable':
+            exp_inp_t: FixedPrecisionType = node.attributes['inp_norm_t'].precision
+        else:
+            exp_inp_t = node.get_input_variable().type.precision
+        inv_inp_t: FixedPrecisionType = node.attributes['inv_inp_t'].precision
+
+        for name, addr_t, fn in (('exp_table', exp_inp_t, exp_table_fn), ('inv_table', inv_inp_t, inv_table_fn)):
+            # softmax_idx_from_real_val slices the top ceillog2(table_size) bits of the address
+            # word. Sizing the table as 2**width makes that the whole word, so no low bits are
+            # dropped and the slice cannot run off the end of a narrower word.
+            size = 1 << int(addr_t.width)
+            if int(node.get_attr(f'{name}_size') or 0) != size:
+                warn(
+                    f'{node.name}: {name}_size {node.get_attr(f"{name}_size")} does not match the {addr_t.width}-bit '
+                    f'address type {addr_t}; overriding to {size} to keep table indexing bit-exact.',
+                    stacklevel=1,
+                )
+            node.set_attr(f'{name}_size', size)
+            k = int(bool(addr_t.signed))
+            data = fn((k, addr_t.integer - k, int(addr_t.width) - addr_t.integer))
+
+            # Capture the type bit_exact derived first: storing a WeightVariable under `name`
+            # makes AttributeDict overwrite `{name}_t` with the variable's own type.
+            named_t = node.attributes[f'{name}_t']
+            node.set_attr(f'{name}_data', data)
+            node.add_weights_variable(
+                name=name, var_name=name + '{index}', precision=named_t.precision, type_name=named_t.name
+            )
+            node.get_weights(name).type = named_t
+            node.attributes[f'{name}_t'] = named_t
+            model.config.layer_name_precision[f'{node.name}_{name}'] = str(named_t.precision)
+
+        return False

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -171,6 +171,7 @@ class VivadoBackend(FPGABackend):
             'vivado:inplace_stream_flatten',
             'vivado:skip_softmax',
             'vivado:fix_softmax_table_size',
+            'vivado:materialize_softmax_tables',
             'infer_precision_types',
             'vivado:distributed_arithmetic_codegen',
             'vivado:distributed_arithmetic_einsum_codegen',

--- a/hls4ml/converters/keras_v3/hgq2/_base.py
+++ b/hls4ml/converters/keras_v3/hgq2/_base.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from math import prod
 from typing import TYPE_CHECKING, Any
+from warnings import warn
 
 import numpy as np
 
@@ -38,6 +39,17 @@ def extract_fixed_quantizer_config(q, tensor: 'KerasTensor', is_input: bool) -> 
         k = np.ravel(k).astype(np.int16)
         B = np.ravel(B).astype(np.int16)
         I = np.ravel(I).astype(np.int16)  # noqa: E741
+
+    # A channel can be trained down to a negative total width. Clamp to 0, not 1: B == 0 is the
+    # constant-zero encoding generate_mask_fn understands, while B == 1 would bring the channel
+    # back as a live 1-bit one. I is legitimately negative and already zeroed for these above.
+    if np.any(B < 0):
+        warn(
+            f'Quantizer {q.name} has {int(np.sum(B < 0))} channel(s) with total bitwidth < 0; '
+            'treating them as constant zero.',
+            stacklevel=2,
+        )
+    B = np.maximum(B, 0)
 
     overflow_mode: str = internal_q.overflow_mode
     round_mode: str = internal_q.round_mode

--- a/hls4ml/converters/keras_v3/hgq2/softmax.py
+++ b/hls4ml/converters/keras_v3/hgq2/softmax.py
@@ -1,10 +1,12 @@
 import typing
 from collections.abc import Sequence
+from functools import partial
 from math import prod
 
 from hls4ml.model.types import FixedPrecisionType, RoundingMode, SaturationMode
 
 from ._base import QLayerHandler
+from .unary_lut import extract_lut_table
 
 if typing.TYPE_CHECKING:
     import hgq
@@ -118,6 +120,16 @@ class QSoftmaxHandler(QLayerHandler):
                 'parallelization_factor': parallelization_factor,
                 'class_name': class_name,
                 '_bit_exact': True,
+                # Not materialized here: for the latency implementation the domain is the
+                # softmax input precision, only final after bit_exact. materialize_softmax_tables
+                # calls these with the (k, i, f) of the address type, and pops them again -- they
+                # are not JSON-serializable, so they must not reach a saved model.
+                '_exp_table_fn': partial(
+                    extract_lut_table, layer.exp_table.activation, layer.exp_table.oq if layer.exp_table.enable_oq else None
+                ),
+                '_inv_table_fn': partial(
+                    extract_lut_table, layer.inv_table.activation, layer.inv_table.oq if layer.inv_table.enable_oq else None
+                ),
             }
         )
 

--- a/hls4ml/converters/keras_v3/hgq2/unary_lut.py
+++ b/hls4ml/converters/keras_v3/hgq2/unary_lut.py
@@ -1,5 +1,5 @@
 import typing
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 import numpy as np
 from quantizers import get_fixed_quantizer_np
@@ -10,9 +10,74 @@ from ._base import KerasV3LayerHandler, QLayerHandler
 
 if typing.TYPE_CHECKING:
     import hgq
+    from hgq.quantizer import Quantizer
+    from hgq.quantizer.internal import FixedPointQuantizerBase
     from keras import KerasTensor
 
 from decimal import Decimal
+
+
+def fixed_grid_by_bit_pattern(k: int, i: int, f: int) -> np.ndarray:
+    """All values a fixed-point type can hold, indexed by their two's-complement bit pattern.
+
+    This is the addressing convention of ``nnet::get_index_unary_lut`` and
+    ``nnet::softmax_real_val_from_idx`` in the generated C++.
+    """
+    K, I, F = Decimal(int(k)), Decimal(int(i)), Decimal(int(f))  # noqa: E741
+    _eps = Decimal(2) ** -F
+    _min = -K * Decimal(2) ** I
+    _max = Decimal(2) ** I - _eps
+    N = (_max - _min) / _eps + 1
+    assert float(N).is_integer(), 'Invalid quantizer range'
+    N = int(N)
+    assert N <= 1e6, 'Too large quantizer range'
+    assert np.log2(N).is_integer(), f'Invalid quantizer range: N must be power of 2, got {N}'
+
+    grid = np.linspace(float(_min), float(_max), N, dtype=np.float32)
+    if k:
+        # idx by binary repr, move the positive part to the front
+        grid = np.concatenate([grid[N // 2 :], grid[: N // 2]])
+    return grid
+
+
+def kif_of(q: 'FixedPointQuantizerBase') -> tuple[int, int, int]:
+    """(k, i, f) of a homogeneous quantizer, with entries representing nothing masked out."""
+    from keras import ops
+
+    k, i, f = q.kif
+    mask = k + i + f > 0
+    i, f = np.where(mask, i, -32), np.where(mask, f, -32)  # type: ignore
+    return int(ops.max(k)), int(ops.max(i)), int(ops.max(f))  # type: ignore
+
+
+def extract_lut_table(activation: Callable, oq: 'Quantizer|None', kif: tuple[int, int, int]) -> np.ndarray:
+    """Tabulate activation over the fixed-point type kif describes, quantized by oq.
+
+    kif is the type the generated C++ addresses the table with, passed in rather than read off
+    a layer: QSoftmax.exp_table has no input quantizer when stable=False, and for the latency
+    softmax the domain is the softmax input precision, only final after the bit_exact pass.
+    """
+    from hgq.quantizer.internal import FixedPointQuantizerBase
+    from keras import ops
+
+    grid = fixed_grid_by_bit_pattern(*kif)
+    table = activation(grid)
+
+    if oq is not None:
+        internal_q = oq.quantizer
+        if not isinstance(internal_q, FixedPointQuantizerBase):
+            raise NotImplementedError('FloatPointQuantizer is not supported yet')
+
+        # Not oq(table): the Quantizer layer broadcasts against the shape it was built for,
+        # which is not the rank-1 grid here. Homogeneous, so this is the same operation.
+        round_mode = internal_q.round_mode
+        if round_mode.startswith('S_'):
+            round_mode = round_mode[2:]
+        fixed_q = get_fixed_quantizer_np(round_mode, internal_q.overflow_mode)
+        k, i, f = (ops.convert_to_numpy(x).ravel().item() for x in internal_q.kif)
+        table = fixed_q(table, k, i, f)  # type: ignore
+
+    return np.asarray(ops.convert_to_numpy(table))
 
 
 class QUnaryLUTHandler(QLayerHandler, KerasV3LayerHandler):
@@ -24,7 +89,7 @@ class QUnaryLUTHandler(QLayerHandler, KerasV3LayerHandler):
         in_tensors: Sequence['KerasTensor'],
         out_tensors: Sequence['KerasTensor'],
     ):
-        from hgq.quantizer.internal import FixedPointQuantizerBase, FloatPointQuantizer
+        from hgq.quantizer.internal import FixedPointQuantizerBase
         from keras import ops
 
         if not layer.enable_iq and not layer.enable_oq:
@@ -32,53 +97,20 @@ class QUnaryLUTHandler(QLayerHandler, KerasV3LayerHandler):
         assert not layer._allow_heterogeneous_table, 'Heterogeneous table is not supported in QUnaryFunctionLUT layer'
 
         iq = layer.iq.quantizer
-        if isinstance(iq, FixedPointQuantizerBase):
-            k, i, f = iq.kif
-            mask = k + i + f > 0
-            i, f = np.where(mask, i, -32), np.where(mask, f, -32)  # type: ignore
-            k, i, f = (Decimal(int(ops.max(x))) for x in (k, i, f))  # type: ignore
-            _min = -k * 2**i
-            _eps = 2**-f
-            _max = 2**i - _eps
-            N = (_max - _min) / _eps + 1
-            assert float(N).is_integer(), 'Invalid quantizer range'
-            N = int(N)
-            assert N <= 1e6, 'Too large quantizer range'
-            assert np.log2(N).is_integer(), f'Invalid quantizer range: N must be power of 2, got {N}'
-
-            all_inputs = np.linspace(float(_min), float(_max), N, dtype=np.float32)
-
-            config = {}
-            config.update(self.default_config)
-            table = layer.activation(all_inputs)
-            if layer.enable_oq:
-                table = layer.oq(table[None, ...])[0]
-            table = ops.convert_to_numpy(table)
-            if k:
-                # idx by binary repr, move the positive part to the front
-                table_pos, table_neg = table[N // 2 :], table[: N // 2]
-                table = np.concatenate([table_pos, table_neg])
-        else:
+        if not isinstance(iq, FixedPointQuantizerBase):
             raise NotImplementedError('FloatPointQuantizer is not supported yet')
+
+        table = extract_lut_table(layer.activation, layer.oq if layer.enable_oq else None, kif_of(iq))
 
         oq = layer.oq.quantizer
-        if isinstance(oq, FixedPointQuantizerBase):
-            round_mode = oq.round_mode
-            if round_mode.startswith('S_'):
-                round_mode = round_mode[2:]
-            overflow_mode = oq.overflow_mode
-            fixed_q = get_fixed_quantizer_np(round_mode, overflow_mode)
-            k, i, f = (ops.convert_to_numpy(x).ravel().item() for x in oq.kif)
-            table = fixed_q(table, k, i, f)  # type: ignore
-
-            k, b, I = bool(k), k + i + f, k + i  # noqa: E741
-            table_t = FixedPrecisionType(b, I, k)
-        else:
-            assert isinstance(oq, FloatPointQuantizer)
+        if not isinstance(oq, FixedPointQuantizerBase):
             raise NotImplementedError('FloatPointQuantizer is not supported yet')
+        k, i, f = (ops.convert_to_numpy(x).ravel().item() for x in oq.kif)
+        k, b, I = bool(k), k + i + f, k + i  # noqa: E741
+        table_t = FixedPrecisionType(b, I, k)
 
-        table = ops.convert_to_numpy(table)
-
+        config = {}
+        config.update(self.default_config)
         config.update(
             {
                 'class_name': 'UnaryLUT',

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -172,27 +172,11 @@ void init_invert_table(typename CONFIG_T::inv_table_t table_out[CONFIG_T::inv_ta
 }
 
 template <class data_T, class res_T, typename CONFIG_T>
-void softmax_latency(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice]) {
-    #pragma HLS pipeline
-    // Initialize the lookup tables
-#ifdef __HLS_SYN__
-    bool initialized = false;
-    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
-    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
-#else
-    static bool initialized = false;
-    static typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
-    static typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
-
-#endif
-    if (!initialized) {
-        // Note we are exponentiating the inputs, which have type data_T
-        init_exp_table<data_T, CONFIG_T>(exp_table);
-        // Note we are inverting the exponentials, which have type exp_table_t
-        init_invert_table<typename CONFIG_T::inv_inp_t, CONFIG_T>(invert_table);
-        initialized = true;
-    }
-
+void softmax_latency_impl(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice],
+                          typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                          typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
+    // Inlined so that the caller's pipeline pragma covers this body
+    #pragma HLS inline
     // Calculate all the e^x's
     typename CONFIG_T::accum_t exp_res[CONFIG_T::n_slice];
     #pragma HLS array_partition variable=exp_res complete
@@ -217,27 +201,11 @@ void softmax_latency(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice
 }
 
 template <class data_T, class res_T, typename CONFIG_T>
-void softmax_stable(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice]) {
-    #pragma HLS pipeline
-    // Initialize the lookup tables
-#ifdef __HLS_SYN__
-    bool initialized = false;
-    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
-    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
-#else
-    static bool initialized = false;
-    static typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
-    static typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
-
-#endif
-    if (!initialized) {
-        // Note we are exponentiating the inputs, which have type data_T
-        init_exp_table<typename CONFIG_T::inp_norm_t, CONFIG_T>(exp_table, true);
-        // Note we are inverting the exponentials, which have type exp_table_t
-        init_invert_table<typename CONFIG_T::inv_inp_t, CONFIG_T>(invert_table);
-        initialized = true;
-    }
-
+void softmax_stable_impl(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice],
+                         typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                         typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
+    // Inlined so that the caller's pipeline pragma covers this body
+    #pragma HLS inline
     // Find the max and compute all delta(x_i, x_max)
     Op_max<data_T> op_max;
     data_T x_max = reduce<data_T, CONFIG_T::n_slice, Op_max<data_T>>(data, op_max);
@@ -269,6 +237,81 @@ void softmax_stable(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice]
         #pragma HLS unroll
         res[i] = exp_res[i] * inv_exp_sum;
     }
+}
+
+// Entry points building the tables at runtime. Used by every softmax whose frontend does
+// not supply pre-computed tables (plain Keras, QKeras, ...).
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_latency(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice]) {
+    #pragma HLS pipeline
+    // Initialize the lookup tables
+#ifdef __HLS_SYN__
+    bool initialized = false;
+    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
+    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
+#else
+    static bool initialized = false;
+    static typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
+    static typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
+
+#endif
+    if (!initialized) {
+        // Note we are exponentiating the inputs, which have type data_T
+        init_exp_table<data_T, CONFIG_T>(exp_table);
+        // Note we are inverting the exponentials, which have type exp_table_t
+        init_invert_table<typename CONFIG_T::inv_inp_t, CONFIG_T>(invert_table);
+        initialized = true;
+    }
+
+    softmax_latency_impl<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
+}
+
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_stable(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice]) {
+    #pragma HLS pipeline
+    // Initialize the lookup tables
+#ifdef __HLS_SYN__
+    bool initialized = false;
+    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
+    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
+#else
+    static bool initialized = false;
+    static typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
+    static typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
+
+#endif
+    if (!initialized) {
+        // Note we are exponentiating the inputs, which have type data_T
+        init_exp_table<typename CONFIG_T::inp_norm_t, CONFIG_T>(exp_table, true);
+        // Note we are inverting the exponentials, which have type exp_table_t
+        init_invert_table<typename CONFIG_T::inv_inp_t, CONFIG_T>(invert_table);
+        initialized = true;
+    }
+
+    softmax_stable_impl<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
+}
+
+// Entry points taking pre-computed tables. Used when the frontend knows the exact table
+// contents (e.g. HGQ2's trained QSoftmax), so that CONFIG_T::exp_scale and the generic
+// exp()/1-over-x reconstruction are bypassed entirely.
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_latency(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice],
+                     typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                     typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
+    #pragma HLS pipeline
+    #pragma HLS function_instantiate variable=exp_table
+    #pragma HLS function_instantiate variable=invert_table
+    softmax_latency_impl<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
+}
+
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_stable(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice],
+                    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
+    #pragma HLS pipeline
+    #pragma HLS function_instantiate variable=exp_table
+    #pragma HLS function_instantiate variable=invert_table
+    softmax_stable_impl<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
 }
 
 template <typename CONFIG_T, int N_TABLE> void init_exp_table_legacy(typename CONFIG_T::table_t table_out[N_TABLE]) {
@@ -411,6 +454,56 @@ void softmax_multidim(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]) {
                 buffer_in[j] = data[i * CONFIG_T::n_slice * CONFIG_T::n_inner + j * CONFIG_T::n_inner + k];
             }
             softmax<data_T, res_T, CONFIG_T>(buffer_in, buffer_out);
+            for (signed j = 0; j < CONFIG_T::n_slice; j++) {
+                #pragma HLS UNROLL
+                res[i * CONFIG_T::n_slice * CONFIG_T::n_inner + j * CONFIG_T::n_inner + k] = buffer_out[j];
+            }
+        }
+    }
+}
+
+// Dispatchers for pre-computed tables. Separate names rather than overloads of softmax /
+// softmax_multidim, so that the allocation pragma below still names a single function.
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_lut(data_T data[CONFIG_T::n_slice], res_T res[CONFIG_T::n_slice],
+                 typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                 typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
+    #pragma HLS inline
+    switch (CONFIG_T::implementation) {
+    case softmax_implementation::latency:
+        softmax_latency<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
+        break;
+    case softmax_implementation::stable:
+        softmax_stable<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
+        break;
+    case softmax_implementation::legacy:
+        // legacy addresses CONFIG_T::table_t tables of its own; supplied tables are unused
+        softmax_legacy<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    case softmax_implementation::argmax:
+        // argmax needs no table at all
+        softmax_argmax<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    }
+}
+
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_multidim_lut(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in],
+                          typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                          typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
+    #pragma HLS inline
+    #pragma HLS allocation instances = softmax_lut<CONFIG_T> limit = CONFIG_T::parallelization_factor function
+    data_T buffer_in[CONFIG_T::n_slice];
+    res_T buffer_out[CONFIG_T::n_slice];
+    for (signed i = 0; i < CONFIG_T::n_outer; i++) {
+        #pragma HLS UNROLL
+        for (signed k = 0; k < CONFIG_T::n_inner; k++) {
+            #pragma HLS UNROLL
+            for (signed j = 0; j < CONFIG_T::n_slice; j++) {
+                #pragma HLS UNROLL
+                buffer_in[j] = data[i * CONFIG_T::n_slice * CONFIG_T::n_inner + j * CONFIG_T::n_inner + k];
+            }
+            softmax_lut<data_T, res_T, CONFIG_T>(buffer_in, buffer_out, exp_table, invert_table);
             for (signed j = 0; j < CONFIG_T::n_slice; j++) {
                 #pragma HLS UNROLL
                 res[i * CONFIG_T::n_slice * CONFIG_T::n_inner + j * CONFIG_T::n_inner + k] = buffer_out[j];

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation_stream.h
@@ -105,26 +105,9 @@ SigmoidActLoop:
 // *************************************************
 
 template <class data_T, class res_T, typename CONFIG_T>
-void softmax_latency(hls::stream<data_T> &data, hls::stream<res_T> &res) {
-    // Initialize the lookup tables
-#ifdef __HLS_SYN__
-    bool initialized = false;
-    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
-    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
-#else
-    static bool initialized = false;
-    static typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
-    static typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
-
-#endif
-    if (!initialized) {
-        // Note we are exponentiating the inputs, which have type data_T
-        init_exp_table<typename data_T::value_type, CONFIG_T>(exp_table);
-        // Note we are inverting the exponentials, which have type exp_table_t
-        init_invert_table<typename CONFIG_T::inv_inp_t, CONFIG_T>(invert_table);
-        initialized = true;
-    }
-
+void softmax_latency_impl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                          typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                          typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
     constexpr unsigned multiplier_limit = DIV_ROUNDUP(data_T::size, CONFIG_T::reuse_factor);
     constexpr unsigned ii = data_T::size / multiplier_limit;
 
@@ -166,26 +149,9 @@ SoftmaxExpLoop:
 }
 
 template <class data_T, class res_T, typename CONFIG_T>
-void softmax_stable(hls::stream<data_T> &data, hls::stream<res_T> &res) {
-    // Initialize the lookup tables
-#ifdef __HLS_SYN__
-    bool initialized = false;
-    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
-    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
-#else
-    static bool initialized = false;
-    static typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
-    static typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
-
-#endif
-    if (!initialized) {
-        // Note we are exponentiating the inputs, which have type data_T
-        init_exp_table<typename CONFIG_T::inp_norm_t, CONFIG_T>(exp_table, true);
-        // Note we are inverting the exponentials, which have type exp_table_t
-        init_invert_table<typename CONFIG_T::inv_inp_t, CONFIG_T>(invert_table);
-        initialized = true;
-    }
-
+void softmax_stable_impl(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                         typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                         typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
     constexpr unsigned multiplier_limit = DIV_ROUNDUP(data_T::size, CONFIG_T::reuse_factor);
     constexpr unsigned ii = data_T::size / multiplier_limit;
 
@@ -242,6 +208,75 @@ SoftmaxArrayLoop:
         }
         res.write(out_pack);
     }
+}
+
+// Entry points building the tables at runtime. Used by every softmax whose frontend does
+// not supply pre-computed tables (plain Keras, QKeras, ...).
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_latency(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+    // Initialize the lookup tables
+#ifdef __HLS_SYN__
+    bool initialized = false;
+    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
+    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
+#else
+    static bool initialized = false;
+    static typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
+    static typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
+
+#endif
+    if (!initialized) {
+        // Note we are exponentiating the inputs, which have type data_T
+        init_exp_table<typename data_T::value_type, CONFIG_T>(exp_table);
+        // Note we are inverting the exponentials, which have type exp_table_t
+        init_invert_table<typename CONFIG_T::inv_inp_t, CONFIG_T>(invert_table);
+        initialized = true;
+    }
+
+    softmax_latency_impl<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
+}
+
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_stable(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+    // Initialize the lookup tables
+#ifdef __HLS_SYN__
+    bool initialized = false;
+    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
+    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
+#else
+    static bool initialized = false;
+    static typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size];
+    static typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size];
+
+#endif
+    if (!initialized) {
+        // Note we are exponentiating the inputs, which have type data_T
+        init_exp_table<typename CONFIG_T::inp_norm_t, CONFIG_T>(exp_table, true);
+        // Note we are inverting the exponentials, which have type exp_table_t
+        init_invert_table<typename CONFIG_T::inv_inp_t, CONFIG_T>(invert_table);
+        initialized = true;
+    }
+
+    softmax_stable_impl<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
+}
+
+// Entry points taking pre-computed tables (e.g. HGQ2's trained QSoftmax).
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_latency(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                     typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                     typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
+    #pragma HLS function_instantiate variable=exp_table
+    #pragma HLS function_instantiate variable=invert_table
+    softmax_latency_impl<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
+}
+
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_stable(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
+    #pragma HLS function_instantiate variable=exp_table
+    #pragma HLS function_instantiate variable=invert_table
+    softmax_stable_impl<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
 }
 
 template <class data_T, class res_T, typename CONFIG_T>
@@ -362,6 +397,30 @@ template <class data_T, class res_T, typename CONFIG_T> void softmax(hls::stream
         softmax_legacy<data_T, res_T, CONFIG_T>(data, res);
         break;
     case softmax_implementation::argmax:
+        softmax_argmax<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    }
+}
+
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_lut(hls::stream<data_T> &data, hls::stream<res_T> &res,
+                 typename CONFIG_T::exp_table_t exp_table[CONFIG_T::exp_table_size],
+                 typename CONFIG_T::inv_table_t invert_table[CONFIG_T::inv_table_size]) {
+    assert(CONFIG_T::axis == -1);
+
+    switch (CONFIG_T::implementation) {
+    case softmax_implementation::latency:
+        softmax_latency<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
+        break;
+    case softmax_implementation::stable:
+        softmax_stable<data_T, res_T, CONFIG_T>(data, res, exp_table, invert_table);
+        break;
+    case softmax_implementation::legacy:
+        // legacy addresses CONFIG_T::table_t tables of its own; supplied tables are unused
+        softmax_legacy<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    case softmax_implementation::argmax:
+        // argmax needs no table at all
         softmax_argmax<data_T, res_T, CONFIG_T>(data, res);
         break;
     }

--- a/test/pytest/generate_ci_yaml.py
+++ b/test/pytest/generate_ci_yaml.py
@@ -38,6 +38,7 @@ LONGLIST = {'test_hgq_layers', 'test_hgq_players', 'test_qkeras', 'test_pytorch_
 KERAS3_LIST = {
     'test_keras_v3_api',
     'test_hgq2_mha',
+    'test_hgq2_softmax',
     'test_einsum_dense',
     'test_qeinsum',
     'test_multiout_onnx',

--- a/test/pytest/test_hgq2_softmax.py
+++ b/test/pytest/test_hgq2_softmax.py
@@ -1,0 +1,157 @@
+"""Regression tests for fastmachinelearning/hls4ml#1523.
+
+``hgq.layers.QSoftmax`` trains two lookup tables (``exp_table`` and ``inv_table``). hls4ml
+used to propagate only their sizes and types, leaving the generated C++ to rebuild the
+contents from ``std::exp`` / ``1/x`` at runtime. These tests pin down that the trained
+tables now reach the generated code, and that plain Keras softmax is unaffected.
+"""
+
+from contextlib import nullcontext
+from pathlib import Path
+
+import keras
+import numpy as np
+import pytest
+
+hgq = pytest.importorskip('hgq')
+
+from hgq.config import QuantizerConfigScope  # noqa: E402
+from hgq.layers import QDense, QSoftmax  # noqa: E402
+from hgq.utils import trace_minmax  # noqa: E402
+
+import hls4ml  # noqa: E402
+from hls4ml.backends.fpga.passes.hgq_proxy_model import generate_mask_fn  # noqa: E402
+from hls4ml.converters.keras_v3.hgq2._base import extract_fixed_quantizer_config  # noqa: E402
+from hls4ml.converters.keras_v3.hgq2.unary_lut import extract_lut_table, fixed_grid_by_bit_pattern  # noqa: E402
+
+test_root_path = Path(__file__).parent
+
+
+def _build_model(stable, shape=(16,), io_type='io_parallel', n_out=8, seed=42):
+    keras.utils.set_random_seed(seed)
+    # Heterogeneous activation quantization is io_parallel-only in hls4ml, so the datalane
+    # quantizers have to be pinned to a single bitwidth to reach the io_stream kernels.
+    scope = QuantizerConfigScope(place='datalane', heterogeneous_axis=()) if io_type == 'io_stream' else nullcontext()
+    with scope:
+        inp = keras.Input(shape)
+        x = QDense(n_out)(inp)
+        out = QSoftmax(axis=-1, stable=stable, name='sm')(x)
+        model = keras.Model(inp, out)
+
+    rng = np.random.default_rng(seed)
+    X = rng.uniform(-2.0, 2.0, size=(200,) + shape).astype(np.float32)
+    trace_minmax(model, X)
+    return model, X
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis'])
+@pytest.mark.parametrize('io_type', ['io_parallel', 'io_stream'])
+@pytest.mark.parametrize('stable', [True, False])
+@pytest.mark.parametrize('shape', [(16,), (4, 16)], ids=['1d', 'multidim'])
+def test_hgq2_softmax_uses_trained_tables(test_case_id, backend, io_type, stable, shape):
+    model, X = _build_model(stable, shape=shape, io_type=io_type)
+    r_keras = np.asarray(model(X))
+
+    impl = 'stable' if stable else 'latency'
+    odir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, backend=backend, io_type=io_type, output_dir=odir, part='xcvu13p-flga2577-2-e'
+    )
+
+    node = hls_model.graph['sm']
+    assert node.get_attr('implementation') == impl
+
+    # The trained tables are carried as weights ...
+    assert 'exp_table' in node.weights and 'inv_table' in node.weights
+    exp_var, inv_var = node.get_weights('exp_table'), node.get_weights('inv_table')
+
+    # ... sized so that the C++ table index is a plain reinterpretation of the address word
+    if stable:
+        exp_addr_t = node.attributes['inp_norm_t'].precision
+    else:
+        exp_addr_t = node.get_input_variable().type.precision
+    inv_addr_t = node.attributes['inv_inp_t'].precision
+    assert len(exp_var.data) == node.get_attr('exp_table_size') == 2**exp_addr_t.width
+    assert len(inv_var.data) == node.get_attr('inv_table_size') == 2**inv_addr_t.width
+
+    # ... typed with what bit_exact derived, not with a type re-inferred from the data
+    assert exp_var.type is node.attributes['exp_table_t']
+    assert inv_var.type is node.attributes['inv_table_t']
+
+    # The non-serializable builders stashed by the converter must not survive
+    assert '_exp_table_fn' not in node.attributes and '_inv_table_fn' not in node.attributes
+
+    # Table contents match an independent recomputation straight from hgq ...
+    sm_layer = model.get_layer('sm')
+    k = int(bool(exp_addr_t.signed))
+    kif = (k, exp_addr_t.integer - k, exp_addr_t.width - exp_addr_t.integer)
+    expected = extract_lut_table(sm_layer.exp_table.activation, sm_layer.exp_table.oq, kif)
+    np.testing.assert_array_equal(np.asarray(exp_var.data).ravel(), np.asarray(expected).ravel())
+
+    # ... and are not simply what the generic C++ reconstruction would produce unquantized
+    naive = np.exp(fixed_grid_by_bit_pattern(*kif) * (-1.0 if stable else 1.0) * node.get_attr('exp_scale'))
+    assert not np.allclose(np.asarray(exp_var.data).ravel(), naive)
+
+    # The generated code passes the tables in
+    hls_model.write()
+    call = [ln for ln in open(f'{odir}/firmware/myproject.cpp') if 'nnet::softmax' in ln]
+    assert len(call) == 1
+    assert exp_var.name in call[0] and inv_var.name in call[0]
+    assert Path(f'{odir}/firmware/weights/{exp_var.name}.h').exists()
+    assert f'#include "weights/{exp_var.name}.h"' in open(f'{odir}/firmware/parameters.h').read()
+
+    # End to end: HGQ2 + bit_exact promises exact agreement with Keras
+    hls_model.compile()
+    r_hls = np.asarray(hls_model.predict(X)).reshape(r_keras.shape)
+    assert np.std(r_hls) > 0
+    np.testing.assert_array_equal(r_hls, r_keras)
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis'])
+def test_plain_keras_softmax_keeps_runtime_tables(test_case_id, backend):
+    """Negative control: non-HGQ softmax must keep the two-argument call."""
+    keras.utils.set_random_seed(0)
+    inp = keras.Input((8,))
+    out = keras.layers.Softmax(name='sm')(inp)
+    model = keras.Model(inp, out)
+
+    odir = str(test_root_path / test_case_id)
+    cfg = hls4ml.utils.config_from_keras_model(model, granularity='name', backend=backend)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=cfg, backend=backend, output_dir=odir, part='xcvu13p-flga2577-2-e'
+    )
+
+    node = hls_model.graph['sm']
+    assert 'exp_table' not in node.weights and 'inv_table' not in node.weights
+
+    hls_model.write()
+    (call,) = (ln for ln in open(f'{odir}/firmware/myproject.cpp') if 'nnet::softmax' in ln)
+    args = call.split('>(')[1].split(')')[0]
+    assert len(args.split(',')) == 2, call
+
+
+def test_dead_channels_stay_zero():
+    """A heterogeneous quantizer channel trained to a negative total width is a dead
+    channel and must be rendered as a constant zero, not resurrected as a 1-bit channel.
+    """
+    from hgq.quantizer import Quantizer, QuantizerConfig
+
+    q = Quantizer(QuantizerConfig('kif', 'weight', heterogeneous_axis=(0,)))
+    x = keras.ops.arange(8.0, dtype='float32')
+    q.build(x.shape)
+    q(x)
+
+    i_var, f_var, _ = q.quantizer.weights
+    i_var.assign(np.array([1, 1, 1, -2, 1, 1, 1, 1], dtype=np.float32))
+    f_var.assign(np.array([3, 3, 3, -4, 3, 3, 3, 3], dtype=np.float32))
+
+    inp = keras.Input(shape=(8,), name='x')
+    conf = extract_fixed_quantizer_config(q, inp, is_input=True)
+    k_arr, b_arr, i_arr = (np.ravel(a) for a in conf['mask_kbi'])
+
+    assert b_arr[3] == 0, f'dead channel clamped to {b_arr[3]}, expected 0'
+    assert i_arr[3] == 0
+    assert (b_arr >= 0).all()
+
+    mask_fn = generate_mask_fn('mask', (8,), *(a.reshape(1, 8) for a in (k_arr, b_arr, i_arr)), 'RND', 'SAT', 'vivado')
+    assert 'out[3] = 0;' in mask_fn


### PR DESCRIPTION
## Description

`hgq.layers.QSoftmax` trains two lookup tables, `exp_table` and `inv_table`. `QSoftmaxHandler`
propagated only their **sizes and types**; the generated C++ rebuilt the **contents** at runtime
from `std::exp` and `1/x` (`nnet::init_exp_table` / `nnet::init_invert_table`). Those
reconstructions are not guaranteed to reproduce the values HGQ trained, and the table was
addressed with a bit-slice whose width came from a different quantity than the address word.

The tables cannot be built at conversion time. For `implementation='latency'` their domain is the
softmax **input** precision, which only the `bit_exact` pass decides. `QSoftmaxHandler` therefore
stashes two domain-parameterised builders on the layer, and a new Vivado pass,
`materialize_softmax_tables`, calls them once the address type is final and turns the result into
weight arrays. It runs in the `vivado:optimize` flow next to `fix_softmax_table_size`, after
`bit_exact` and before `transform_types`.

The pass also forces `exp_table_size == 2**width` of the address type. `softmax_idx_from_real_val`
slices the top `ceillog2(table_size)` bits of the address word, so when the two disagree the table
is read at each bin's lower edge, or the slice runs off a narrower word. This is an independent
defect from the table contents and is a plausible larger contributor to the error reported in the
issue — see "Numerical behaviour" below.

The kernels gain `softmax_lut` / `softmax_multidim_lut` entry points taking the two tables as
arguments. `softmax_latency` / `softmax_stable` were split into an `_impl` body plus the existing
runtime-initialising entry point, which is unchanged, so plain Keras and QKeras softmax generate
exactly the code they did before. Separate names rather than overloads of `softmax`, so that
`softmax_multidim`'s `#pragma HLS allocation instances = softmax<CONFIG_T>` still names a single
function.

The same issue reports invalid types such as `ap_ufixed<2,32>`. That spelling is `bit_exact`'s
deliberate sentinel for `B < 1`, not itself a bug, but it is reached through a real one: HGQ's
heterogeneous quantizers can train a channel to a negative total bitwidth. `extract_fixed_quantizer_config`
now clamps `B` to **0**, which is the constant-zero encoding `generate_mask_fn` already understands,
rather than to 1, which would bring a pruned channel back as a live 1-bit one. `generate_mask_fn`'s
`if b == 0` is widened to `b <= 0` so the other four frontends that build `mask_kbi` are covered too.

Fixes #1523

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing configs, APIs or generated code behave differently)
- [ ] New frontend / backend
- [ ] New layer / operator support
- [ ] New configuration option — a new `io_type`, Strategy, or config attribute
- [ ] Research paper implementation
- [ ] Documentation
- [ ] Build, CI or tooling
- [ ] Refactor / cleanup (no functional change)

## Affected areas

**Backends:**
- [x] Vivado, Vitis (VivadoAccelerator inherits `vivado:optimize` and so also gets the pass; not exercised)
- [ ] Backend-independent (core IR, optimizer, `hls4ml.model`)

Nothing under `hls4ml/model/` changes. Quartus, oneAPI, Catapult and Libero are untouched: the pass
is registered under the Vivado backend only, and their softmax kernels keep building tables at
runtime exactly as before.

**Frontends:**
- [x] Keras v3 (HGQ2 handlers only)
- [ ] Not related to a frontend

**Components:**
- [x] IR (layers + model graph) / optimizer passes
- [x] C++ templates / HLS sources under `hls4ml/templates/`
- [ ] Profiling, reporting or the CLI
- [x] Packaging, build or CI (one entry in `generate_ci_yaml.py`)

## Configurations affected and exercised

The axis this change is keyed on is the softmax `implementation`, not Strategy.

| Backend | `io_type` | `implementation` | Verified |
|---|---|---|---|
| Vivado | io_parallel | stable, latency | pytest + csim, 1D and multidim inputs |
| Vivado | io_stream | stable, latency | pytest + csim, 1D and multidim inputs |
| Vitis | io_parallel | stable, latency | pytest + csim, 1D and multidim inputs |
| Vitis | io_stream | stable, latency | pytest + csim, 1D and multidim inputs |
| Vivado, Vitis | both | argmax, legacy | pass returns early; covered by the existing `test_softmax.py` |
| VivadoAccelerator | — | — | not run |

Deliberately left out: no synthesis run of any configuration (see below), and no HGQ2 softmax on
Quartus / oneAPI / Catapult / Libero, which the HGQ2 frontend is not tested on today
(`test_hgq_layers.py`, `test_hgq_players.py` and `test_hgq2_mha.py` are all Vivado/Vitis only).

**New configuration axis introduced by this PR:** none.

## Impact on generated HLS

- [ ] This PR **does not change** the generated HLS for existing models.
- [x] This PR **changes** the generated HLS. Numbers below.

The change is confined to HGQ2 `QSoftmax`. For every other softmax the emitted call, the config
struct and the kernel body are byte-identical to `main`; `test_hgq2_softmax.py` carries an explicit
negative control asserting a plain `keras.layers.Softmax` still gets the two-argument call.

For HGQ2 `QSoftmax` the call gains two arguments and the project gains two weight headers
(`exp_table<n>.h`, `inv_table<n>.h`), while the runtime `init_*_table` loops disappear from that
layer.

**Numerical behaviour:** intentionally changed. After this PR, `hls_model.predict` on the test
models is bit-exact with Keras — `np.testing.assert_array_equal`, not `assert_allclose` — for all
16 covered combinations.

One caveat worth recording, since it bears on how the issue is attributed. Before implementing this
I compared HGQ's trained tables against what `init_exp_table` / `init_invert_table` reconstruct for
default `QSoftmax` configurations, and they matched **bit for bit** (the C++ assigns through
`exp_table_t`, which already carries HGQ's `RND_CONV`/`SAT`). On those models the reported error
therefore came from the address-width mismatch, not from the table values. Both are fixed here, and
carrying the trained tables makes the result independent of `exp_scale` and of the generic
reconstruction; but I have not isolated the two effects on the reporter's model.

| Model / test | Backend & version | Part | Latency (cycles) | II | LUT | FF | DSP | BRAM |
|---|---|---|---|---|---|---|---|---|
| before | — | — | not run | | | | | |
| after  | — | — | not run | | | | | |

**No synthesis was run.** C simulation proves the arithmetic; it cannot see two things that need a
real build: whether `#pragma HLS allocation instances = softmax_lut<CONFIG_T>` resolves as intended
in `softmax_multidim_lut`, and the QoR effect of `function_instantiate` on the table arguments.
Both are flagged here rather than assumed.

## Tests

New file `test/pytest/test_hgq2_softmax.py`, 19 tests:

- `test_hgq2_softmax_uses_trained_tables`, parametrised over backend × `io_type` × `stable` ×
  input shape (16 cases). Asserts the weights exist and are sized `2**addr_width`; that they carry
  the `NamedType` `bit_exact` derived rather than one re-inferred from the data (this catches
  `AttributeDict.__setitem__` silently overwriting `<name>_t` when a `WeightVariable` is stored);
  that the contents equal an independent recomputation straight from `hgq` and **differ** from a
  naive `exp(x * exp_scale)` reconstruction, so the test cannot pass vacuously; that the generated
  call names both arrays and the headers are written and included; and finally
  `assert_array_equal(r_hls, r_keras)`.
- `test_plain_keras_softmax_keeps_runtime_tables` — negative control, two-argument call preserved.
- `test_dead_channels_stay_zero` — a heterogeneous quantizer channel forced to a negative total
  width stays `b == 0` and renders as `out[3] = 0;`.

`test_hgq2_softmax` is added to `KERAS3_LIST` in `generate_ci_yaml.py`, so CI runs it under
`.pytest-keras3-only` alongside `test_hgq2_mha`. Without that it would be batched into a default
job, whose environment has Keras 2 and no `hgq`.

Commands run, all from `test/pytest` on this branch:

```
pytest test_hgq2_softmax.py -q -p no:randomly            # 19 passed
pytest test_softmax.py -q -p no:randomly -k "Vivado or Vitis"   # 116 passed
pytest test_sparsepixels.py test_bit_exact_zeropadding.py -q -p no:randomly
                                                          # 17 passed, 2 failed
pre-commit run --files <every file in this diff>          # all hooks passed
pre-commit run --hook-stage manual --all-files check-manifest
                                                          # only uninitialised submodules reported
```

The two failures are `test_bit_exact_zeropadding.py::test_bit_exact_zeropadding{1,2}d[io_parallel-oneAPI]`.
They fail identically on an unmodified `origin/main` worktree here, so they are pre-existing and
unrelated — this PR does not touch oneAPI.

`test_hgq_layers.py` and `test_hgq_players.py`, which cover the `QUnaryLUTHandler` refactor, could
**not** be run: HGQ v1 is not installed in my environment (`ModuleNotFoundError: No module named
'HGQ'`). Instead I checked the refactor directly, running the extracted helpers and the verbatim
pre-refactor algorithm side by side on `QUnaryFunctionLUT` layers with relu, sigmoid, tanh and exp
activations; the tables are byte-identical. That refactor also fixes a latent bug it inherited: the
old code called `layer.oq(table[None, ...])`, which fails on any layer built for rank > 2 — which
is exactly what `QSoftmax`'s sublayers are for a multidimensional input.

**Test configuration:** Linux, Python 3.10, Keras 3 on the TensorFlow backend, `hgq` 0.1.8. No HLS
toolchain — `compile()` builds against the bundled `ap_types/` with g++.

## AI assistance disclosure

- [ ] **None** — no AI tool was used.
- [ ] **Assisted** — completion, refactoring, docstrings, tests; design and code are mine.
- [ ] **Substantial** — significant AI-generated portions, reviewed and edited by me.
- [x] **Agentic** — produced largely end-to-end by an AI agent from my prompts.

Tool(s) and model(s): Claude Code (Claude Opus 5)

Where it was used: all files in this diff — the optimizer pass, the converter changes, the kernel
split, and the tests — from prompts describing the issue.

If anything other than *None* is ticked, confirm all of the following:

- [x] **I am the author of this contribution and take full responsibility for it.** ...
- [x] I verified the generated code against real hls4ml and HLS semantics ...
- [x] All numbers, logs and test results quoted in this PR come from runs I actually performed ...
- [x] I have the right to submit this work under the project's licence ...
- [x] No AI tool is credited as an author in any commit in this branch.

## Checklist

**Required:**
- [x] I have read the [contributing guidelines](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I installed and ran `pre-commit` on the files I edited.
- [x] I added tests under `test/pytest` covering this change.
- [x] I self-reviewed the full diff ...
- [x] The AI assistance disclosure above is complete and accurate.

**If applicable:**
- [ ] Documentation under `docs/` updated. — not applicable; this is a bug fix with no new
      user-facing option, and no `docs/` page describes the softmax table construction.
- [ ] No new build or synthesis warnings. — cannot confirm, no synthesis was run.
- [ ] Public API / config schema changes are documented. — none.

## Release note

```release-note
HGQ2 QSoftmax layers now emit the lookup tables trained by HGQ instead of rebuilding them at
runtime in the generated C++, making Vivado and Vitis output bit-exact with Keras.
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
