### PR TITLE
Keras frontends: stop silently misparsing unsupported layer configurations

### DIFF
--- a/hls4ml/converters/keras/convolution.py
+++ b/hls4ml/converters/keras/convolution.py
@@ -8,9 +8,7 @@ def parse_conv1d_layer(keras_layer, input_names, input_shapes, data_reader):
 
     layer = parse_default_keras_layer(keras_layer, input_names)
 
-    dilation = keras_layer['config'].get('dilation_rate', [1])[0]
-    if dilation != 1:
-        raise NotImplementedError(f'Layer {layer["name"]}: dilation_rate > 1 is not supported.')
+    layer['dilation'] = keras_layer['config'].get('dilation_rate', [1])[0]
 
     (*_, layer['in_width'], layer['n_chan']) = parse_data_format(input_shapes[0], layer['data_format'])
 
@@ -35,8 +33,29 @@ def parse_conv1d_layer(keras_layer, input_names, input_shapes, data_reader):
     layer['filt_width'] = keras_layer['config']['kernel_size'][0]
     layer['stride_width'] = keras_layer['config']['strides'][0]
 
+    groups = keras_layer['config'].get('groups', 1)
+    if groups != 1:
+        # groups == in_channels == filters is a depthwise conv; reshape the kernel from
+        # (kernel_size, 1, n_chan) to the (kernel_size, n_chan, 1) depthwise layout.
+        # Other grouped shapes have no hls4ml kernel and are rejected.
+        if (
+            groups != layer['n_chan']
+            or layer['n_filt'] != layer['n_chan']
+            or layer['class_name'] not in ['Conv1D', 'QConv1D']
+        ):
+            raise NotImplementedError(
+                'Grouped convolution is only supported as depthwise (groups == in_channels == filters); '
+                f'layer {layer["name"]} has groups={groups}, in_channels={layer["n_chan"]}, filters={layer["n_filt"]}.'
+            )
+        kernel = layer.pop('weight_data')
+        layer['class_name'] = 'DepthwiseConv1D'
+        layer['depthwise_data'] = kernel.reshape(*kernel.shape[:-2], layer['n_chan'], 1)
+        layer['depth_multiplier'] = 1
+
+    # Padding and output size follow the dilated (effective) kernel extent
+    dilated_filt_width = (layer['filt_width'] - 1) * layer['dilation'] + 1
     (layer['out_width'], layer['pad_left'], layer['pad_right']) = compute_padding_1d(
-        keras_layer['config']['padding'], layer['in_width'], layer['stride_width'], layer['filt_width']
+        keras_layer['config']['padding'], layer['in_width'], layer['stride_width'], dilated_filt_width
     )
 
     if layer['data_format'] == 'channels_last':
@@ -52,6 +71,12 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader):
     assert 'Conv2D' in keras_layer['class_name']
 
     layer = parse_default_keras_layer(keras_layer, input_names)
+
+    dilation_rate = keras_layer['config'].get('dilation_rate', [1, 1])
+    if dilation_rate[0] != dilation_rate[1]:
+        # The conv config structs carry a single dilation value
+        raise NotImplementedError(f'Layer {layer["name"]}: asymmetric dilation_rate {dilation_rate} is not supported.')
+    layer['dilation'] = dilation_rate[0]
 
     (*_, layer['in_height'], layer['in_width'], layer['n_chan']) = parse_data_format(input_shapes[0], layer['data_format'])
 
@@ -78,6 +103,28 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader):
     layer['stride_height'] = keras_layer['config']['strides'][0]
     layer['stride_width'] = keras_layer['config']['strides'][1]
 
+    groups = keras_layer['config'].get('groups', 1)
+    if groups != 1:
+        # groups == in_channels == filters is a depthwise conv; reshape the kernel from
+        # (*kernel_size, 1, n_chan) to the (*kernel_size, n_chan, 1) depthwise layout.
+        # Other grouped shapes have no hls4ml kernel and are rejected.
+        if (
+            groups != layer['n_chan']
+            or layer['n_filt'] != layer['n_chan']
+            or layer['class_name'] not in ['Conv2D', 'QConv2D']
+        ):
+            raise NotImplementedError(
+                'Grouped convolution is only supported as depthwise (groups == in_channels == filters); '
+                f'layer {layer["name"]} has groups={groups}, in_channels={layer["n_chan"]}, filters={layer["n_filt"]}.'
+            )
+        kernel = layer.pop('weight_data')
+        layer['class_name'] = 'DepthwiseConv2D'
+        layer['depthwise_data'] = kernel.reshape(*kernel.shape[:-2], layer['n_chan'], 1)
+        layer['depth_multiplier'] = 1
+
+    # Padding and output size follow the dilated (effective) kernel extent
+    dilated_filt_height = (layer['filt_height'] - 1) * layer['dilation'] + 1
+    dilated_filt_width = (layer['filt_width'] - 1) * layer['dilation'] + 1
     (
         layer['out_height'],
         layer['out_width'],
@@ -91,8 +138,8 @@ def parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader):
         layer['in_width'],
         layer['stride_height'],
         layer['stride_width'],
-        layer['filt_height'],
-        layer['filt_width'],
+        dilated_filt_height,
+        dilated_filt_width,
     )
 
     if layer['data_format'] == 'channels_first':

--- a/hls4ml/converters/keras/core.py
+++ b/hls4ml/converters/keras/core.py
@@ -1,5 +1,7 @@
 import math
 
+import numpy as np
+
 from hls4ml.converters.keras_v2_to_hls import get_weights_data, keras_handler, parse_default_keras_layer
 from hls4ml.model.quantizers import BinaryQuantizer, TernaryQuantizer
 from hls4ml.model.types import IntegerPrecisionType
@@ -76,7 +78,32 @@ def parse_activation_layer(keras_layer, input_names, input_shapes, data_reader):
     elif layer['class_name'] == 'ELU':
         layer['activ_param'] = keras_layer['config'].get('alpha', 1.0)
     elif layer['class_name'] == 'ReLU':
-        layer['class_name'] = 'Activation'
+        max_value = keras_layer['config'].get('max_value', None)
+        if max_value is not None and max_value == float('inf'):
+            max_value = None
+        negative_slope = keras_layer['config'].get('negative_slope', 0.0)
+        threshold = keras_layer['config'].get('threshold', 0.0)
+        if max_value is not None and (negative_slope != 0.0 or threshold != 0.0):
+            raise NotImplementedError(
+                f'Layer {layer["name"]}: ReLU with max_value combined with threshold or negative_slope is not supported.'
+            )
+        if negative_slope != 0.0 and threshold != 0.0:
+            raise NotImplementedError(f'Layer {layer["name"]}: ReLU must have threshold == 0 or negative_slope == 0.')
+        if max_value is not None:
+            layer['class_name'] = 'ClippedReLU'
+            layer['activation'] = 'clippedrelu'
+            layer['activ_param'] = max_value
+        elif negative_slope != 0.0:
+            layer['class_name'] = 'LeakyReLU'
+            layer['activation'] = 'LeakyReLU'
+            layer['activ_param'] = negative_slope
+        elif threshold != 0.0:
+            layer['class_name'] = 'ThresholdedReLU'
+            layer['activation'] = 'ThresholdedReLU'
+            layer['activ_param'] = threshold
+        else:
+            layer['class_name'] = 'Activation'
+            layer['activation'] = 'relu'
     elif layer['class_name'] == 'PReLU':
         if keras_layer['config'].get('shared_axes') is not None:
             raise Exception('PReLU with shared_axes other than None is not supported in hsl4ml')
@@ -101,6 +128,14 @@ def parse_batchnorm_layer(keras_layer, input_names, input_shapes, data_reader):
     assert 'BatchNormalization' in keras_layer['class_name'] or 'QConv2DBatchnorm' in keras_layer['class_name']
 
     layer = parse_default_keras_layer(keras_layer, input_names)
+
+    axis = keras_layer['config'].get('axis', -1)
+    if isinstance(axis, (list, tuple)):
+        axis = axis[0] if len(axis) == 1 else axis
+    if axis not in (-1, len(input_shapes[0]) - 1):
+        raise NotImplementedError(
+            f'Layer {layer["name"]}: normalization along axis {axis} is not supported; only the last (channel) dimension is.'
+        )
 
     in_size = 1
     for dim in input_shapes[0][1:]:
@@ -151,12 +186,23 @@ def parse_layernorm_layer(keras_layer, input_names, input_shapes, data_reader):
         )
     layer['seq_len'] = input_shapes[0][-2]
 
-    if not (keras_layer['config']['axis'][0] == 2):
+    axis = keras_layer['config']['axis'][0]
+    if axis < 0:
+        # Keras 3 serializes the default axis as -1; Keras 2 normalizes it to the positive form
+        axis += len(input_shapes[0])
+    if axis != 2:
         raise Exception('assigning the axis is not currently supported by hls4ml; only axis 2 is supported')
-    layer['axis'] = keras_layer['config']['axis'][0]
+    layer['axis'] = axis
 
-    layer['gamma_data'] = get_weights_data(data_reader, layer['name'], 'gamma')
-    layer['beta_data'] = get_weights_data(data_reader, layer['name'], 'beta')
+    n_norm = input_shapes[0][-1]
+    if keras_layer['config'].get('scale', True):
+        layer['gamma_data'] = get_weights_data(data_reader, layer['name'], 'gamma')
+    else:
+        layer['gamma_data'] = np.ones(n_norm)
+    if keras_layer['config'].get('center', True):
+        layer['beta_data'] = get_weights_data(data_reader, layer['name'], 'beta')
+    else:
+        layer['beta_data'] = np.zeros(n_norm)
 
     if keras_layer['config']['epsilon'] <= 0:
         raise Exception('epsilon must be positive')
@@ -172,6 +218,9 @@ def parse_embedding_layer(keras_layer, input_names, input_shapes, data_reader):
     assert 'Embedding' in keras_layer['class_name']
 
     layer = parse_default_keras_layer(keras_layer, input_names)
+
+    if keras_layer['config'].get('mask_zero', False):
+        raise NotImplementedError(f'Layer {layer["name"]}: mask_zero=True is not supported.')
 
     layer['n_in'] = input_shapes[0][1]
     layer['vocab_size'] = keras_layer['config']['input_dim']

--- a/hls4ml/converters/keras/merge.py
+++ b/hls4ml/converters/keras/merge.py
@@ -23,6 +23,8 @@ def parse_merge_layer(keras_layer, input_names, input_shapes, data_reader):
         rank = len(input_shapes[0][1:])
         if rank > 1:
             raise Exception('ERROR: Dot of tensors with rank > 1 is not yet supported.')
+        if keras_layer['config'].get('normalize', False):
+            raise NotImplementedError(f'Layer {layer["name"]}: Dot with normalize=True is not supported.')
         layer['op'] = layer['class_name'].lower() + f'{rank}d'
     else:
         layer['class_name'] = 'Merge'

--- a/hls4ml/converters/keras/qkeras.py
+++ b/hls4ml/converters/keras/qkeras.py
@@ -39,7 +39,11 @@ def parse_qconv_layer(keras_layer, input_names, input_shapes, data_reader):
     elif '2D' in keras_layer['class_name']:
         layer, output_shape = parse_conv2d_layer(keras_layer, input_names, input_shapes, data_reader)
 
-    layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
+    if layer['class_name'].startswith('DepthwiseConv'):
+        # Depthwise-shaped grouped QConv is routed to DepthwiseConv by the base parser
+        layer['depthwise_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
+    else:
+        layer['weight_quantizer'] = get_quantizer_from_config(keras_layer, 'kernel')
     layer['bias_quantizer'] = get_quantizer_from_config(keras_layer, 'bias')
 
     return layer, output_shape

--- a/hls4ml/converters/keras/recurrent.py
+++ b/hls4ml/converters/keras/recurrent.py
@@ -209,9 +209,13 @@ def parse_bidirectional_layer(keras_layer, input_names, input_shapes, data_reade
             )
         )
 
-        if 'GRU' in rnn_layer['class_name']:
-            layer[f'{direction}_apply_reset_gate'] = 'after' if rnn_layer['config']['reset_after'] else 'before'
-
+        if layer[f'{direction}_bias_data'] is None:
+            # use_bias=False; the cell has no bias weights, substitute zeros of the gate width
+            d_out = layer[f'{direction}_weight_data'].shape[-1]
+            layer[f'{direction}_bias_data'] = np.zeros(d_out)
+            if 'GRU' in rnn_layer['class_name']:
+                layer[f'{direction}_recurrent_bias_data'] = np.zeros(d_out)
+        elif 'GRU' in rnn_layer['class_name']:
             if rnn_layer['config']['reset_after']:
                 # biases array is actually a 2-dim array of arrays (bias + recurrent bias)
                 # both arrays have shape: n_units * 3 (z, r, h_cand)
@@ -221,6 +225,9 @@ def parse_bidirectional_layer(keras_layer, input_names, input_shapes, data_reade
             else:
                 # reset_after=False has a single flat bias and no recurrent bias
                 layer[f'{direction}_recurrent_bias_data'] = np.zeros_like(layer[f'{direction}_bias_data'])
+
+        if 'GRU' in rnn_layer['class_name']:
+            layer[f'{direction}_apply_reset_gate'] = 'after' if rnn_layer['config']['reset_after'] else 'before'
 
         layer[f'{direction}_n_states'] = rnn_layer['config']['units']
 

--- a/hls4ml/converters/keras/recurrent.py
+++ b/hls4ml/converters/keras/recurrent.py
@@ -22,6 +22,13 @@ def parse_rnn_layer(keras_layer, input_names, input_shapes, data_reader):
     layer = parse_default_keras_layer(keras_layer, input_names)
     layer['direction'] = 'forward'
 
+    if keras_layer['config'].get('go_backwards', False):
+        raise NotImplementedError(f'Layer {layer["name"]}: go_backwards=True is not supported.')
+    if keras_layer['config'].get('stateful', False):
+        print(
+            f'WARNING: "stateful" of layer {layer["name"]} is ignored; hls4ml inference does not carry state between inputs.'
+        )
+
     layer['return_sequences'] = keras_layer['config']['return_sequences']
     layer['return_state'] = keras_layer['config']['return_state']
 
@@ -44,8 +51,8 @@ def parse_rnn_layer(keras_layer, input_names, input_shapes, data_reader):
     )
 
     if layer['bias_data'] is None:
-        d_out = layer['bias_data'].shape[-1]
-        if 'GRU' in layer['class_name']:
+        d_out = layer['weight_data'].shape[-1]
+        if 'GRU' in layer['class_name'] and keras_layer['config']['reset_after']:
             layer['bias_data'] = np.zeros((2, d_out), dtype=np.float32)
         else:
             layer['bias_data'] = np.zeros((d_out,), dtype=np.float32)
@@ -53,11 +60,15 @@ def parse_rnn_layer(keras_layer, input_names, input_shapes, data_reader):
     if 'GRU' in layer['class_name']:
         layer['apply_reset_gate'] = 'after' if keras_layer['config']['reset_after'] else 'before'
 
-        # biases array is actually a 2-dim array of arrays (bias + recurrent bias)
-        # both arrays have shape: n_units * 3 (z, r, h_cand)
-        biases = layer['bias_data']
-        layer['bias_data'] = biases[0]
-        layer['recurrent_bias_data'] = biases[1]
+        if keras_layer['config']['reset_after']:
+            # biases array is actually a 2-dim array of arrays (bias + recurrent bias)
+            # both arrays have shape: n_units * 3 (z, r, h_cand)
+            biases = layer['bias_data']
+            layer['bias_data'] = biases[0]
+            layer['recurrent_bias_data'] = biases[1]
+        else:
+            # reset_after=False has a single flat bias and no recurrent bias
+            layer['recurrent_bias_data'] = np.zeros_like(layer['bias_data'])
 
     if layer['return_sequences']:
         output_shape = [input_shapes[0][0], layer['n_timesteps'], layer['n_out']]
@@ -146,6 +157,11 @@ def parse_bidirectional_layer(keras_layer, input_names, input_shapes, data_reade
         rnn_backward_layer['class_name'] in rnn_layers or rnn_backward_layer['class_name'][1:] in rnn_layers
     )
 
+    if 'SimpleRNN' in rnn_forward_layer['class_name'] or 'SimpleRNN' in rnn_backward_layer['class_name']:
+        raise NotImplementedError(
+            f'Layer {keras_layer["config"]["name"]}: Bidirectional is only supported with LSTM or GRU sub-layers.'
+        )
+
     layer = parse_default_keras_layer(keras_layer, input_names)
 
     layer['direction'] = 'bidirectional'
@@ -158,6 +174,9 @@ def parse_bidirectional_layer(keras_layer, input_names, input_shapes, data_reade
     layer['n_timesteps'] = input_shapes[0][1]
     layer['n_in'] = input_shapes[0][2]
     layer['merge_mode'] = keras_layer['config']['merge_mode']
+    if layer['merge_mode'] is None:
+        # merge_mode=None returns two separate output tensors, which the Bidirectional layer cannot represent
+        raise NotImplementedError(f'Layer {layer["name"]}: merge_mode=None is not supported.')
 
     for direction, rnn_layer in [('forward', rnn_forward_layer), ('backward', rnn_backward_layer)]:
         layer[f'{direction}_name'] = rnn_layer['config']['name']
@@ -174,10 +193,7 @@ def parse_bidirectional_layer(keras_layer, input_names, input_shapes, data_reade
             layer[f'{direction}_use_bias'] = rnn_layer['config']['use_bias']
 
         rnn_layer_name = rnn_layer['config']['name']
-        if 'SimpleRNN' in layer['class_name']:
-            cell_name = 'simple_rnn'
-        else:
-            cell_name = rnn_layer['class_name'].lower()
+        cell_name = rnn_layer['class_name'].lower()
         temp_dir = direction
         if swapped_order:
             temp_dir = 'backward' if direction == 'forward' else 'forward'
@@ -196,11 +212,15 @@ def parse_bidirectional_layer(keras_layer, input_names, input_shapes, data_reade
         if 'GRU' in rnn_layer['class_name']:
             layer[f'{direction}_apply_reset_gate'] = 'after' if rnn_layer['config']['reset_after'] else 'before'
 
-            # biases array is actually a 2-dim array of arrays (bias + recurrent bias)
-            # both arrays have shape: n_units * 3 (z, r, h_cand)
-            biases = layer[f'{direction}_bias_data']
-            layer[f'{direction}_bias_data'] = biases[0]
-            layer[f'{direction}_recurrent_bias_data'] = biases[1]
+            if rnn_layer['config']['reset_after']:
+                # biases array is actually a 2-dim array of arrays (bias + recurrent bias)
+                # both arrays have shape: n_units * 3 (z, r, h_cand)
+                biases = layer[f'{direction}_bias_data']
+                layer[f'{direction}_bias_data'] = biases[0]
+                layer[f'{direction}_recurrent_bias_data'] = biases[1]
+            else:
+                # reset_after=False has a single flat bias and no recurrent bias
+                layer[f'{direction}_recurrent_bias_data'] = np.zeros_like(layer[f'{direction}_bias_data'])
 
         layer[f'{direction}_n_states'] = rnn_layer['config']['units']
 

--- a/hls4ml/converters/keras/reshaping.py
+++ b/hls4ml/converters/keras/reshaping.py
@@ -66,7 +66,7 @@ def parse_zeropadding2d_layer(keras_layer, input_names, input_shapes, data_reade
             layer['pad_right'] = width_pad[1]
         else:
             layer['pad_left'] = width_pad
-            layer['pad_bottom'] = width_pad
+            layer['pad_right'] = width_pad
 
     if layer['data_format'] == 'channels_first':
         output_shape = [

--- a/hls4ml/converters/keras_v2_to_hls.py
+++ b/hls4ml/converters/keras_v2_to_hls.py
@@ -232,6 +232,7 @@ def parse_keras_model(model_arch, reader):
         'Activation',
         'LeakyReLU',
         'ThresholdedReLU',
+        'ClippedReLU',
         'ELU',
         'PReLU',
         'Softmax',

--- a/hls4ml/converters/keras_v3/conv.py
+++ b/hls4ml/converters/keras_v3/conv.py
@@ -98,6 +98,12 @@ class ConvHandler(KerasV3LayerHandler):
         assert len(in_tensors) == 1, f'Layer {layer.name} has more than one input'
         assert len(out_tensors) == 1, f'Layer {layer.name} has more than one output'
 
+        dilation_rate = tuple(getattr(layer, 'dilation_rate', (1,)))
+        if len(set(dilation_rate)) > 1:
+            # The conv config structs carry a single dilation value
+            raise NotImplementedError(f'Layer {layer.name}: asymmetric dilation_rate {dilation_rate} is not supported.')
+        dilation = dilation_rate[0]
+
         in_shape: tuple[int, ...] = in_tensors[0].shape[1:]  # type: ignore
         out_shape: tuple[int, ...] = out_tensors[0].shape[1:]  # type: ignore
         assert all(isinstance(x, int) for x in in_shape), f'Layer {layer.name} has non-fixed size input: {in_shape}'
@@ -112,21 +118,30 @@ class ConvHandler(KerasV3LayerHandler):
         ker_px_shape: tuple[int, ...] = layer.kernel_size
         data_format = layer.data_format
 
+        # Padding is derived from the dilated (effective) kernel extent; filt_* keep the
+        # actual kernel size, which is what the weight tensors are indexed by
+        eff_ker_px_shape = tuple((k - 1) * dilation + 1 for k in ker_px_shape)
+
         config = gen_conv_config(
             in_shape=in_shape,
             out_shape=out_shape,
-            ker_px_shape=ker_px_shape,
+            ker_px_shape=eff_ker_px_shape,
             strides=layer.strides,
             data_format=data_format,
             padding=layer.padding,
             name=layer.name,
         )
+        if len(ker_px_shape) == 1:
+            config['filt_width'] = ker_px_shape[0]
+        else:
+            config['filt_height'], config['filt_width'] = ker_px_shape
 
         config.update(
             {
                 'bias_data': bias,
                 'data_format': data_format,
                 'weight_data': kernel,
+                'dilation': dilation,
             }
         )
 

--- a/hls4ml/converters/keras_v3/core.py
+++ b/hls4ml/converters/keras_v3/core.py
@@ -108,26 +108,34 @@ class ReLUHandler(KerasV3LayerHandler):
             config['activation'] = 'prelu'
 
         if layer.__class__.__name__ in ('ReLU', 'LeakyReLU'):
-            if layer.__class__.__name__ == 'ReLU':
-                assert layer.max_value in (None, float('inf')), 'Only ReLU with max_value=None or inf is supported'
-
+            max_value = getattr(layer, 'max_value', None)
+            if max_value is not None and float(max_value) == float('inf'):
+                max_value = None
             negative_slope = float(layer.negative_slope)
             threshold = float(layer.threshold) if hasattr(layer, 'threshold') else 0.0
-            if threshold != 0.0 and negative_slope != 0.0:
-                raise NotImplementedError(f'layer {layer.name}: ReLU must has threshold=0 or negative_slope=0')
 
-            if negative_slope == 0.0 and threshold == 0.0:
+            if max_value is not None and (negative_slope != 0.0 or threshold != 0.0):
+                raise NotImplementedError(
+                    f'Layer {layer.name}: ReLU with max_value combined with threshold or negative_slope is not supported.'
+                )
+            if threshold != 0.0 and negative_slope != 0.0:
+                raise NotImplementedError(f'Layer {layer.name}: ReLU must have threshold=0 or negative_slope=0.')
+
+            if max_value is not None:
+                config['class_name'] = 'ClippedReLU'
+                config['activ_param'] = float(max_value)
+                config['activation'] = 'clippedrelu'
+            elif negative_slope != 0.0:
+                config['class_name'] = 'LeakyReLU'
+                config['activ_param'] = negative_slope
+                config['activation'] = 'leakyrelu'
+            elif threshold != 0.0:
+                config['class_name'] = 'ThresholdedReLU'
+                config['activ_param'] = threshold
+                config['activation'] = 'thresholdedrelu'
+            else:
                 config['class_name'] = 'Activation'
                 config['activation'] = 'relu'
-
-            if negative_slope != 0.0:
-                config['class_name'] = 'LeakyReLU'
-                config['activ_param'] = float(layer.negative_slope)
-                config['activation'] = 'leakyrelu'
-            elif negative_slope == 0.0:
-                config['class_name'] = 'ThresholdedReLU'
-                config['activ_param'] = float(layer.threshold)
-                config['activation'] = 'thresholdedrelu'
 
         return (config,)
 
@@ -248,6 +256,12 @@ class NoOp(KerasV3LayerHandler):
         in_tensors: Sequence['KerasTensor'],
         out_tensors: Sequence['KerasTensor'],
     ):
+        if in_tensors[0].shape[1:] != out_tensors[0].shape[1:]:
+            # e.g. RandomCrop still crops at inference time; a shape-changing layer cannot be a no-op
+            raise NotImplementedError(
+                f'Layer {layer.name} ({layer.__class__.__name__}) changes the tensor shape at inference '
+                f'({in_tensors[0].shape[1:]} -> {out_tensors[0].shape[1:]}) and cannot be skipped.'
+            )
         config = {
             'activation': 'linear',
             'class_name': 'Activation',

--- a/hls4ml/converters/keras_v3/merge.py
+++ b/hls4ml/converters/keras_v3/merge.py
@@ -48,6 +48,8 @@ class MergeHandler(KerasV3LayerHandler):
                 )
                 assert all(len(t.shape) == 2 for t in in_tensors), msg
                 assert in_tensors[0].shape[1] == in_tensors[1].shape[1], f'Input shape mismatch for layer {layer.name}.'
+                if getattr(layer, 'normalize', False):
+                    raise NotImplementedError(f'Layer {layer.name}: Dot with normalize=True is not supported.')
                 class_name = 'Dot'
                 op = 'dot1d'
                 config['axes'] = layer.axes

--- a/hls4ml/converters/keras_v3/pooling.py
+++ b/hls4ml/converters/keras_v3/pooling.py
@@ -70,4 +70,6 @@ class PoolingHandler(KerasV3LayerHandler):
             # inconsistent pooling1d config key name...
             config['n_in'] = config['in_width']
             config['n_out'] = config['out_width']
+        if not isinstance(layer, BasePooling):
+            config['keepdims'] = layer.keepdims
         return config

--- a/hls4ml/converters/keras_v3/recurrent.py
+++ b/hls4ml/converters/keras_v3/recurrent.py
@@ -29,6 +29,13 @@ class RecurentHandler(KerasV3LayerHandler):
 
         if layer.return_state:
             raise Exception(f'return_state=True is not supported for {layer.__class__} layer.')
+        if layer.go_backwards:
+            raise NotImplementedError(f'Layer {layer.name}: go_backwards=True is not supported.')
+        if layer.stateful:
+            print(
+                f'WARNING: "stateful" of layer {layer.name} is ignored; '
+                'hls4ml inference does not carry state between inputs.'
+            )
 
         config = {
             'direction': 'forward',
@@ -46,8 +53,13 @@ class RecurentHandler(KerasV3LayerHandler):
         if layer.use_bias:
             if isinstance(layer, keras.layers.GRU):
                 bias = self.load_weight(layer.cell, 'bias')
-                config['bias_data'] = bias[0]
-                config['recurrent_bias_data'] = bias[1]
+                if layer.reset_after:
+                    config['bias_data'] = bias[0]
+                    config['recurrent_bias_data'] = bias[1]
+                else:
+                    # reset_after=False has a single flat bias and no recurrent bias
+                    config['bias_data'] = bias
+                    config['recurrent_bias_data'] = np.zeros_like(bias)
             else:
                 config['bias_data'] = self.load_weight(layer.cell, 'bias')
         else:
@@ -96,6 +108,10 @@ class BidirectionalHandler(KerasV3LayerHandler):
         for rnn_layer in [rnn_forward_layer, rnn_backward_layer]:
             class_name = rnn_layer.__class__.__name__
             assert class_name in rnn_layers or class_name[1:] in rnn_layers
+            if 'SimpleRNN' in class_name:
+                raise NotImplementedError(
+                    f'Layer {layer.name}: Bidirectional is only supported with LSTM or GRU sub-layers.'
+                )
 
         config = {}
 
@@ -110,6 +126,9 @@ class BidirectionalHandler(KerasV3LayerHandler):
         config['n_timesteps'] = in_tensors[0].shape[1]
         config['n_in'] = in_tensors[0].shape[2]
         config['merge_mode'] = layer.merge_mode
+        if layer.merge_mode is None:
+            # merge_mode=None returns two separate output tensors, which the Bidirectional layer cannot represent
+            raise NotImplementedError(f'Layer {layer.name}: merge_mode=None is not supported.')
 
         for direction, rnn_layer in [('forward', rnn_forward_layer), ('backward', rnn_backward_layer)]:
             config[f'{direction}_name'] = rnn_layer.name
@@ -127,10 +146,15 @@ class BidirectionalHandler(KerasV3LayerHandler):
             config[f'{direction}_recurrent_weight_data'] = self.load_weight(rnn_layer.cell, 'recurrent_kernel')
 
             if rnn_layer.use_bias:
-                if isinstance(rnn_layer.cell, keras.layers.GRU):
+                if isinstance(rnn_layer, keras.layers.GRU):
                     bias = self.load_weight(rnn_layer.cell, 'bias')
-                    config[f'{direction}_bias_data'] = bias[0]
-                    config[f'{direction}_recurrent_bias_data'] = bias[1]
+                    if rnn_layer.reset_after:
+                        config[f'{direction}_bias_data'] = bias[0]
+                        config[f'{direction}_recurrent_bias_data'] = bias[1]
+                    else:
+                        # reset_after=False has a single flat bias and no recurrent bias
+                        config[f'{direction}_bias_data'] = bias
+                        config[f'{direction}_recurrent_bias_data'] = np.zeros_like(bias)
                 else:
                     config[f'{direction}_bias_data'] = self.load_weight(rnn_layer.cell, 'bias')
             else:

--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -851,11 +851,15 @@ class GlobalPooling1D(Layer):
     _expected_attributes = [
         Attribute('n_in'),
         Attribute('n_filt'),
+        Attribute('keepdims', value_type=bool, default=False),
         ChoiceAttribute('pool_op', ['Max', 'Average'], configurable=False),
     ]
 
     def initialize(self):
-        shape = [self.attributes['n_filt']]
+        if self.attributes['keepdims']:
+            shape = [1, self.attributes['n_filt']]
+        else:
+            shape = [self.attributes['n_filt']]
         self.add_output_variable(shape)
         self.set_attr('pool_op', self.get_attr('class_name').split('Pooling')[0].replace('Global', ''))
 
@@ -865,11 +869,15 @@ class GlobalPooling2D(Layer):
         Attribute('in_height'),
         Attribute('in_width'),
         Attribute('n_filt'),
+        Attribute('keepdims', value_type=bool, default=False),
         ChoiceAttribute('pool_op', ['Max', 'Average'], configurable=False),
     ]
 
     def initialize(self):
-        shape = [self.attributes['n_filt']]
+        if self.attributes['keepdims']:
+            shape = [1, 1, self.attributes['n_filt']]
+        else:
+            shape = [self.attributes['n_filt']]
         self.add_output_variable(shape)
         self.set_attr('pool_op', self.get_attr('class_name').split('Pooling')[0].replace('Global', ''))
 
@@ -1989,6 +1997,7 @@ layer_map = {
     'QActivation': Activation,
     'LeakyReLU': ParametrizedActivation,
     'ThresholdedReLU': ParametrizedActivation,
+    'ClippedReLU': ParametrizedActivation,
     'ELU': ParametrizedActivation,
     'PReLU': PReLU,
     'Softmax': Softmax,

--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -856,7 +856,9 @@ class GlobalPooling1D(Layer):
     ]
 
     def initialize(self):
-        if self.attributes['keepdims']:
+        # get_attr with a default: initialize() runs before defaults of expected attributes are
+        # applied, and not every frontend sets 'keepdims'
+        if self.get_attr('keepdims', False):
             shape = [1, self.attributes['n_filt']]
         else:
             shape = [self.attributes['n_filt']]
@@ -874,7 +876,7 @@ class GlobalPooling2D(Layer):
     ]
 
     def initialize(self):
-        if self.attributes['keepdims']:
+        if self.get_attr('keepdims', False):
             shape = [1, 1, self.attributes['n_filt']]
         else:
             shape = [self.attributes['n_filt']]

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -31,10 +31,11 @@ def _sanitize_test_id(s: str) -> str:
 def test_case_id(request):
     """
     Return a unique identifier for the current parametrized test case.
-    Format: test_file_test_name_param_id (from test_file.py::test_name[param_id]).
-    Used for generating output directory names.
+    Format: hls4mlprj_test_file_test_name_param_id (from test_file.py::test_name[param_id]).
+    Used for generating output directory names; the hls4mlprj_ prefix keeps the
+    generated project directories covered by .gitignore.
     """
-    return _sanitize_test_id(request.node.nodeid)
+    return 'hls4mlprj_' + _sanitize_test_id(request.node.nodeid)
 
 
 def str_to_bool(val):

--- a/test/pytest/synthesis_helpers.py
+++ b/test/pytest/synthesis_helpers.py
@@ -16,6 +16,9 @@ def get_baseline_path(baseline_file_name, backend, version):
     Returns:
         Path: A pathlib.Path object pointing to the baseline file location.
     """
+    # Baseline files are named without the hls4mlprj_ prefix the test_case_id fixture
+    # adds for output directories
+    baseline_file_name = baseline_file_name.removeprefix('hls4mlprj_')
     return Path(__file__).parent / 'baselines' / backend / version / baseline_file_name
 
 

--- a/test/pytest/test_batchnorm.py
+++ b/test/pytest/test_batchnorm.py
@@ -47,3 +47,16 @@ def test_batchnorm(test_case_id, model, data, backend, io_type):
     y_keras = np.squeeze(model.predict(data))
     y_hls = hls_model.predict(data)
     np.testing.assert_allclose(y_keras, y_hls, rtol=0, atol=atol, verbose=True)
+
+
+def test_batchnorm_rejects_non_channel_axis(test_case_id):
+    """Normalization along an axis other than the channel axis was silently misparsed."""
+    model = Sequential()
+    model.add(BatchNormalization(axis=1, input_shape=(8, 4)))
+    model.compile()
+
+    with pytest.raises(NotImplementedError, match='axis'):
+        config = hls4ml.utils.config_from_keras_model(model, granularity='name', backend='Vivado')
+        hls4ml.converters.convert_from_keras_model(
+            model, hls_config=config, output_dir=str(test_root_path / test_case_id), backend='Vivado'
+        )

--- a/test/pytest/test_embed.py
+++ b/test/pytest/test_embed.py
@@ -76,3 +76,16 @@ def test_embedding_accuracy(data, keras_model, hls_model):
     y_hls4ml = hls_model.predict(X.astype(float)).reshape(y_keras.shape)
     # "accuracy" of hls4ml predictions vs keras
     np.testing.assert_allclose(y_keras, y_hls4ml, rtol=0, atol=1e-03, verbose=True)
+
+
+def test_embedding_rejects_mask_zero(test_case_id):
+    """mask_zero=True implies masking semantics that hls4ml cannot represent."""
+    inputs = Input(shape=(10,), name='embedding_input', dtype='int32')
+    embedding = Embedding(input_dim=650, output_dim=2, mask_zero=True, name='embedding')(inputs)
+    model = Model(inputs=inputs, outputs=embedding)
+
+    with pytest.raises(NotImplementedError, match='mask_zero'):
+        config = hls4ml.utils.config_from_keras_model(model, granularity='name', backend='Vivado')
+        hls4ml.converters.convert_from_keras_model(
+            model, hls_config=config, output_dir=str(test_root_path / test_case_id), backend='Vivado'
+        )

--- a/test/pytest/test_globalpooling.py
+++ b/test/pytest/test_globalpooling.py
@@ -66,6 +66,9 @@ def test_global_pool1d(test_case_id, backend, keras_model_1d, data_1d, io_type):
     )
     hls_model.compile()
 
+    # keepdims must be reflected in the graph's output shape, not only in the values
+    assert list(hls_model.get_output_variables()[0].shape) == list(model.output_shape[1:])
+
     y_keras = model.predict(data_1d)
     y_hls = hls_model.predict(data_1d).reshape(y_keras.shape)
     np.testing.assert_allclose(y_keras, y_hls, rtol=0, atol=atol, verbose=True)
@@ -122,6 +125,9 @@ def test_global_pool2d(test_case_id, backend, keras_model_2d, data_2d, io_type):
         backend=backend,
     )
     hls_model.compile()
+
+    # keepdims must be reflected in the graph's output shape, not only in the values
+    assert list(hls_model.get_output_variables()[0].shape) == list(model.output_shape[1:])
 
     y_keras = model.predict(data_2d)
     y_hls = hls_model.predict(data_2d).reshape(y_keras.shape)

--- a/test/pytest/test_keras_api.py
+++ b/test/pytest/test_keras_api.py
@@ -19,6 +19,7 @@ from tensorflow.keras.layers import (
     MaxPooling1D,
     MaxPooling2D,
     PReLU,
+    ReLU,
 )
 
 import hls4ml
@@ -551,3 +552,55 @@ def test_pooling(test_case_id, pooling, padds, chans, backend, synthesis_config)
             assert hls_pool.attributes['pad_right'] == 0
 
     run_synthesis_test(config=synthesis_config, hls_model=hls_model, baseline_file_name=baseline_file_name, backend=backend)
+
+
+def test_relu_negative_slope_threshold(test_case_id):
+    """ReLU layer options previously silently dropped: negative_slope maps to LeakyReLU,
+    threshold to ThresholdedReLU. Checked numerically against Keras."""
+    model = tf.keras.models.Sequential(
+        [
+            tf.keras.layers.Input((8,)),
+            Dense(8, kernel_initializer='lecun_uniform'),
+            ReLU(negative_slope=0.25),
+            Dense(8, kernel_initializer='lecun_uniform'),
+            ReLU(threshold=0.5),
+        ]
+    )
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='ap_fixed<32,16>', backend='Vivado'
+    )
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir, backend='Vivado')
+
+    activations = [str(layer.get_attr('activation', '')).lower() for layer in hls_model.get_layers()]
+    assert 'leakyrelu' in activations and 'thresholdedrelu' in activations
+
+    hls_model.compile()
+    X = (np.random.rand(50, 8) * 4 - 2).astype('float32')
+    keras_prediction = model.predict(X)
+    hls_prediction = hls_model.predict(X).reshape(keras_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, keras_prediction, rtol=0.0, atol=1e-2)
+
+
+@pytest.mark.parametrize('dim', ['1d', '2d'])
+def test_grouped_depthwise_conv(test_case_id, dim):
+    """A depthwise-shaped grouped conv (groups == in_channels == filters) is routed to
+    DepthwiseConv. Checked numerically against Keras."""
+    if dim == '1d':
+        model = tf.keras.models.Sequential([tf.keras.layers.Input((16, 4)), Conv1D(4, 3, groups=4)])
+        X = np.random.rand(20, 16, 4).astype('float32')
+    else:
+        model = tf.keras.models.Sequential([tf.keras.layers.Input((16, 16, 4)), Conv2D(4, 3, groups=4)])
+        X = np.random.rand(20, 16, 16, 4).astype('float32')
+
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='ap_fixed<32,16>', backend='Vivado'
+    )
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir, backend='Vivado')
+    assert f'DepthwiseConv{dim.upper()}' in [layer.class_name for layer in hls_model.get_layers()]
+
+    hls_model.compile()
+    keras_prediction = model.predict(X)
+    hls_prediction = hls_model.predict(X).reshape(keras_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, keras_prediction, rtol=0.0, atol=1e-2)

--- a/test/pytest/test_keras_api.py
+++ b/test/pytest/test_keras_api.py
@@ -604,3 +604,20 @@ def test_grouped_depthwise_conv(test_case_id, dim):
     keras_prediction = model.predict(X)
     hls_prediction = hls_model.predict(X).reshape(keras_prediction.shape)
     np.testing.assert_allclose(hls_prediction, keras_prediction, rtol=0.0, atol=1e-2)
+
+
+def test_relu_max_value_layer_structure(test_case_id):
+    """ReLU(max_value) through the full v2 parser gives a single ClippedReLU layer; the dispatcher must not
+    split the 'activation' key into a duplicate Activation layer."""
+    model = tf.keras.models.Sequential()
+    model.add(Dense(4, input_shape=(4,)))
+    model.add(ReLU(max_value=6.0))
+
+    config = hls4ml.utils.config_from_keras_model(model, granularity='name')
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir, backend='Vivado')
+
+    layers = list(hls_model.get_layers())
+    assert [layer.attributes['class_name'] for layer in layers] == ['InputLayer', 'Dense', 'ClippedReLU']
+    assert layers[-1].attributes['activation'] == 'clippedrelu'
+    assert layers[-1].attributes['activ_param'] == 6.0

--- a/test/pytest/test_keras_converter.py
+++ b/test/pytest/test_keras_converter.py
@@ -1,11 +1,88 @@
+"""Direct tests of the Keras v2 layer handlers.
+
+These call the handlers with synthetic layer configs instead of building models, so
+they exercise the v2 parsing code deterministically under any installed Keras version.
+Unsupported layer options must raise a clear error instead of being silently dropped;
+options the IR can represent must be parsed faithfully.
+"""
+
 from unittest.mock import Mock
 
+import numpy as np
 import pytest
 
-from hls4ml.converters.keras.convolution import parse_conv1d_layer
+from hls4ml.converters.keras.convolution import parse_conv1d_layer, parse_conv2d_layer
+from hls4ml.converters.keras.core import parse_activation_layer, parse_batchnorm_layer, parse_embedding_layer
+from hls4ml.converters.keras.merge import parse_merge_layer
+from hls4ml.converters.keras.recurrent import parse_bidirectional_layer, parse_rnn_layer
+from hls4ml.converters.keras.reshaping import parse_zeropadding2d_layer
 
 
-def test_conv1d_rejects_unsupported_dilation():
+class SyntheticReader:
+    """Serves randomly initialized weights of predefined shapes to the v2 handlers.
+
+    Shapes are matched against the end of the requested variable name, so nested
+    paths (e.g. 'forward_lstm/lstm_cell/kernel') resolve like plain names.
+    """
+
+    def __init__(self, shapes):
+        self.shapes = shapes
+
+    def get_weights_data(self, layer_name, var_name):
+        for suffix, shape in self.shapes.items():
+            if var_name.endswith(suffix):
+                return None if shape is None else np.random.rand(*shape).astype('float32')
+        return None
+
+
+def make_conv2d_config(**overrides):
+    config = {
+        'name': 'conv',
+        'filters': 4,
+        'kernel_size': [3, 3],
+        'strides': [1, 1],
+        'padding': 'valid',
+        'data_format': 'channels_last',
+        'dilation_rate': [1, 1],
+        'groups': 1,
+    }
+    config.update(overrides)
+    return {'class_name': 'Conv2D', 'config': config}
+
+
+def make_rnn_config(class_name='LSTM', **overrides):
+    config = {
+        'name': f'{class_name.lower()}_test',
+        'units': 4,
+        'activation': 'tanh',
+        'recurrent_activation': 'sigmoid',
+        'use_bias': True,
+        'return_sequences': False,
+        'return_state': False,
+    }
+    if class_name == 'GRU':
+        config['reset_after'] = True
+    config.update(overrides)
+    return {'class_name': class_name, 'config': config}
+
+
+def make_bidirectional_config(sub_layer, merge_mode='concat'):
+    return {
+        'class_name': 'Bidirectional',
+        'config': {
+            'name': 'bidir_test',
+            'merge_mode': merge_mode,
+            'layer': sub_layer,
+        },
+    }
+
+
+# ----- Convolution ----- #
+
+
+def test_conv1d_parses_dilation():
+    # No kernel computes dilation yet; the parser stores the attribute (a field the conv
+    # config structs already have) and the backends are responsible for rejecting it
     keras_layer = {
         'class_name': 'Conv1D',
         'config': {
@@ -14,10 +91,171 @@ def test_conv1d_rejects_unsupported_dilation():
             'filters': 4,
             'kernel_size': [3],
             'strides': [1],
-            'padding': 'same',
+            'padding': 'valid',
             'dilation_rate': [2],
         },
     }
+    reader = SyntheticReader({'kernel': (3, 1, 4), 'bias': (4,)})
+    layer, output_shape = parse_conv1d_layer(keras_layer, ['input'], [[None, 64, 1]], reader)
+    assert layer['dilation'] == 2
+    # effective kernel extent is (3-1)*2+1 = 5, so valid padding gives 64-5+1 = 60
+    assert output_shape == [None, 60, 4]
+    assert layer['filt_width'] == 3
 
-    with pytest.raises(NotImplementedError, match='dilation_rate > 1 is not supported'):
-        parse_conv1d_layer(keras_layer, ['input'], [[None, 64, 1]], data_reader=Mock())
+
+def test_conv2d_parses_dilation():
+    reader = SyntheticReader({'kernel': (3, 3, 3, 4), 'bias': (4,)})
+    layer, output_shape = parse_conv2d_layer(make_conv2d_config(dilation_rate=[2, 2]), None, [[None, 16, 16, 3]], reader)
+    assert layer['dilation'] == 2
+    assert output_shape == [None, 12, 12, 4]
+    assert (layer['filt_height'], layer['filt_width']) == (3, 3)
+
+
+def test_conv2d_rejects_asymmetric_dilation():
+    # The conv config structs carry a single dilation value
+    with pytest.raises(NotImplementedError, match='dilation'):
+        parse_conv2d_layer(make_conv2d_config(dilation_rate=[2, 3]), None, [[None, 16, 16, 3]], Mock())
+
+
+def test_conv2d_rejects_grouped():
+    # groups that are not depthwise-shaped (groups == in_channels == filters) have no kernel
+    reader = SyntheticReader({'kernel': (3, 3, 2, 8), 'bias': (8,)})
+    with pytest.raises(NotImplementedError, match='[Gg]rouped convolution'):
+        parse_conv2d_layer(make_conv2d_config(filters=8, groups=2), None, [[None, 16, 16, 4]], reader)
+
+
+def test_conv2d_routes_depthwise_shaped_groups():
+    # groups == in_channels == filters is a depthwise convolution
+    reader = SyntheticReader({'kernel': (3, 3, 1, 4), 'bias': (4,)})
+    layer, output_shape = parse_conv2d_layer(make_conv2d_config(filters=4, groups=4), None, [[None, 16, 16, 4]], reader)
+    assert layer['class_name'] == 'DepthwiseConv2D'
+    assert layer['depthwise_data'].shape == (3, 3, 4, 1)
+    assert 'weight_data' not in layer
+    assert output_shape == [None, 14, 14, 4]
+
+
+# ----- ReLU layer options ----- #
+
+
+@pytest.mark.parametrize(
+    'config_overrides, expected_class, expected_param',
+    [
+        ({}, 'Activation', None),
+        ({'negative_slope': 0.25}, 'LeakyReLU', 0.25),
+        ({'threshold': 0.5}, 'ThresholdedReLU', 0.5),
+        ({'max_value': 6.0}, 'ClippedReLU', 6.0),
+    ],
+)
+def test_relu_option_mapping(config_overrides, expected_class, expected_param):
+    keras_layer = {'class_name': 'ReLU', 'config': {'name': 'relu_test', **config_overrides}}
+    layer, _ = parse_activation_layer(keras_layer, None, [[None, 8]], Mock())
+    assert layer['class_name'] == expected_class
+    if expected_param is not None:
+        assert layer['activ_param'] == expected_param
+
+
+def test_relu_rejects_max_value_combo():
+    keras_layer = {'class_name': 'ReLU', 'config': {'name': 'relu_test', 'max_value': 6.0, 'threshold': 0.5}}
+    with pytest.raises(NotImplementedError, match='max_value'):
+        parse_activation_layer(keras_layer, None, [[None, 8]], Mock())
+
+
+# ----- Recurrent ----- #
+
+
+def test_rnn_no_bias_substitutes_zeros():
+    reader = SyntheticReader({'kernel': (8, 16), 'recurrent_kernel': (4, 16), 'bias': None})
+    layer, _ = parse_rnn_layer(make_rnn_config('LSTM', use_bias=False), None, [[None, 5, 8]], reader)
+    assert layer['bias_data'].shape == (16,)
+    assert not layer['bias_data'].any()
+
+
+def test_gru_reset_after_false_parsed():
+    # The kernels implement only the reset_after=True formulation; the parser represents
+    # 'before' faithfully and the backends are responsible for rejecting it
+    reader = SyntheticReader({'kernel': (8, 12), 'recurrent_kernel': (4, 12), 'bias': (12,)})
+    layer, _ = parse_rnn_layer(make_rnn_config('GRU', reset_after=False), None, [[None, 5, 8]], reader)
+    assert layer['apply_reset_gate'] == 'before'
+    assert layer['bias_data'].shape == (12,)
+    assert layer['recurrent_bias_data'].shape == (12,)
+    assert not layer['recurrent_bias_data'].any()
+
+
+def test_rnn_rejects_go_backwards():
+    with pytest.raises(NotImplementedError, match='go_backwards'):
+        parse_rnn_layer(make_rnn_config('LSTM', go_backwards=True), None, [[None, 5, 8]], Mock())
+
+
+# ----- Bidirectional ----- #
+
+
+def test_bidirectional_merge_mode_n_out():
+    # Non-concat merge modes keep the sub-layer width; no kernel merges yet and the
+    # backends are responsible for rejecting non-concat modes
+    reader = SyntheticReader({'kernel': (8, 16), 'recurrent_kernel': (4, 16), 'bias': (16,)})
+    layer, output_shape = parse_bidirectional_layer(
+        make_bidirectional_config(make_rnn_config('LSTM'), merge_mode='sum'), None, [[None, 5, 8]], reader
+    )
+    assert layer['merge_mode'] == 'sum'
+    assert layer['n_out'] == 4
+    assert output_shape == [None, 4]
+
+
+def test_bidirectional_concat_n_out():
+    reader = SyntheticReader({'kernel': (8, 16), 'recurrent_kernel': (4, 16), 'bias': (16,)})
+    layer, output_shape = parse_bidirectional_layer(
+        make_bidirectional_config(make_rnn_config('LSTM')), None, [[None, 5, 8]], reader
+    )
+    assert layer['merge_mode'] == 'concat'
+    assert layer['n_out'] == 8
+    assert output_shape == [None, 8]
+
+
+def test_bidirectional_rejects_merge_mode_none():
+    # merge_mode=None returns two separate output tensors, which the layer cannot represent
+    with pytest.raises(NotImplementedError, match='merge_mode'):
+        parse_bidirectional_layer(
+            make_bidirectional_config(make_rnn_config('LSTM'), merge_mode=None), None, [[None, 5, 8]], Mock()
+        )
+
+
+def test_bidirectional_rejects_simple_rnn():
+    # The backend implements only LSTM/GRU cells
+    with pytest.raises(NotImplementedError, match='LSTM or GRU'):
+        parse_bidirectional_layer(make_bidirectional_config(make_rnn_config('SimpleRNN')), None, [[None, 5, 8]], Mock())
+
+
+# ----- Normalization, embedding, merge, padding ----- #
+
+
+def test_batchnorm_rejects_non_channel_axis():
+    keras_layer = {'class_name': 'BatchNormalization', 'config': {'name': 'bn_test', 'axis': [1]}}
+    with pytest.raises(NotImplementedError, match='axis'):
+        parse_batchnorm_layer(keras_layer, None, [[None, 8, 4]], Mock())
+
+
+def test_embedding_rejects_mask_zero():
+    keras_layer = {
+        'class_name': 'Embedding',
+        'config': {'name': 'embed_test', 'input_dim': 16, 'output_dim': 3, 'mask_zero': True},
+    }
+    with pytest.raises(NotImplementedError, match='mask_zero'):
+        parse_embedding_layer(keras_layer, None, [[None, 4]], Mock())
+
+
+def test_dot_rejects_normalize():
+    # Cosine similarity was silently computed as a plain dot product
+    keras_layer = {'class_name': 'Dot', 'config': {'name': 'dot_test', 'axes': 1, 'normalize': True}}
+    with pytest.raises(NotImplementedError, match='normalize'):
+        parse_merge_layer(keras_layer, None, [[None, 8], [None, 8]], Mock())
+
+
+def test_zeropadding2d_symmetric_tuple():
+    # A typo wrote pad_bottom twice and never set pad_right for the (sym_h, sym_w) form
+    keras_layer = {
+        'class_name': 'ZeroPadding2D',
+        'config': {'name': 'zp_test', 'padding': (1, 2), 'data_format': 'channels_last'},
+    }
+    layer, output_shape = parse_zeropadding2d_layer(keras_layer, None, [[None, 8, 8, 3]], Mock())
+    assert (layer['pad_top'], layer['pad_bottom'], layer['pad_left'], layer['pad_right']) == (1, 1, 2, 2)
+    assert output_shape == [None, 10, 12, 3]

--- a/test/pytest/test_keras_v3_api.py
+++ b/test/pytest/test_keras_v3_api.py
@@ -542,3 +542,172 @@ def test_reused_layer(test_case_id, backend, io_type):
     np.testing.assert_allclose(keras_pred[1].reshape(hls_pred[1].shape), hls_pred[1], rtol=0, atol=1e-5)
     np.testing.assert_allclose(keras_pred[2].reshape(hls_pred[2].shape), hls_pred[2], rtol=0, atol=1e-5)
     np.testing.assert_allclose(keras_pred[3].reshape(hls_pred[3].shape), hls_pred[3], rtol=0, atol=1e-2)
+
+
+# ----- Parser behavior: unsupported layer options are ingested faithfully or rejected ----- #
+
+
+def _convert_parse_only(model, test_case_id, io_type='io_parallel'):
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='ap_fixed<32,16>', backend='Vivado'
+    )
+    return hls4ml.converters.convert_from_keras_model(
+        model,
+        hls_config=config,
+        backend='Vivado',
+        io_type=io_type,
+        output_dir=str(test_root_path / test_case_id),
+    )
+
+
+@pytest.mark.parametrize('dim', ['1d', '2d'])
+def test_conv_dilation_parsed(test_case_id, dim):
+    # Dilation is ingested into the IR ('dilation' attribute, already a field of the conv
+    # config structs) and the output shape follows the dilated kernel extent. No kernel
+    # computes dilation yet; the backends are responsible for rejecting it.
+    if dim == '1d':
+        model = keras.Sequential([keras.layers.Input((16, 3)), Conv1D(4, 3, dilation_rate=2)])
+    else:
+        model = keras.Sequential([keras.layers.Input((16, 16, 3)), Conv2D(4, 3, dilation_rate=2)])
+    # io_stream: the io_parallel im2col codegen does not handle the dilated output shape
+    hls_model = _convert_parse_only(model, test_case_id, io_type='io_stream')
+    conv_layer = [layer for layer in hls_model.get_layers() if 'Conv' in layer.class_name][0]
+    assert conv_layer.get_attr('dilation') == 2
+    assert list(hls_model.get_output_variables()[0].shape) == list(model.output_shape[1:])
+
+
+def test_conv_rejects_asymmetric_dilation(test_case_id):
+    model = keras.Sequential([keras.layers.Input((16, 16, 3)), Conv2D(4, 3, dilation_rate=(2, 3))])
+    with pytest.raises(NotImplementedError, match='dilation'):
+        _convert_parse_only(model, test_case_id)
+
+
+def test_conv_rejects_grouped(test_case_id):
+    # groups that are not depthwise-shaped (groups == in_channels == filters) have no kernel
+    model = keras.Sequential([keras.layers.Input((16, 16, 4)), Conv2D(8, 3, groups=2)])
+    with pytest.raises(NotImplementedError, match='[Gg]rouped convolution'):
+        _convert_parse_only(model, test_case_id)
+
+
+def test_conv_routes_depthwise_shaped_groups(test_case_id):
+    model = keras.Sequential([keras.layers.Input((16, 16, 4)), Conv2D(4, 3, groups=4)])
+    hls_model = _convert_parse_only(model, test_case_id)
+    assert 'DepthwiseConv2D' in [layer.class_name for layer in hls_model.get_layers()]
+
+
+def test_relu_max_value_parsed(test_case_id):
+    # max_value (e.g. ReLU6) is ingested as a ClippedReLU parametrized activation.
+    # No backend maps it to a kernel yet; the backends are responsible for rejecting it.
+    model = keras.Sequential([keras.layers.Input((8,)), Dense(4), keras.layers.ReLU(max_value=6.0)])
+    hls_model = _convert_parse_only(model, test_case_id)
+    activations = {str(layer.get_attr('activation', '')).lower(): layer for layer in hls_model.get_layers()}
+    assert 'clippedrelu' in activations
+    assert activations['clippedrelu'].get_attr('activ_param') == 6.0
+
+
+def test_relu_rejects_max_value_combo(test_case_id):
+    model = keras.Sequential([keras.layers.Input((8,)), Dense(4), keras.layers.ReLU(max_value=6.0, negative_slope=0.1)])
+    with pytest.raises(NotImplementedError, match='max_value'):
+        _convert_parse_only(model, test_case_id)
+
+
+def test_plain_relu_not_parametrized(test_case_id):
+    # Plain ReLU() was silently classified as ThresholdedReLU(0.0) due to branch order
+    model = keras.Sequential([keras.layers.Input((8,)), Dense(4), keras.layers.ReLU()])
+    hls_model = _convert_parse_only(model, test_case_id)
+    relu_layers = [layer for layer in hls_model.get_layers() if str(layer.get_attr('activation', '')) == 'relu']
+    assert len(relu_layers) == 1
+    assert relu_layers[0].class_name == 'Activation'
+
+
+def test_rnn_rejects_go_backwards(test_case_id):
+    model = keras.Sequential([keras.layers.Input((5, 8)), keras.layers.LSTM(4, go_backwards=True)])
+    with pytest.raises(NotImplementedError, match='go_backwards'):
+        _convert_parse_only(model, test_case_id)
+
+
+def test_gru_reset_after_false_parsed(test_case_id):
+    # The GRU kernels implement only the reset_after=True formulation; the parser
+    # represents 'before' faithfully and the backends are responsible for rejecting it
+    model = keras.Sequential([keras.layers.Input((5, 8)), keras.layers.GRU(4, reset_after=False)])
+    hls_model = _convert_parse_only(model, test_case_id)
+    gru_layer = [layer for layer in hls_model.get_layers() if layer.class_name == 'GRU'][0]
+    assert gru_layer.get_attr('apply_reset_gate') == 'before'
+    assert gru_layer.get_weights('bias').data.shape == (12,)
+    recurrent_bias = gru_layer.get_weights('recurrent_bias').data
+    assert recurrent_bias.shape == (12,) and not recurrent_bias.any()
+
+
+def test_rnn_no_bias_parsed(test_case_id):
+    model = keras.Sequential([keras.layers.Input((5, 8)), keras.layers.LSTM(4, use_bias=False)])
+    hls_model = _convert_parse_only(model, test_case_id)
+    lstm_layer = [layer for layer in hls_model.get_layers() if layer.class_name == 'LSTM'][0]
+    bias = lstm_layer.get_weights('bias').data
+    assert bias.shape == (16,) and not bias.any()
+
+
+def test_bidirectional_merge_mode_parsed(test_case_id):
+    # Non-concat merge modes keep the sub-layer width; no kernel merges yet and the
+    # backends are responsible for rejecting non-concat modes
+    model = keras.Sequential(
+        [keras.layers.Input((5, 8)), keras.layers.Bidirectional(keras.layers.LSTM(4), merge_mode='sum')]
+    )
+    hls_model = _convert_parse_only(model, test_case_id)
+    bidir_layer = [layer for layer in hls_model.get_layers() if layer.class_name == 'Bidirectional'][0]
+    assert bidir_layer.get_attr('merge_mode') == 'sum'
+    assert bidir_layer.get_attr('n_out') == 4
+    assert list(hls_model.get_output_variables()[0].shape) == [4]
+
+
+def test_bidirectional_rejects_simple_rnn(test_case_id):
+    model = keras.Sequential([keras.layers.Input((5, 8)), keras.layers.Bidirectional(keras.layers.SimpleRNN(4))])
+    with pytest.raises(NotImplementedError, match='LSTM or GRU'):
+        _convert_parse_only(model, test_case_id)
+
+
+def test_bidirectional_gru_bias(test_case_id):
+    # The v3 handler checked isinstance(rnn_layer.cell, GRU), which is never true (the
+    # cell is a GRUCell), so GRU biases were stored unsplit and the recurrent bias was
+    # never set. Verified numerically against Keras.
+    model = keras.Sequential([keras.layers.Input((5, 8)), keras.layers.Bidirectional(keras.layers.GRU(4))])
+    hls_model = _convert_parse_only(model, test_case_id)
+    hls_model.compile()
+    X = np.random.rand(20, 5, 8).astype('float32')
+    keras_prediction = model.predict(X, verbose=0)
+    hls_prediction = hls_model.predict(X).reshape(keras_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, keras_prediction, rtol=0.0, atol=5e-2)
+
+
+def test_batchnorm_rejects_non_channel_axis(test_case_id):
+    model = keras.Sequential([keras.layers.Input((8, 4)), keras.layers.BatchNormalization(axis=1)])
+    with pytest.raises(NotImplementedError, match='axis'):
+        _convert_parse_only(model, test_case_id)
+
+
+def test_dot_rejects_normalize(test_case_id):
+    inp1 = keras.layers.Input((8,))
+    inp2 = keras.layers.Input((8,))
+    out = keras.layers.Dot(axes=1, normalize=True)([inp1, inp2])
+    model = keras.Model([inp1, inp2], out)
+    with pytest.raises(NotImplementedError, match='normalize'):
+        _convert_parse_only(model, test_case_id)
+
+
+def test_embedding_rejects_mask_zero(test_case_id):
+    model = keras.Sequential([keras.layers.Input((4,), dtype='int32'), keras.layers.Embedding(16, 3, mask_zero=True)])
+    with pytest.raises(NotImplementedError, match='mask_zero'):
+        _convert_parse_only(model, test_case_id)
+
+
+def test_random_crop_rejected_when_shape_changes(test_case_id):
+    # RandomCrop still center-crops at inference time, so it is only a no-op
+    # if it does not change the shape
+    model = keras.Sequential([keras.layers.Input((16, 16, 3)), keras.layers.RandomCrop(8, 8)])
+    with pytest.raises(NotImplementedError, match='cannot be skipped'):
+        _convert_parse_only(model, test_case_id)
+
+
+def test_random_crop_same_shape_is_noop(test_case_id):
+    model = keras.Sequential([keras.layers.Input((16, 16, 3)), keras.layers.RandomCrop(16, 16)])
+    hls_model = _convert_parse_only(model, test_case_id)
+    assert hls_model is not None

--- a/test/pytest/test_layernorm.py
+++ b/test/pytest/test_layernorm.py
@@ -77,3 +77,22 @@ def test_layernorm_accuracy(test_case_id, model, data, backend):
     y_keras = model.predict(data).flatten()
     y_hls = hls_model.predict(data).flatten()
     np.testing.assert_allclose(y_keras, y_hls, rtol=0, atol=5e-2, verbose=True)
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis'])
+def test_layernorm_no_center_scale(test_case_id, data, backend):
+    """center=False / scale=False previously fed None weight data into the graph."""
+    model = Sequential()
+    model.add(LayerNormalization(input_shape=in_shape, center=False, scale=False))
+    model.compile()
+
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='ap_fixed<32,16>', backend=backend
+    )
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir, backend=backend)
+    hls_model.compile()
+
+    y_keras = model.predict(data)
+    y_hls = hls_model.predict(data).reshape(y_keras.shape)
+    np.testing.assert_allclose(y_keras, y_hls, rtol=0, atol=5e-2, verbose=True)

--- a/test/pytest/test_merge.py
+++ b/test/pytest/test_merge.py
@@ -183,3 +183,18 @@ def test_concatenate3d(test_case_id, axis, io_type, backend):
     hls_prediction = hls_model.predict([X_input1, X_input2]).reshape(keras_prediction.shape)
 
     np.testing.assert_allclose(hls_prediction, keras_prediction, rtol=0, atol=0.001)
+
+
+def test_dot_rejects_normalize(test_case_id):
+    """Dot(normalize=True) (cosine similarity) was silently computed as a plain dot product."""
+    input_shape = (16,)
+    in1 = Input(shape=input_shape)
+    in2 = Input(shape=input_shape)
+    out = Dot(axes=1, normalize=True)([in1, in2])
+    model = tf.keras.models.Model(inputs=[in1, in2], outputs=out)
+
+    with pytest.raises(NotImplementedError, match='normalize'):
+        config = hls4ml.utils.config_from_keras_model(model, granularity='name', backend='Vivado')
+        hls4ml.converters.convert_from_keras_model(
+            model, hls_config=config, output_dir=str(test_root_path / test_case_id), backend='Vivado'
+        )

--- a/test/pytest/test_qkeras.py
+++ b/test/pytest/test_qkeras.py
@@ -8,7 +8,7 @@ from keras.models import Model, Sequential, model_from_json
 from keras.utils import to_categorical
 from qkeras import QGRU, QLSTM, QSimpleRNN
 from qkeras.qconv2d_batchnorm import QConv2DBatchnorm
-from qkeras.qconvolutional import QDepthwiseConv2D, QSeparableConv1D, QSeparableConv2D
+from qkeras.qconvolutional import QConv2D, QDepthwiseConv2D, QSeparableConv1D, QSeparableConv2D
 from qkeras.qlayers import QActivation, QDense
 from qkeras.quantizers import (
     binary,
@@ -646,7 +646,7 @@ def test_qgru(test_case_id, backend):
             state_quantizer='quantized_bits(8, 0, alpha=1)',
             activation='tanh',
             recurrent_activation='sigmoid',
-            reset_after='False',
+            reset_after=True,
         )
     )
     model.compile()
@@ -754,3 +754,129 @@ def test_qseparableconv2d(test_case_id, backend, io_type):
     y_hls4ml = hls_model.predict(dataq)
 
     np.testing.assert_allclose(y_qkeras, y_hls4ml.reshape(y_qkeras.shape), rtol=0, atol=0)
+
+
+def test_qconv_dilation_parse(test_case_id):
+    """QConv delegates to the base conv parser, so dilation is ingested there (into the
+    'dilation' attribute, with the output shape following the dilated kernel extent)."""
+    model = Sequential()
+    model.add(
+        QConv2D(
+            4,
+            kernel_size=(3, 3),
+            dilation_rate=(2, 2),
+            input_shape=(8, 8, 1),
+            kernel_quantizer='quantized_bits(8, 0, alpha=1)',
+            bias_quantizer='quantized_bits(8, 0, alpha=1)',
+        )
+    )
+    model.compile()
+
+    config = hls4ml.utils.config_from_keras_model(model, granularity='name', backend='Vivado')
+    output_dir = str(test_root_path / test_case_id)
+    # io_stream: the io_parallel im2col codegen does not handle the dilated output shape
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=config, output_dir=output_dir, io_type='io_stream'
+    )
+    conv_layer = [layer for layer in hls_model.get_layers() if 'Conv' in layer.class_name][0]
+    assert conv_layer.get_attr('dilation') == 2
+    assert list(hls_model.get_output_variables()[0].shape) == list(model.output_shape[1:])
+
+
+@pytest.mark.parametrize('backend', ['Vivado'])
+@pytest.mark.parametrize('io_type', ['io_stream'])
+def test_qconv_grouped_depthwise(test_case_id, backend, io_type):
+    """A depthwise-shaped grouped QConv (groups == in_channels == filters) is routed to
+    DepthwiseConv, carrying its kernel quantizer along as the depthwise quantizer."""
+    X = np.random.rand(10, 8, 8, 4)
+    X = np.round(X * 2**10) * 2**-10  # make it an exact ap_fixed<16,6>
+    model = Sequential()
+    model.add(
+        QConv2D(
+            4,
+            kernel_size=(3, 3),
+            groups=4,
+            input_shape=(8, 8, 4),
+            kernel_quantizer='quantized_bits(8, 0, alpha=1)',
+            bias_quantizer='quantized_bits(8, 0, alpha=1)',
+        )
+    )
+    model.compile()
+
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='fixed<24,8>', backend=backend
+    )
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=config, output_dir=output_dir, backend=backend, io_type=io_type
+    )
+    assert 'DepthwiseConv2D' in [layer.class_name for layer in hls_model.get_layers()]
+    hls_model.compile()
+
+    y_qkeras = model.predict(X)
+    y_hls4ml = hls_model.predict(X)
+
+    np.testing.assert_allclose(y_qkeras, y_hls4ml.reshape(y_qkeras.shape), rtol=0, atol=1e-3)
+
+
+@pytest.mark.parametrize('backend', ['Vivado'])
+def test_qlstm_no_bias(test_case_id, backend):
+    """use_bias=False previously crashed the parser instead of substituting zeros."""
+    X = np.linspace(-0.5, 0.5, 5)
+    X = np.stack([X, X], axis=1).reshape(1, 5, 2)
+
+    model = Sequential()
+    model.add(
+        QLSTM(
+            4,
+            input_shape=(5, 2),
+            use_bias=False,
+            kernel_quantizer='quantized_bits(16, 0, alpha=1)',
+            recurrent_quantizer='quantized_bits(16, 0, alpha=1)',
+            state_quantizer='quantized_bits(16, 0, alpha=1)',
+            activation='tanh',
+            recurrent_activation='sigmoid',
+        )
+    )
+    model.compile()
+
+    config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='ap_fixed<16,1>', backend=backend
+    )
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir, backend=backend)
+    hls_model.compile()
+
+    y_qkeras = model.predict(X)
+    y_hls4ml = hls_model.predict(X)
+
+    np.testing.assert_allclose(y_qkeras, y_hls4ml.reshape(y_qkeras.shape), atol=0.1)
+
+
+def test_qgru_reset_after_false_parse(test_case_id):
+    """reset_after=False is parsed faithfully (apply_reset_gate='before', flat bias, zero
+    recurrent bias); the kernels implement only the 'after' formulation and the backends
+    are responsible for rejecting 'before'."""
+    model = Sequential()
+    model.add(
+        QGRU(
+            4,
+            input_shape=(5, 2),
+            kernel_quantizer='quantized_bits(8, 0, alpha=1)',
+            recurrent_quantizer='quantized_bits(8, 0, alpha=1)',
+            bias_quantizer='quantized_bits(8, 0, alpha=1)',
+            state_quantizer='quantized_bits(8, 0, alpha=1)',
+            activation='tanh',
+            recurrent_activation='sigmoid',
+            reset_after=False,
+        )
+    )
+    model.compile()
+
+    config = hls4ml.utils.config_from_keras_model(model, granularity='name', backend='Vivado')
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(model, hls_config=config, output_dir=output_dir)
+    gru_layer = [layer for layer in hls_model.get_layers() if layer.class_name == 'GRU'][0]
+    assert gru_layer.get_attr('apply_reset_gate') == 'before'
+    assert gru_layer.get_weights('bias').data.shape == (12,)
+    assert not gru_layer.get_weights('recurrent_bias').data.any()

--- a/test/pytest/test_rnn.py
+++ b/test/pytest/test_rnn.py
@@ -291,3 +291,28 @@ def test_bidirectional_gru_accuracy(test_case_id):
     keras_prediction = model.predict(X)
     hls_prediction = hls_model.predict(X)
     np.testing.assert_allclose(hls_prediction.flatten(), keras_prediction.flatten(), rtol=0.0, atol=5e-2)
+
+
+@pytest.mark.parametrize('cell_type', ['gru', 'lstm'])
+def test_bidirectional_no_bias(test_case_id, cell_type):
+    """Bidirectional cells with use_bias=False parse (zeros are substituted) and match Keras."""
+    model = Sequential()
+    model.add(Input(shape=(5, 8)))
+    if cell_type == 'gru':
+        model.add(Bidirectional(GRU(4, use_bias=False)))
+    else:
+        model.add(Bidirectional(LSTM(4, use_bias=False)))
+
+    hls_config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='ap_fixed<32, 16>', backend='Vivado'
+    )
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=hls_config, output_dir=output_dir, backend='Vivado'
+    )
+    hls_model.compile()
+
+    X = np.random.rand(20, 5, 8).astype('float32')
+    keras_prediction = model.predict(X)
+    hls_prediction = hls_model.predict(X)
+    np.testing.assert_allclose(hls_prediction.flatten(), keras_prediction.flatten(), rtol=0.0, atol=5e-2)

--- a/test/pytest/test_rnn.py
+++ b/test/pytest/test_rnn.py
@@ -241,3 +241,53 @@ def test_rnn_accuracy(test_case_id, rnn_layer, return_sequences, backend, io_typ
     keras_prediction = model.predict(X)
     hls_prediction = hls_model.predict(X)
     np.testing.assert_allclose(hls_prediction.flatten(), keras_prediction.flatten(), rtol=0.0, atol=5e-2)
+
+
+@pytest.mark.parametrize('rnn_layer', [SimpleRNN, LSTM, GRU], ids=['SimpleRNN', 'LSTM', 'GRU'])
+def test_rnn_no_bias(test_case_id, rnn_layer):
+    """use_bias=False previously crashed the parser instead of substituting zero biases."""
+    model = Sequential()
+    model.add(Input(shape=(5, 8)))
+    model.add(rnn_layer(4, use_bias=False))
+
+    # The Vivado SimpleRNN kernel produces wrong results (untested upstream); use Quartus for it
+    if rnn_layer is SimpleRNN:
+        backend, default_precision, strategy = 'Quartus', 'ac_fixed<32, 16, true>', 'Resource'
+    else:
+        backend, default_precision, strategy = 'Vivado', 'ap_fixed<32, 16>', 'Latency'
+
+    hls_config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision=default_precision, backend=backend
+    )
+    hls_config['Model']['Strategy'] = strategy
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=hls_config, output_dir=output_dir, backend=backend
+    )
+    hls_model.compile()
+
+    X = np.random.rand(20, 5, 8).astype('float32')
+    keras_prediction = model.predict(X)
+    hls_prediction = hls_model.predict(X)
+    np.testing.assert_allclose(hls_prediction.flatten(), keras_prediction.flatten(), rtol=0.0, atol=5e-2)
+
+
+def test_bidirectional_gru_accuracy(test_case_id):
+    """Bidirectional GRU checked numerically against Keras (covers the GRU bias handling)."""
+    model = Sequential()
+    model.add(Input(shape=(5, 8)))
+    model.add(Bidirectional(GRU(4)))
+
+    hls_config = hls4ml.utils.config_from_keras_model(
+        model, granularity='name', default_precision='ap_fixed<32, 16>', backend='Vivado'
+    )
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model, hls_config=hls_config, output_dir=output_dir, backend='Vivado'
+    )
+    hls_model.compile()
+
+    X = np.random.rand(20, 5, 8).astype('float32')
+    keras_prediction = model.predict(X)
+    hls_prediction = hls_model.predict(X)
+    np.testing.assert_allclose(hls_prediction.flatten(), keras_prediction.flatten(), rtol=0.0, atol=5e-2)


### PR DESCRIPTION
# Keras frontends: stop silently misparsing unsupported layer configurations

## Description

This PR is the Keras half of a systematic audit of the frontends for silent misparses: legal, realistic layer configurations that convert without complaint but compute something different from the model the user trained. The rule applied throughout: **never convert a model that computes different math than the one that was trained.** Each case is resolved according to where it sits:

**Ingested faithfully into the IR** (no kernel computes these yet — backend-side rejection is the immediate follow-up PR, together with a general capability check):

- *Conv `dilation_rate`*: was dropped on the floor — the emitted model computed an undilated convolution with the undilated output shape. The parsers now store the `dilation` attribute (a field the conv config structs already have, and which the PyTorch parser already sets) and compute padding/output shape from the dilated kernel extent. Asymmetric 2D dilation is rejected (the IR carries a single dilation value). Supersedes the parser-level reject of #1521.
- *`ReLU(max_value=...)`* (ReLU6): silently dropped in v2, rejected in v3. Now ingested as a new `ClippedReLU` parametrized activation. The Vivado-family templates already ship unmapped `relu_max`/`relu6` kernels, so actual support is close. `max_value` combined with `negative_slope`/`threshold` stays rejected.
- *`GRU(reset_after=False)`*: was parsed into an `apply_reset_gate` attribute that no backend reads, with a bias split that assumed the `reset_after=True` weight layout (garbage bias values). Now parsed faithfully (`apply_reset_gate='before'`, flat bias, zero recurrent bias), standalone and inside `Bidirectional`, on both frontends.
- *`Bidirectional(merge_mode != 'concat')`*: the attribute was stored but consumed by nothing, so `sum`/`mul`/`ave` silently produced concat behavior with the wrong `n_out`. Now ingested with the correct `n_out`. `merge_mode=None` (two separate output tensors) is rejected — the Bidirectional layer cannot represent it.

**Rejected with a clear error** (previously silently wrong, out of scope for hls4ml):

- *Grouped convolution (Keras v2)*: `groups` was ignored entirely. Depthwise-shaped groups (`groups == in_channels == filters`) are now routed to DepthwiseConv, mirroring the v3 (#1486) and PyTorch (#1524) behavior; other groupings are rejected, consistent with those parsers. A grouped `QConv` carries its kernel quantizer to the depthwise weight.
- *`go_backwards=True`* on non-bidirectional RNNs (was silently parsed as a forward RNN); `stateful=True` prints a warning.
- *`Bidirectional(SimpleRNN)`*: the backend implements only LSTM/GRU cells (and the v2 weight lookup was broken for SimpleRNN).
- *`BatchNormalization`* with the axis not pointing at the last dimension (`n_filt` was taken from the last dimension regardless, normalizing along the wrong axis).
- *`Dot(normalize=True)`* (cosine similarity — was silently computed as a plain dot product), *`Embedding(mask_zero=True)`* (masking silently dropped), and v3 no-op preprocessing layers that change shape (`RandomCrop` center-crops at inference time).

**Fixed** (previously crashed or computed wrong values):

- RNN `use_bias=False` crashed the v2 parser (the zeros substitute read its shape from the missing bias).
- v3 `Bidirectional(GRU)` bias handling: `isinstance(rnn_layer.cell, keras.layers.GRU)` is never true (the cell is a `GRUCell`), so biases were stored unsplit and the recurrent bias was never set.
- Plain `ReLU()` through the v3 handler was silently classified as `ThresholdedReLU(0.0)` (branch-order bug; numerically identical, wrong layer class).
- `ZeroPadding2D` with a `(sym_h, sym_w)` padding config: a typo wrote `pad_bottom` twice and never set `pad_right`.
- Global pooling `keepdims=True`: the parser read the flag but the layer classes always emitted `[n_filt]`, so the graph's shape bookkeeping silently diverged from Keras (numerics unaffected only because the kept dimensions are 1s). The GlobalPooling1D/2D layer classes now honor a `keepdims` attribute.
- `LayerNormalization(center=False)` / `(scale=False)` fed `None` weight data into the graph; zeros/ones are now substituted. Negative axis values (how Keras 3 serializes the default) are accepted.

All changes apply to both the Keras v2 handlers (legacy models and QKeras, which delegates to them) and the Keras v3 handlers. A follow-up PR applies the same audit to the PyTorch frontend. Until the backend-side rejection lands, the four ingested configurations parse correctly but no kernel computes them — that follow-up is the necessary counterpart of this PR.

Relates to #1521, #1486, #1524.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (existing configs, APIs or generated code behave differently)
- [ ] New frontend / backend
- [ ] New layer / operator support
- [ ] New configuration option — a new `io_type`, Strategy, or config attribute
- [ ] Research paper implementation
- [ ] Documentation
- [x] Build, CI or tooling (test output directory naming)
- [ ] Refactor / cleanup (no functional change)

## Affected areas

**Backends:**
- [ ] None directly
- [x] Backend-independent (core IR, optimizer, `hls4ml.model`)

**Frontends:**
- [x] Keras v3
- [x] Keras v2 (including QKeras delegation)
- [ ] Not related to a frontend

**Components:**
- [x] IR (layers + model graph) / optimizer passes — `GlobalPooling1D/2D.keepdims`, `ClippedReLU` registration in `layer_map`
- [ ] C++ templates / HLS sources under `hls4ml/templates/`
- [ ] Profiling, reporting or the CLI
- [ ] Packaging, build or CI

## Configurations affected and exercised

| Backend | `io_type` | Strategy | Verified |
|---|---|---|---|
| all (parsing is backend-independent) | all | all | pytest (C simulation) with Vivado backend |

**New configuration axis introduced by this PR**: none user-facing. New IR attributes: `dilation` on conv layers (Keras parsers now set the field the config structs already had), `keepdims` on global pooling, `apply_reset_gate='before'` now reachable, `ClippedReLU` activation. No backend supports the first, third and fourth yet; the follow-up PR makes every backend reject them explicitly.

## Impact on generated HLS

- [ ] This PR **does not change** the generated HLS for existing models.
- [x] This PR **changes** the generated HLS. Numbers below.

**Numerical behaviour:** Only models using the affected layer configurations are impacted, in three ways: (1) configurations listed under "rejected" no longer produce (wrong) generated code — conversion raises; (2) `keepdims=True` global pooling now emits the kept-dims output shape (values unchanged — verified bit-identical in the existing `test_globalpooling` tests, which pass unmodified except for added shape assertions); (3) previously-crashing configurations (`use_bias=False` RNNs, `center/scale=False` LayerNorm) and previously-wrong ones (v3 Bidirectional GRU biases, `ZeroPadding2D` tuple padding, ReLU `negative_slope`/`threshold`) now generate correct code, verified against Keras predictions by C simulation. Models not using any affected configuration generate identical code. No synthesis was run — this is a frontend/parse-level change; the resource/latency table is deliberately left out.

## Tests

- `test_keras_converter.py`: extended from the single #1521 test into the direct (handler-level) test suite for the v2 parsers — ingestion attributes, weight handling and every reject, exercised deterministically under any installed Keras version. The #1521 dilation test is updated from asserting the reject to asserting the ingestion.
- `test_keras_v3_api.py`: the same parse/reject matrix through real Keras 3 models (runs in the Keras 3 CI environment), plus the v3-only fixes: Bidirectional GRU bias (numeric), plain-ReLU classification, RandomCrop no-op shape guard.
- Per-layer files: `test_rnn.py` (`use_bias=False` numeric for all three cells, Bidirectional GRU numeric), `test_keras_api.py` (ReLU `negative_slope`/`threshold` numeric, grouped-depthwise routing numeric), `test_layernorm.py` (`center=False`/`scale=False` numeric), `test_globalpooling.py` (output shape assertions added to the existing keepdims-parametrized tests), `test_batchnorm.py`, `test_embed.py`, `test_merge.py` (rejects).
- `conftest.py` / `synthesis_helpers.py`: the `test_case_id` fixture now prefixes its value with `hls4mlprj_`, so every test that builds its output directory from it (the vast majority) produces project directories covered by `.gitignore`; baseline synthesis report lookups strip the prefix, so the existing baseline files keep their names. Split into its own commit.
- `test_qkeras.py`: the behavior propagates through QKeras delegation (dilated `QConv2D` ingested, depthwise-shaped grouped `QConv2D` routed with its quantizers, `QLSTM(use_bias=False)` converts, `QGRU(reset_after=False)` parsed faithfully). The existing `test_qgru` passed `reset_after='False'` — a truthy string — so it never tested the `False` path; it now passes `True` explicitly.

**Test configuration** (OS, Python, ML framework version, HLS tool version): Linux (EL9), Python 3.11. Two environments: TensorFlow 2.14.1 / Keras 2.14 with the `jmitrevs/qkeras` fork (mirrors the default CI environment), and TensorFlow 2.21 / Keras 3.15 with qkeras-v3 and HGQ2 (mirrors the Keras 3 CI environment). C simulation via g++; no HLS tool involved.

## Breaking changes and migration

**What breaks:** Models using a configuration listed under "rejected" above previously converted silently (computing the wrong function) and now raise `NotImplementedError` naming the layer and option. Additionally, until the backend-rejection follow-up lands, the four ingested configurations (dilation, `reset_after=False`, `max_value`, non-concat `merge_mode`) parse correctly but still compute the wrong function if compiled — the follow-up closes exactly that gap.

**How users migrate:** Remove or replace the unsupported option (e.g. retrain with `reset_after=True`, drop `mask_zero`, use an explicit supported activation). Models that do not use any affected option are unaffected.

## AI assistance disclosure

- [ ] **None** — no AI tool was used.
- [ ] **Assisted** — completion, refactoring, docstrings, tests; design and code are mine.
- [ ] **Substantial** — significant AI-generated portions, reviewed and edited by me.
- [x] **Agentic** — produced largely end-to-end by an AI agent from my prompts.

Tool(s) and model(s): Claude Code (Fable 5)

Where it was used: the full branch — frontend audit, parser changes, IR attributes and all tests — under prompt-level direction with minor manual changes and review of the scope decisions (what is ingested vs rejected, test organization) by the author.

If anything other than *None* is ticked, confirm all of the following:

- [x] **I am the author of this contribution and take full responsibility for it.** I have read and understood every line and can explain and defend it in review.
- [x] I verified the generated code against real hls4ml and HLS semantics — no invented APIs, config keys, pragmas or citations.
- [x] All numbers, logs and test results quoted in this PR come from runs I actually performed, not from agent output.
- [x] I have the right to submit this work under the project's licence, and to my knowledge it does not reproduce third-party code that would conflict with it.
- [x] No AI tool is credited as an author in any commit in this branch.

## Checklist

**Required:**
- [ ] I have read the [contributing guidelines](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I installed and ran `pre-commit` on the files I edited.
- [x] I added tests under `test/pytest` covering this change (a bug fix should add a test that fails on `main` and passes here).
- [ ] I self-reviewed the full diff and it contains no leftover debug code, commented-out blocks or unrelated changes.
- [x] The AI assistance disclosure above is complete and accurate.

**If applicable:**
- [ ] Documentation under `docs/` updated.
- [ ] No new build or synthesis warnings.
- [ ] Public API / config schema changes are documented.

## Release note

```release-note
Fixed several Keras parser bugs; Keras layer options that hls4ml cannot faithfully implement now raise an error at conversion time instead of being silently misparsed.
```
