### PR TITLE
PyTorch frontend: stop silently misparsing unsupported layer configurations

### DIFF
--- a/docs/attr_doc_gen.py
+++ b/docs/attr_doc_gen.py
@@ -92,6 +92,14 @@ def print_attrs(attrs, file):
             file.write('  * Available in: ' + ', '.join(attr.available_in) + '\n\n')
 
 
+def strip_trailing_blank_lines(file_name='attributes.rst'):
+    """Ends the file with exactly one newline, as the pre-commit hooks require."""
+    with open(file_name) as file:
+        content = file.read()
+    with open(file_name, mode='w') as file:
+        file.write(content.rstrip('\n') + '\n')
+
+
 def write_all_attributes(all_layers_attrs):
     with open('attributes.rst', mode='w') as file:
         file.write('================\n')
@@ -127,6 +135,8 @@ def write_all_attributes(all_layers_attrs):
                 file.write('---------------------------\n')
                 print_attrs(attr_list.unique_backend_attrs, file)
 
+    strip_trailing_blank_lines()
+
 
 def write_only_configurable(all_layers_attrs):
     with open('attributes.rst', mode='w') as file:
@@ -141,6 +151,8 @@ def write_only_configurable(all_layers_attrs):
             config_attrs = attr_list.only_configurable
             if len(config_attrs) > 0:
                 print_attrs(config_attrs, file)
+
+    strip_trailing_blank_lines()
 
 
 if __name__ == '__main__':

--- a/docs/ir/attributes.rst
+++ b/docs/ir/attributes.rst
@@ -3646,4 +3646,3 @@ Backend-specific attributes
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
   * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
-

--- a/docs/ir/attributes.rst
+++ b/docs/ir/attributes.rst
@@ -87,19 +87,19 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_size: int (Default: 1024)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 ParametrizedActivation
 ======================
@@ -143,19 +143,19 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_size: int (Default: 1024)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 PReLU
 =====
@@ -203,19 +203,19 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_size: int (Default: 1024)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 Softmax
 =======
@@ -251,59 +251,197 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_size: int (Default: 1024)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * n_outer: int (Default: 1)
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * n_inner: int (Default: 1)
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * implementation: list [latency,stable,argmax,legacy] (Default: stable)
 
   * Choice of implementation of softmax function. "latency" provides good latency at the expense of extra resources. performs well on small number of classes. "stable" may require extra clock cycles but has better accuracy. "legacy" is the older implementation which has bad accuracy, but is fast and has low resource use. It is superseded by the "latency" implementation for most applications. "argmax" is a special implementation that can be used if only the output with the highest probability is important. Using this implementation will save resources and clock cycles.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * skip: bool (Default: False)
 
   * If enabled, skips the softmax node and returns the raw outputs.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * exp_table_t: NamedType (Default: fixed<18,8,RND,SAT,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * inv_table_t: NamedType (Default: fixed<18,8,RND,SAT,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * inv_inp_t: NamedType (Default: fixed<18,8,RND,SAT,0>)
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * accum_t: NamedType (Default: fixed<18,8,RND,SAT,0>)
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
+
+IFNeuron
+========
+Base attributes
+---------------
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* threshold_t: NamedType
+
+* membrane_t: NamedType
+
+Type attributes
+---------------
+* index: int
+
+  * Internal node counter used for bookkeeping and variable/tensor naming.
+
+* n_in: int
+
+* n_out: int
+
+* window_size: int (Default: 0)
+
+* threshold: float
+
+* threshold_mode: str (Default: scalar)
+
+* reset_mechanism: list [subtract,zero] (Default: subtract)
+
+Configurable attributes
+-----------------------
+* trace: int (Default: False)
+
+  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
+
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* threshold_t: NamedType
+
+* membrane_t: NamedType
+
+LIFNeuron
+=========
+Base attributes
+---------------
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* beta_t: NamedType
+
+* threshold_t: NamedType
+
+* membrane_t: NamedType
+
+Type attributes
+---------------
+* index: int
+
+  * Internal node counter used for bookkeeping and variable/tensor naming.
+
+* n_in: int
+
+* n_out: int
+
+* window_size: int (Default: 0)
+
+* threshold: float
+
+* threshold_mode: str (Default: scalar)
+
+* beta: float
+
+* beta_mode: str (Default: scalar)
+
+* reset_mechanism: list [subtract,zero] (Default: subtract)
+
+Configurable attributes
+-----------------------
+* trace: int (Default: False)
+
+  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
+
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* beta_t: NamedType
+
+* threshold_t: NamedType
+
+* membrane_t: NamedType
+
+SNNReadout
+==========
+Base attributes
+---------------
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* membrane_t: NamedType
+
+Type attributes
+---------------
+* index: int
+
+  * Internal node counter used for bookkeeping and variable/tensor naming.
+
+* n_classes: int
+
+* window_size: int (Default: 1)
+
+* class_threshold: int (Default: 1)
+
+* beta: float (Default: 1.0)
+
+* state_reset_policy: list [fixed_window,tlast,host_pulse,never] (Default: fixed_window)
+
+* decision_rule: list [argmax_spike_count,first_to_threshold,threshold_then_argmax,binary_logit,argmax_membrane] (Default: argmax_membrane)
+
+Configurable attributes
+-----------------------
+* trace: int (Default: False)
+
+  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
+
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* output_mode: list [spike,membrane] (Default: spike)
+
+* membrane_t: NamedType
 
 TernaryTanh
 ===========
@@ -339,19 +477,19 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_size: int (Default: 1024)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 HardActivation
 ==============
@@ -399,19 +537,19 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_size: int (Default: 1024)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 Reshape
 =======
@@ -487,13 +625,13 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * strategy: list [latency,resource] (Default: latency)
 
@@ -529,13 +667,13 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 Conv1D
 ======
@@ -597,25 +735,25 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * parallelization_factor: int (Default: 1)
 
   * The number of outputs computed in parallel. Essentially the number of multiplications of input window with the convolution kernel occuring in parallel. Higher number results in more parallelism (lower latency and II) at the expense of resources used.Currently only supported in io_parallel.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI, Coyote
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 Conv2D
 ======
@@ -689,25 +827,25 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * parallelization_factor: int (Default: 1)
 
   * The number of outputs computed in parallel. Essentially the number of multiplications of input window with the convolution kernel occuring in parallel. Higher number results in more parallelism (lower latency and II) at the expense of resources used.Currently only supported in io_parallel.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI, Coyote
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 Conv2DBatchnorm
 ===============
@@ -781,25 +919,25 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * parallelization_factor: int (Default: 1)
 
   * The number of outputs computed in parallel. Essentially the number of multiplications of input window with the convolution kernel occuring in parallel. Higher number results in more parallelism (lower latency and II) at the expense of resources used.Currently only supported in io_parallel.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI, Coyote
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 SeparableConv1D
 ===============
@@ -867,29 +1005,29 @@ Backend-specific attributes
 ---------------------------
 * depthwise_accum_t: NamedType
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * pointwise_accum_t: NamedType
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * depthwise_result_t: NamedType
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * depthwise_reuse_factor: int (Default: 1)
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * pointwise_reuse_factor: int (Default: 1)
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 * dw_output_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
@@ -985,25 +1123,25 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * parallelization_factor: int (Default: 1)
 
   * The number of outputs computed in parallel. Essentially the number of multiplications of input window with the convolution kernel occuring in parallel. Higher number results in more parallelism (lower latency and II) at the expense of resources used.Currently only supported in io_parallel.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI, Coyote
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 SeparableConv2D
 ===============
@@ -1083,29 +1221,29 @@ Backend-specific attributes
 ---------------------------
 * depthwise_accum_t: NamedType
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * pointwise_accum_t: NamedType
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * depthwise_result_t: NamedType
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * depthwise_reuse_factor: int (Default: 1)
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * pointwise_reuse_factor: int (Default: 1)
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 * dw_output_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
@@ -1225,25 +1363,25 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * parallelization_factor: int (Default: 1)
 
   * The number of outputs computed in parallel. Essentially the number of multiplications of input window with the convolution kernel occuring in parallel. Higher number results in more parallelism (lower latency and II) at the expense of resources used.Currently only supported in io_parallel.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI, Coyote
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 BatchNormalization
 ==================
@@ -1297,7 +1435,7 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 Pooling1D
 =========
@@ -1347,19 +1485,19 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 Pooling2D
 =========
@@ -1421,19 +1559,19 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 GlobalPooling1D
 ===============
@@ -1453,6 +1591,8 @@ Type attributes
 
 * n_filt: int
 
+* keepdims: bool (Default: False)
+
 * pool_op: list [Max,Average]
 
 Configurable attributes
@@ -1471,13 +1611,13 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 GlobalPooling2D
 ===============
@@ -1499,6 +1639,8 @@ Type attributes
 
 * n_filt: int
 
+* keepdims: bool (Default: False)
+
 * pool_op: list [Max,Average]
 
 Configurable attributes
@@ -1517,13 +1659,13 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 ZeroPadding1D
 =============
@@ -1707,7 +1849,7 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 MatMul
 ======
@@ -1739,13 +1881,13 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 Dot
 ===
@@ -1793,13 +1935,13 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, Vivado, VivadoAccelerator, VivadoAccelerator, Vitis, Vitis, Quartus, Quartus, Catapult, Catapult, SymbolicExpression, SymbolicExpression, oneAPI, oneAPI, Libero, Libero, XLS, XLS
+  * Available in: Vivado, Vivado, VivadoAccelerator, VivadoAccelerator, Vitis, Vitis, Quartus, Quartus, Catapult, Catapult, SymbolicExpression, SymbolicExpression, oneAPI, oneAPI, Coyote, Coyote, Libero, Libero, XLS, XLS
 
 Concatenate
 ===========
@@ -1847,7 +1989,7 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 Resize
 ======
@@ -1955,7 +2097,7 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 SimpleRNN
 =========
@@ -2019,37 +2161,37 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * recurrent_reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI, Coyote
 
 * static: bool (Default: True)
 
   * If set to True, will reuse the the same recurrent block for computation, resulting in lower resource usage at the expense of serialized computation and higher latency/II.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 * table_size: int (Default: 1024)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI, Coyote
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI, Coyote
 
 LSTM
 ====
@@ -2123,37 +2265,37 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * recurrent_reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI, Coyote
 
 * static: bool (Default: True)
 
   * If set to True, will reuse the the same recurrent block for computation, resulting in lower resource usage at the expense of serialized computation and higher latency/II.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 * table_size: int (Default: 1024)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI, Coyote
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI, Coyote
 
 GRU
 ===
@@ -2229,37 +2371,37 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * recurrent_reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI, Coyote
 
 * static: bool (Default: True)
 
   * If set to True, will reuse the the same recurrent block for computation, resulting in lower resource usage at the expense of serialized computation and higher latency/II.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 * table_size: int (Default: 1024)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI, Coyote
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, oneAPI, Coyote
 
 Bidirectional
 =============
@@ -2359,55 +2501,55 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * forward_reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 * backward_reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 * forward_recurrent_reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 * backward_recurrent_reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 * static: bool (Default: True)
 
   * If set to True, will reuse the the same recurrent block for computation, resulting in lower resource usage at the expense of serialized computation and higher latency/II.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 * table_size: int (Default: 1024)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 TimeDistributed
 ===============
@@ -2445,7 +2587,7 @@ Backend-specific attributes
 
   * Controls the amont and type of parallelism in the loop over time steps. If set to "off", no parallelism will be used. If set to "unroll", the loop will be unrolled. This may result in excessive resource use and cannot be used in "io_stream" mode. If set to "pipeline", the loop will be pipelined.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 GarNet
 ======
@@ -2477,7 +2619,7 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, Vivado, VivadoAccelerator, VivadoAccelerator, Vitis, Vitis, Quartus, Quartus, Catapult, Catapult, SymbolicExpression, SymbolicExpression, oneAPI, oneAPI, Libero, Libero, XLS, XLS
+  * Available in: Vivado, Vivado, VivadoAccelerator, VivadoAccelerator, Vitis, Vitis, Quartus, Quartus, Catapult, Catapult, SymbolicExpression, SymbolicExpression, oneAPI, oneAPI, Coyote, Coyote, Libero, Libero, XLS, XLS
 
 GarNetStack
 ===========
@@ -2525,7 +2667,7 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, Vivado, VivadoAccelerator, VivadoAccelerator, Vitis, Vitis, Quartus, Quartus, Catapult, Catapult, SymbolicExpression, SymbolicExpression, oneAPI, oneAPI, Libero, Libero, XLS, XLS
+  * Available in: Vivado, Vivado, VivadoAccelerator, VivadoAccelerator, Vitis, Vitis, Quartus, Quartus, Catapult, Catapult, SymbolicExpression, SymbolicExpression, oneAPI, oneAPI, Coyote, Coyote, Libero, Libero, XLS, XLS
 
 Quant
 =====
@@ -2563,7 +2705,7 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 BipolarQuant
 ============
@@ -2641,7 +2783,7 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 BatchNormOnnx
 =============
@@ -2673,7 +2815,7 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 LayerGroup
 ==========
@@ -2791,37 +2933,37 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * table_range_power2: int (Default: 0)
 
   * The negative power of 2 that represents the range of the lookup table, e.g. a value of 1 would represent a range of 0.5.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 * table_size: int (Default: 4096)
 
   * The size of the lookup table used to approximate the function.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 * table_t: NamedType (Default: ufixed<8,5,RND_CONV,SAT,0>)
 
   * The datatype (precision) used for the values of the lookup table.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 * accum_t: NamedType (Default: fixed<14,4,RND_CONV,SAT,0>)
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis
+  * Available in: Vivado, VivadoAccelerator, Vitis, Coyote
 
 EinsumDense
 ===========
@@ -2953,7 +3095,7 @@ Backend-specific attributes
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 DACombinational
 ===============
@@ -2968,6 +3110,196 @@ Type attributes
 * index: int
 
   * Internal node counter used for bookkeeping and variable/tensor naming.
+
+Configurable attributes
+-----------------------
+* trace: int (Default: False)
+
+  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
+
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+SparseInputReduce
+=================
+Base attributes
+---------------
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+Type attributes
+---------------
+* index: int
+
+  * Internal node counter used for bookkeeping and variable/tensor naming.
+
+* in_height: int
+
+* in_width: int
+
+* n_chan: int
+
+* n_sparse: int
+
+* threshold: float
+
+* hash_bits: int (Default: 10)
+
+Configurable attributes
+-----------------------
+* trace: int (Default: False)
+
+  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
+
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+SparseConv2D
+============
+Base attributes
+---------------
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* weight_t: NamedType
+
+* bias_t: NamedType
+
+* accum_t: NamedType
+
+Type attributes
+---------------
+* index: int
+
+  * Internal node counter used for bookkeeping and variable/tensor naming.
+
+* n_sparse: int
+
+* n_chan: int
+
+* n_filt: int
+
+* kernel_size: int
+
+Weight attributes
+-----------------
+* weight: WeightVariable
+
+* bias: WeightVariable
+
+Configurable attributes
+-----------------------
+* trace: int (Default: False)
+
+  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
+
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* weight_t: NamedType
+
+* bias_t: NamedType
+
+* accum_t: NamedType
+
+SparseActivation
+================
+Base attributes
+---------------
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+Type attributes
+---------------
+* index: int
+
+  * Internal node counter used for bookkeeping and variable/tensor naming.
+
+* n_sparse: int
+
+* n_chan: int
+
+* activation: str
+
+Configurable attributes
+-----------------------
+* trace: int (Default: False)
+
+  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
+
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+SparsePooling2D
+===============
+Base attributes
+---------------
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* accum_t: NamedType
+
+Type attributes
+---------------
+* index: int
+
+  * Internal node counter used for bookkeeping and variable/tensor naming.
+
+* n_sparse: int
+
+* n_chan: int
+
+* in_height: int
+
+* in_width: int
+
+* pool_height: int
+
+* pool_width: int
+
+* pool_op: str (Default: avg)
+
+Configurable attributes
+-----------------------
+* trace: int (Default: False)
+
+  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
+
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* accum_t: NamedType
+
+SparseFlatten
+=============
+Base attributes
+---------------
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+Type attributes
+---------------
+* index: int
+
+  * Internal node counter used for bookkeeping and variable/tensor naming.
+
+* n_sparse: int
+
+* n_chan: int
+
+* out_height: int
+
+* out_width: int
 
 Configurable attributes
 -----------------------
@@ -3037,6 +3369,30 @@ Configurable attributes
 
 * table_t: NamedType (Default: fixed<18,8,TRN,WRAP,0>)
 
+Clone
+=====
+Base attributes
+---------------
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+Type attributes
+---------------
+* index: int
+
+  * Internal node counter used for bookkeeping and variable/tensor naming.
+
+Configurable attributes
+-----------------------
+* trace: int (Default: False)
+
+  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
+
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
 Repack
 ======
 Base attributes
@@ -3061,8 +3417,42 @@ Configurable attributes
 
   * The datatype (precision) of the output tensor.
 
-Clone
-=====
+BatchNormalizationQuantizedTanh
+===============================
+Base attributes
+---------------
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* accum_t: NamedType
+
+Type attributes
+---------------
+* index: int
+
+  * Internal node counter used for bookkeeping and variable/tensor naming.
+
+* n_in: int
+
+* n_filt: int (Default: 0)
+
+Configurable attributes
+-----------------------
+* trace: int (Default: False)
+
+  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
+
+* result_t: NamedType
+
+  * The datatype (precision) of the output tensor.
+
+* accum_t: NamedType
+
+* reuse_factor: int (Default: 1)
+
+Broadcast
+=========
 Base attributes
 ---------------
 * result_t: NamedType
@@ -3145,25 +3535,25 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * parallelization_factor: int (Default: 1)
 
   * The number of outputs computed in parallel. Essentially the number of multiplications of input window with the convolution kernel occuring in parallel. Higher number results in more parallelism (lower latency and II) at the expense of resources used.Currently only supported in io_parallel.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI, Coyote
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
 PointwiseConv2D
 ===============
@@ -3237,80 +3627,23 @@ Backend-specific attributes
 
   * The datatype (precision) used to store intermediate results of the computation within the layer.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * reuse_factor: int (Default: 1)
 
   * The number of times each multiplier is used by controlling the amount of pipelining/unrolling. Lower number results in more parallelism and lower latency at the expense of the resources used.Reuse factor = 1 corresponds to all multiplications executed in parallel, and hence, the lowest possible latency.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Libero, XLS
+  * Available in: Vivado, VivadoAccelerator, Vitis, Quartus, Catapult, SymbolicExpression, oneAPI, Coyote, Libero, XLS
 
 * parallelization_factor: int (Default: 1)
 
   * The number of outputs computed in parallel. Essentially the number of multiplications of input window with the convolution kernel occuring in parallel. Higher number results in more parallelism (lower latency and II) at the expense of resources used.Currently only supported in io_parallel.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, oneAPI, Coyote
 
 * conv_implementation: list [LineBuffer,Encoded] (Default: LineBuffer)
 
   * "LineBuffer" implementation is preferred over "Encoded" for most use cases. This attribute only applies to io_stream.
 
-  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult
+  * Available in: Vivado, VivadoAccelerator, Vitis, Catapult, Coyote
 
-Broadcast
-=========
-Base attributes
----------------
-* result_t: NamedType
-
-  * The datatype (precision) of the output tensor.
-
-Type attributes
----------------
-* index: int
-
-  * Internal node counter used for bookkeeping and variable/tensor naming.
-
-Configurable attributes
------------------------
-* trace: int (Default: False)
-
-  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
-
-* result_t: NamedType
-
-  * The datatype (precision) of the output tensor.
-
-BatchNormalizationQuantizedTanh
-===============================
-Base attributes
----------------
-* result_t: NamedType
-
-  * The datatype (precision) of the output tensor.
-
-* accum_t: NamedType
-
-Type attributes
----------------
-* index: int
-
-  * Internal node counter used for bookkeeping and variable/tensor naming.
-
-* n_in: int
-
-* n_filt: int (Default: 0)
-
-Configurable attributes
------------------------
-* trace: int (Default: False)
-
-  * Enables saving of layer output (tracing) when using hls_model.predict(...) or hls_model.trace(...)
-
-* result_t: NamedType
-
-  * The datatype (precision) of the output tensor.
-
-* accum_t: NamedType
-
-* reuse_factor: int (Default: 1)

--- a/hls4ml/converters/pytorch/convolution.py
+++ b/hls4ml/converters/pytorch/convolution.py
@@ -102,12 +102,21 @@ def parse_conv2d_layer(operation, layer_name, input_names, input_shapes, node, c
     layer['filt_width'] = class_object.kernel_size[1]
     layer['stride_height'] = class_object.stride[0]
     layer['stride_width'] = class_object.stride[1]
+    if class_object.dilation[0] != class_object.dilation[1]:
+        raise NotImplementedError(
+            f'Layer {layer_name}: Conv2d with different dilation factors per dimension is not supported.'
+        )
     layer['dilation'] = class_object.dilation[0]
-    layer['pad_top'] = layer['pad_bottom'] = class_object.padding[0]
-    layer['pad_left'] = layer['pad_right'] = class_object.padding[1]
 
     # Ouput info
-    (layer['out_height'], layer['out_width'], _, _, _, _) = compute_padding_2d_pytorch(
+    (
+        layer['out_height'],
+        layer['out_width'],
+        layer['pad_top'],
+        layer['pad_bottom'],
+        layer['pad_left'],
+        layer['pad_right'],
+    ) = compute_padding_2d_pytorch(
         class_object.padding,
         layer['in_height'],
         layer['in_width'],

--- a/hls4ml/converters/pytorch/core.py
+++ b/hls4ml/converters/pytorch/core.py
@@ -2,7 +2,7 @@ import math
 
 import numpy as np
 
-from hls4ml.converters.pytorch_to_hls import pytorch_handler
+from hls4ml.converters.pytorch_to_hls import get_call_arg, pytorch_handler
 from hls4ml.utils.einsum_utils import _validate_einsum_expr
 
 
@@ -57,7 +57,7 @@ def parse_linear_layer(operation, layer_name, input_names, input_shapes, node, c
     return layer, output_shape
 
 
-activation_layers = ['Softmax', 'ReLU', 'LeakyReLU', 'Threshold', 'ELU', 'PReLU', 'Sigmoid', 'Tanh']
+activation_layers = ['Softmax', 'ReLU', 'ReLU6', 'Hardtanh', 'LeakyReLU', 'Threshold', 'ELU', 'PReLU', 'Sigmoid', 'Tanh']
 
 
 @pytorch_handler(*activation_layers)
@@ -79,38 +79,61 @@ def parse_activation_layer(operation, layer_name, input_names, input_shapes, nod
         if layer['class_name'] == 'PReLU':
             layer['param_data'] = class_object.weight.data.numpy()
         if layer['class_name'] == 'Threshold':
+            if class_object.value != 0:
+                raise NotImplementedError(
+                    f'Layer {layer_name}: Threshold with a replacement value other than 0 is not supported.'
+                )
             layer['activ_param'] = class_object.threshold
             layer['class_name'] = 'ThresholdedReLU'
             layer['activation'] = 'ThresholdedReLU'
             if layer['activ_param'] < 0:
                 raise Exception('negative threshold values not supported')
+        if layer['class_name'] in ['ReLU6', 'Hardtanh']:
+            min_val = class_object.min_val
+            max_val = class_object.max_val
         if hasattr(class_object, 'dim'):
             layer['axis'] = class_object.dim
-            if layer['class_name'] == 'Softmax' and layer['axis'] is None:
-                layer['axis'] = -1
-            if 'IOType' in config:
-                if layer['class_name'] == 'Softmax' and config['IOType'] == 'io_stream' and layer['axis'] != -1:
-                    raise Exception('dim needs to be -1 for io_stream')
     else:
         if layer['class_name'] in ['ReLU', 'Sigmoid', 'Tanh']:
             layer['class_name'] = 'Activation'
         if layer['class_name'] == 'LeakyReLU':
-            layer['activ_param'] = node.kwargs['negative_slope']
+            layer['activ_param'] = get_call_arg(node, 1, 'negative_slope', 0.01)
         if layer['class_name'] == 'ELU':
-            layer['activ_param'] = node.kwargs['alpha']
+            layer['activ_param'] = get_call_arg(node, 1, 'alpha', 1.0)
         if layer['class_name'] == 'Threshold':
-            layer['activ_param'] = node.args[1]
+            if get_call_arg(node, 2, 'value', 0) != 0:
+                raise NotImplementedError(
+                    f'Layer {layer_name}: Threshold with a replacement value other than 0 is not supported.'
+                )
+            layer['activ_param'] = get_call_arg(node, 1, 'threshold')
             if layer['activ_param'] < 0:
                 raise Exception('negative threshold values not supported')
             layer['class_name'] = 'ThresholdedReLU'
             layer['activation'] = 'ThresholdedReLU'
-        if 'dim' in node.kwargs:
-            layer['axis'] = node.kwargs['dim']
-            if layer['class_name'] == 'Softmax' and layer['axis'] is None:
-                layer['axis'] = -1
-            if 'IOType' in config:
-                if layer['class_name'] == 'Softmax' and config['IOType'] == 'io_stream' and layer['axis'] != -1:
-                    raise Exception('dim needs to be -1 for io_stream')
+        if layer['class_name'] == 'ReLU6':
+            min_val, max_val = 0.0, 6.0
+        if layer['class_name'] == 'Hardtanh':
+            min_val = get_call_arg(node, 1, 'min_val', -1.0)
+            max_val = get_call_arg(node, 2, 'max_val', 1.0)
+        if layer['class_name'] == 'Softmax':
+            layer['axis'] = get_call_arg(node, 1, 'dim', None)
+
+    if layer['class_name'] in ['ReLU6', 'Hardtanh']:
+        # ReLU6 is Hardtanh(0, 6); Hardtanh clipped at 0 from below is a clipped ReLU
+        if min_val != 0:
+            raise NotImplementedError(f'Layer {layer_name}: Hardtanh is only supported with min_val == 0 (a clipped ReLU).')
+        layer['class_name'] = 'ClippedReLU'
+        layer['activation'] = 'clippedrelu'
+        layer['activ_param'] = max_val
+
+    if layer['class_name'] == 'Softmax':
+        if layer.get('axis') is None:
+            layer['axis'] = -1
+        if layer['axis'] == len(input_shapes[0]) - 1:
+            layer['axis'] = -1  # the last dimension, in its canonical form
+        if 'IOType' in config:
+            if config['IOType'] == 'io_stream' and layer['axis'] != -1:
+                raise Exception('dim needs to be -1 for io_stream')
 
     output_shape = input_shapes[0]
     return layer, output_shape
@@ -132,6 +155,11 @@ def parse_batchnorm_layer(operation, layer_name, input_names, input_shapes, node
 
     # batchnorm para
     if node.op == 'call_module':
+        if not class_object.track_running_stats:
+            raise NotImplementedError(
+                f'Layer {layer_name}: BatchNorm with track_running_stats=False is not supported '
+                '(it normalizes with per-batch statistics at inference time).'
+            )
         layer['epsilon'] = class_object.eps
         layer['use_gamma'] = layer['use_beta'] = class_object.affine
 
@@ -186,8 +214,15 @@ def parse_layernorm_layer(operation, layer_name, input_names, input_shapes, node
 
     layer['axis'] = 2
 
-    layer['gamma_data'] = class_object.weight.data.numpy()
-    layer['beta_data'] = class_object.bias.data.numpy()
+    # with elementwise_affine=False (or bias=False) the weights do not exist; substitute identity values
+    if class_object.weight is not None:
+        layer['gamma_data'] = class_object.weight.data.numpy()
+    else:
+        layer['gamma_data'] = np.ones(class_object.normalized_shape)
+    if class_object.bias is not None:
+        layer['beta_data'] = class_object.bias.data.numpy()
+    else:
+        layer['beta_data'] = np.zeros(class_object.normalized_shape)
 
     if class_object.eps <= 0:
         raise Exception('epsilon must be positive')

--- a/hls4ml/converters/pytorch/merge.py
+++ b/hls4ml/converters/pytorch/merge.py
@@ -1,4 +1,6 @@
-from hls4ml.converters.pytorch_to_hls import pytorch_handler
+import numpy as np
+
+from hls4ml.converters.pytorch_to_hls import get_call_arg, pytorch_handler
 
 concat_layers = ['cat', 'concat', 'concatenate']
 
@@ -20,7 +22,11 @@ def parse_concat_layer(operation, layer_name, input_names, input_shapes, node, c
     if rank > 3:
         raise Exception('ERROR: Concatenation of tensors with rank > 3 is not yet supported.')
     layer['op'] = layer['class_name'].lower() + f'{rank}d'
-    layer['axis'] = node.kwargs.get('dim', 0)
+    layer['axis'] = get_call_arg(node, 1, 'dim', 0)
+
+    axis = layer['axis'] if layer['axis'] >= 0 else layer['axis'] + len(input_shapes[0])
+    if axis == 0:
+        raise NotImplementedError(f'Layer {layer_name}: concatenation along the batch dimension is not supported.')
 
     output_shape = input_shapes[0][:]
     output_shape[layer['axis']] += input_shapes[1][layer['axis']]
@@ -56,6 +62,23 @@ def parse_merge_layer(operation, layer_name, input_names, input_shapes, node, cl
 
     layer['inputs'] = input_names
 
-    output_shape = input_shapes[0][:]
+    # The output shape is that of the tensor input. A scalar operand arrives as a size-1 constant input;
+    # it can be folded into add/subtract/multiply downstream. General broadcasting is not supported.
+    feature_sizes = [np.prod([dim for dim in shape if dim is not None]) for shape in input_shapes]
+    feature_shapes = [[dim for dim in shape if dim is not None] for shape in input_shapes]
+    if len(input_shapes) == 2 and feature_shapes[0] != feature_shapes[1]:
+        scalar_foldable = layer['op'] in ('add', 'subtract', 'multiply')
+        if feature_sizes[0] == 1 and scalar_foldable:
+            output_shape = input_shapes[1][:]
+        elif feature_sizes[1] == 1 and scalar_foldable:
+            output_shape = input_shapes[0][:]
+        else:
+            raise NotImplementedError(
+                f'Layer {layer_name}: broadcasting of inputs with different shapes '
+                f'({input_shapes[0]} and {input_shapes[1]}) is not supported.'
+            )
+    else:
+        # prefer the shape that carries the batch entry (a constant input has none)
+        output_shape = max(input_shapes, key=len)[:]
 
     return layer, output_shape

--- a/hls4ml/converters/pytorch/pooling.py
+++ b/hls4ml/converters/pytorch/pooling.py
@@ -1,4 +1,4 @@
-from hls4ml.converters.pytorch_to_hls import pytorch_handler
+from hls4ml.converters.pytorch_to_hls import get_call_arg, pytorch_handler
 from hls4ml.converters.utils import compute_padding_1d_pytorch, compute_padding_2d_pytorch, parse_data_format
 
 pooling_layers = ['MaxPool1d', 'MaxPool2d', 'AvgPool1d', 'AvgPool2d']
@@ -22,31 +22,52 @@ def parse_pooling_layer(operation, layer_name, input_names, input_shapes, node, 
     layer['name'] = layer_name
     layer['inputs'] = input_names
     layer['data_format'] = 'channels_first'  # Pytorch default (can't change)
-    if node.op == 'call_module' and 'Avg' in operation:
-        if class_object.count_include_pad:
-            layer['count_pad'] = True
-        else:
-            layer['count_pad'] = False
+
+    # Read the layer options, from the module or from the (positional or keyword) call arguments.
+    # Call signature: (input, kernel_size, stride, padding, dilation, ceil_mode) for max pooling and
+    # (input, kernel_size, stride, padding, ceil_mode, count_include_pad[, divisor_override]) for average pooling.
+    if node.op == 'call_module':
+        kernel_size = class_object.kernel_size
+        stride = class_object.stride
+        padding = class_object.padding
+        ceil_mode = bool(class_object.ceil_mode)
+        dilation = getattr(class_object, 'dilation', 1)  # only max pooling has it
+        count_include_pad = bool(getattr(class_object, 'count_include_pad', True))
+        divisor_override = getattr(class_object, 'divisor_override', None)  # only AvgPool2d has it
     else:
-        layer['count_pad'] = True
+        kernel_size = get_call_arg(node, 1, 'kernel_size')
+        stride = get_call_arg(node, 2, 'stride', None)
+        padding = get_call_arg(node, 3, 'padding', 0)
+        if 'Max' in operation:
+            dilation = get_call_arg(node, 4, 'dilation', 1)
+            ceil_mode = bool(get_call_arg(node, 5, 'ceil_mode', False))
+            count_include_pad = True
+            divisor_override = None
+        else:
+            dilation = 1
+            ceil_mode = bool(get_call_arg(node, 4, 'ceil_mode', False))
+            count_include_pad = bool(get_call_arg(node, 5, 'count_include_pad', True))
+            divisor_override = get_call_arg(node, 6, 'divisor_override', None) if operation == 'AvgPool2d' else None
+    if stride is None:
+        # if stride is not set it defaults to the kernel size
+        stride = kernel_size
+
+    if ceil_mode:
+        raise NotImplementedError(f'Layer {layer_name}: pooling with ceil_mode=True is not supported.')
+    if any(d != 1 for d in (dilation if isinstance(dilation, (tuple, list)) else (dilation,))):
+        raise NotImplementedError(f'Layer {layer_name}: pooling with dilation != 1 is not supported.')
+    if divisor_override is not None:
+        raise NotImplementedError(f'Layer {layer_name}: average pooling with divisor_override is not supported.')
+
+    layer['count_pad'] = count_include_pad
 
     if int(layer['class_name'][-2]) == 1:
         (*_, layer['n_in'], layer['n_filt']) = parse_data_format(input_shapes[0], layer['data_format'])
-        if node.op == 'call_module':
-            layer['pool_width'] = (
-                class_object.kernel_size if type(class_object.kernel_size) is not tuple else class_object.kernel_size[0]
-            )
-            layer['stride_width'] = class_object.stride if type(class_object.stride) is not tuple else class_object.stride[0]
 
-            if type(class_object.padding) is tuple:
-                padding = class_object.padding[0]
-            else:
-                padding = class_object.padding
-
-        else:
-            layer['pool_width'] = int(node.args[1])
-            layer['stride_width'] = node.kwargs['stride'] if node.kwargs['stride'] is not None else int(node.args[1])
-            padding = node.kwargs['padding']
+        layer['pool_width'] = kernel_size[0] if isinstance(kernel_size, (tuple, list)) else kernel_size
+        layer['stride_width'] = stride[0] if isinstance(stride, (tuple, list)) else stride
+        if isinstance(padding, (tuple, list)):
+            padding = padding[0]
 
         if padding == 0:  # No padding, i.e., 'VALID' padding in Keras/Tensorflow
             layer['padding'] = 'valid'
@@ -67,48 +88,22 @@ def parse_pooling_layer(operation, layer_name, input_names, input_shapes, node, 
             input_shapes[0], layer['data_format']
         )
 
-        if node.op == 'call_module':
-            if type(class_object.stride) is tuple:
-                layer['stride_height'] = class_object.stride[0]
-                layer['stride_width'] = class_object.stride[1]
-            else:
-                layer['stride_height'] = class_object.stride
-                layer['stride_width'] = class_object.stride
-
-            if type(class_object.kernel_size) is tuple:
-                layer['pool_height'] = class_object.kernel_size[0]
-                layer['pool_width'] = class_object.kernel_size[1]
-            else:
-                layer['pool_height'] = class_object.kernel_size
-                layer['pool_width'] = class_object.kernel_size
-
-            if type(class_object.padding) is tuple:
-                padding = class_object.padding
-            else:
-                padding = [class_object.padding, class_object.padding]
-
+        if isinstance(kernel_size, (tuple, list)):
+            layer['pool_height'] = kernel_size[0]
+            layer['pool_width'] = kernel_size[1]
         else:
-            if type(node.kwargs['stride']) is tuple:
-                layer['stride_height'] = node.kwargs['stride'][0]
-                layer['stride_width'] = node.kwargs['stride'][1]
-            else:
-                if node.kwargs['stride'] is None:
-                    # if stride is not set it is supposed to default to the kernel size
-                    layer['stride_height'] = node.args[1]
-                    layer['stride_width'] = node.args[1]
-                else:
-                    layer['stride_height'] = node.kwargs['stride']
-                    layer['stride_width'] = node.kwargs['stride']
-            if type(node.args[1]) is tuple:
-                layer['pool_height'] = node.args[1][0]
-                layer['pool_width'] = node.args[1][1]
-            else:
-                layer['pool_height'] = node.args[1]
-                layer['pool_width'] = node.args[1]
-            if type(node.kwargs['padding']) is tuple:
-                padding = node.kwargs['padding']
-            else:
-                padding = [node.kwargs['padding'], node.kwargs['padding']]
+            layer['pool_height'] = kernel_size
+            layer['pool_width'] = kernel_size
+
+        if isinstance(stride, (tuple, list)):
+            layer['stride_height'] = stride[0]
+            layer['stride_width'] = stride[1]
+        else:
+            layer['stride_height'] = stride
+            layer['stride_width'] = stride
+
+        if not isinstance(padding, (tuple, list)):
+            padding = [padding, padding]
 
         if all(x == 0 for x in padding):  # No padding, i.e., 'VALID' padding in Keras/Tensorflow
             layer['padding'] = 'valid'

--- a/hls4ml/converters/pytorch/recurrent.py
+++ b/hls4ml/converters/pytorch/recurrent.py
@@ -5,6 +5,24 @@ from hls4ml.converters.pytorch_to_hls import pytorch_handler
 rnn_layers = ['RNN', 'LSTM', 'GRU']
 
 
+def _collect_output_index_paths(node, path=(), paths=None):
+    """Collects the chains of getitem indices through which the RNN output tuple is consumed.
+
+    Each entry in the returned list is a tuple of indices leading from the RNN output to an actual consumer,
+    e.g. ``(0,)`` for the output sequence and ``(1, 0)`` for the hidden state of an LSTM. Getitem nodes with
+    no consumers (from unpacking into unused variables) are ignored.
+    """
+    if paths is None:
+        paths = []
+    for user in node.users:
+        if 'getitem' in user.name:
+            if len(user.users) > 0:
+                _collect_output_index_paths(user, path + (user.args[1],), paths)
+        else:
+            paths.append(path)
+    return paths
+
+
 @pytorch_handler(*rnn_layers)
 def parse_rnn_layer(operation, layer_name, input_names, input_shapes, node, class_object, data_reader, config):
     assert operation in rnn_layers
@@ -22,7 +40,28 @@ def parse_rnn_layer(operation, layer_name, input_names, input_shapes, node, clas
     if operation == 'RNN':
         layer['class_name'] = 'SimpleRNN'
 
-    layer['return_sequences'] = False  # parameter does not exist in pytorch
+    if getattr(class_object, 'proj_size', 0) > 0:
+        raise NotImplementedError(f'Layer {layer_name}: LSTM with proj_size > 0 is not supported.')
+
+    # PyTorch RNN layers return a tuple (output_sequence, final_state); which element the model consumes
+    # decides whether the layer must produce the full sequence or only the final state
+    index_paths = _collect_output_index_paths(node)
+    for p in index_paths:
+        if not all(isinstance(i, int) for i in p):
+            raise NotImplementedError(
+                f'Layer {layer_name}: slicing of the outputs of an RNN layer is not supported '
+                '(only selecting the output sequence or the final hidden state).'
+            )
+    sequence_used = any(p[:1] == (0,) for p in index_paths)
+    state_used = any(p[:1] == (1,) for p in index_paths) or any(p == () for p in index_paths)
+    if operation == 'LSTM' and any(p[:2] == (1, 1) for p in index_paths):
+        raise NotImplementedError(f'Layer {layer_name}: use of the cell state of an LSTM layer is not supported.')
+    if sequence_used and state_used:
+        raise NotImplementedError(
+            f'Layer {layer_name}: use of both the output sequence and the final state of an RNN layer is not supported.'
+        )
+
+    layer['return_sequences'] = sequence_used
     layer['return_state'] = False  # parameter does not exist in pytorch
 
     if layer['class_name'] == 'SimpleRNN':
@@ -47,24 +86,29 @@ def parse_rnn_layer(operation, layer_name, input_names, input_shapes, node, clas
         raise Exception('hls4ml does not support num_layers > 1')
 
     if class_object.bidirectional:
-        raise Exception('hls4ml does not support birectional RNNs')
+        raise Exception('hls4ml does not support bidirectional RNNs')
     if class_object.dropout > 0:
         raise Exception('hls4ml does not support RNNs with dropout')
 
     # transpose weight and recurrent weight to match keras order used in the HLS code
     layer['weight_data'] = class_object.weight_ih_l0.data.numpy().transpose()
     layer['recurrent_weight_data'] = class_object.weight_hh_l0.data.numpy().transpose()
-    layer['bias_data'] = class_object.bias_ih_l0.data.numpy()
-    layer['recurrent_bias_data'] = class_object.bias_hh_l0.data.numpy()
 
-    if class_object.bias is False:
-        layer['bias_data'] = np.zeros(layer['weight_data'].shape[0])
-        layer['recurrent_bias_data'] = np.zeros(layer['recurrent_weight_data'].shape[0])
+    if class_object.bias:
+        layer['bias_data'] = class_object.bias_ih_l0.data.numpy()
+        layer['recurrent_bias_data'] = class_object.bias_hh_l0.data.numpy()
+    else:
+        # the bias parameters do not exist in the module; substitute zeros of the gate width
+        layer['bias_data'] = np.zeros(layer['weight_data'].shape[-1])
+        layer['recurrent_bias_data'] = np.zeros(layer['recurrent_weight_data'].shape[-1])
 
     if layer['class_name'] == 'GRU':
         layer['apply_reset_gate'] = 'after'  # Might be true for pytorch? It's not a free parameter
 
-    output_shape = [input_shapes[0][0], layer['n_out']]
+    if layer['return_sequences']:
+        output_shape = [input_shapes[0][0], layer['n_timesteps'], layer['n_out']]
+    else:
+        output_shape = [input_shapes[0][0], layer['n_out']]
 
     layer['pytorch'] = True  # need to switch some behaviors to match pytorch implementations
     if len(input_names) == 1:

--- a/hls4ml/converters/pytorch/reshape.py
+++ b/hls4ml/converters/pytorch/reshape.py
@@ -15,19 +15,20 @@ def parse_reshape_layer(operation, layer_name, input_names, input_shapes, node, 
     layer['name'] = layer_name
     layer['inputs'] = input_names
 
-    layer['target_shape'] = [int(i) for i in node.args[1:]]
+    target_shape = [int(i) for i in node.args[1:]]
+    # The first target dimension is the batch dimension; remove it before deducing a -1 entry,
+    # so that a literal batch size does not enter the deduction
+    target_shape = target_shape[1:]
     # View can have -1 as one as the dimensions,
     # leaving it to us to deduce it from the other dimensions and the overall size
-    if -1 in layer['target_shape']:
+    if -1 in target_shape:
         size = np.prod(input_shapes[0][1:])
-        for i in range(0, len(layer['target_shape'])):
-            if layer['target_shape'][i] == -1:
-                cl = layer['target_shape'][:]
+        for i in range(0, len(target_shape)):
+            if target_shape[i] == -1:
+                cl = target_shape[:]
                 cl.remove(-1)
-                layer['target_shape'][i] = int(size / np.prod(cl))
-
-    # remove the batch dimension
-    layer['target_shape'] = layer['target_shape'][1:]
+                target_shape[i] = int(size / np.prod(cl))
+    layer['target_shape'] = target_shape
 
     output_shape = input_shapes[0][:1] + layer['target_shape']
 
@@ -132,28 +133,48 @@ def handle_upsample(operation, layer_name, input_names, input_shapes, node, clas
     layer['class_name'] = 'Resize'
     layer['data_format'] = 'channels_first'
 
+    def output_size(in_size, scale_factor, target_size, dim_name):
+        """Computes one output dimension from either the scale factor or the target size."""
+        if scale_factor is not None:
+            return int(in_size * scale_factor)
+        if target_size % in_size != 0:
+            raise NotImplementedError(
+                f'Layer {layer_name}: upsampling from {dim_name} {in_size} to {target_size} '
+                'is not supported (the target size must be an integer multiple of the input size).'
+            )
+        return target_size
+
+    scale_factor = class_object.scale_factor
+    target_size = class_object.size  # set when the layer was constructed with size= instead of scale_factor=
+
     input_shape = parse_data_format(input_shapes[0], 'channels_first')
     if len(input_shape) == 2:
         layer['in_height'] = 1
         layer['in_width'], layer['n_chan'] = input_shape
 
+        if isinstance(target_size, (tuple, list)):
+            target_size = target_size[0]
+
         layer['out_height'] = 1
-        layer['out_width'] = int(layer['in_width'] * class_object.scale_factor)
+        layer['out_width'] = output_size(layer['in_width'], scale_factor, target_size, 'width')
 
         output_shape = [input_shapes[0][0], layer['n_chan'], layer['out_width']]
     elif len(input_shape) == 3:
         layer['in_height'], layer['in_width'], layer['n_chan'] = input_shape
 
-        scale_factor = class_object.scale_factor
         if isinstance(scale_factor, tuple):
             scale_height = scale_factor[0]
             scale_width = scale_factor[1]
         else:
             scale_height = scale_factor
             scale_width = scale_factor
+        if isinstance(target_size, (tuple, list)):
+            target_height, target_width = target_size
+        else:
+            target_height = target_width = target_size
 
-        layer['out_height'] = int(layer['in_height'] * scale_height)
-        layer['out_width'] = int(layer['in_width'] * scale_width)
+        layer['out_height'] = output_size(layer['in_height'], scale_height, target_height, 'height')
+        layer['out_width'] = output_size(layer['in_width'], scale_width, target_width, 'width')
 
         output_shape = [input_shapes[0][0], layer['n_chan'], layer['out_height'], layer['out_width']]
     else:

--- a/hls4ml/converters/pytorch_to_hls.py
+++ b/hls4ml/converters/pytorch_to_hls.py
@@ -85,9 +85,28 @@ def pytorch_handler(*args):
     return decorator
 
 
+def get_call_arg(node, position, name, default=None):
+    """Reads an argument of a traced function call, whether it was passed positionally or by keyword.
+
+    Args:
+        node: The traced call node.
+        position (int): Position of the argument in the call signature, counting the input tensor as position 0.
+        name (str): Keyword name of the argument.
+        default: Value to return if the argument was not passed.
+
+    Returns:
+        The argument value, or ``default`` if it was not passed.
+    """
+    if len(node.args) > position:
+        return node.args[position]
+    return node.kwargs.get(name, default)
+
+
 # map names of operations between torch.nn and torch.nn.functionals
 layer_name_map = {
     'relu': 'ReLU',
+    'relu6': 'ReLU6',
+    'hardtanh': 'Hardtanh',
     'tanh': 'Tanh',
     'leaky_relu': 'LeakyReLU',
     'elu': 'ELU',
@@ -184,15 +203,32 @@ def parse_pytorch_model(config, verbose=True):
     i = 0  # count number of consts and use it in the name
     for node in traced_model.nodes:
         if node.name.split('_')[0] in merge_layers:
-            for arg in node.args:
+            for arg_idx, arg in enumerate(node.args):
                 if np.isscalar(arg):
-                    # add an input node with the constant value
+                    # add an input node with the constant value, in the position the scalar had in the call
                     new_node = traced_model.placeholder(name='const_' + str(i), type_expr=torch.Tensor, default_value=arg)
                     node.prepend(new_node)
-                    node.update_arg(1, new_node)
+                    node.update_arg(arg_idx, new_node)
                     i += 1
 
     traced_model.lint()
+
+    def resolve_getitem_source(node_name, visited=None):
+        """Recursively resolve nested getitem calls to find the actual source node."""
+        if visited is None:
+            visited = set()
+
+        if node_name in visited:
+            raise Exception(f'Circular reference detected in getitem chain: {node_name}')
+        visited.add(node_name)
+
+        for tmp_node in traced_model.nodes:
+            if tmp_node.name == node_name:
+                if 'getitem' in tmp_node.args[0].name:
+                    return resolve_getitem_source(tmp_node.args[0].name, visited)
+                else:
+                    return tmp_node.args[0]
+        raise Exception(f'Could not find source node for getitem: {node_name}')
 
     for node in traced_model.nodes:
         if node.op == 'call_module':
@@ -243,32 +279,18 @@ def parse_pytorch_model(config, verbose=True):
                 for arg in node.args:
                     if isinstance(arg, tuple):
                         for input in arg:
+                            if hasattr(input, 'name') and 'getitem' in input.name:
+                                input = resolve_getitem_source(input.name)
                             input_shapes.append(output_shapes[str(input)])
                             input_names.append(inputs_map.get(str(input), str(input)))
                     else:
+                        if hasattr(arg, 'name') and 'getitem' in arg.name:
+                            arg = resolve_getitem_source(arg.name)
                         input_shapes.append(output_shapes[str(arg)])
                         input_names.append(inputs_map.get(str(arg), str(arg)))
 
             # if a 'getitem' is the input to a node, step back in the graph to find the real source of the input
             elif 'getitem' in node.args[0].name:
-
-                def resolve_getitem_source(node_name, visited=None):
-                    """Recursively resolve nested getitem calls to find the actual source node."""
-                    if visited is None:
-                        visited = set()
-
-                    if node_name in visited:
-                        raise Exception(f'Circular reference detected in getitem chain: {node_name}')
-                    visited.add(node_name)
-
-                    for tmp_node in traced_model.nodes:
-                        if tmp_node.name == node_name:
-                            if 'getitem' in tmp_node.args[0].name:
-                                return resolve_getitem_source(tmp_node.args[0].name, visited)
-                            else:
-                                return tmp_node.args[0]
-                    raise Exception(f'Could not find source node for getitem: {node_name}')
-
                 source_node = resolve_getitem_source(node.args[0].name)
                 input_names = [inputs_map.get(str(source_node), str(source_node))]
                 input_shapes = [output_shapes[str(source_node)]]
@@ -377,7 +399,8 @@ def parse_pytorch_model(config, verbose=True):
 
             layer_counter += 1
 
-            input_names = [inputs_map.get(str(i), str(i)) for i in node.all_input_nodes]
+            input_nodes = [resolve_getitem_source(i.name) if 'getitem' in i.name else i for i in node.all_input_nodes]
+            input_names = [inputs_map.get(str(i), str(i)) for i in input_nodes]
             input_shapes = [list(output_shapes[str(i)]) for i in input_names]
 
             # Process the layer
@@ -435,7 +458,8 @@ def parse_pytorch_model(config, verbose=True):
 
             layer_counter += 1
 
-            input_names = [inputs_map.get(str(i), str(i)) for i in node.all_input_nodes]
+            input_nodes = [resolve_getitem_source(i.name) if 'getitem' in i.name else i for i in node.all_input_nodes]
+            input_names = [inputs_map.get(str(i), str(i)) for i in input_nodes]
 
             # Process the layer
             input_shapes = [list(output_shapes[str(i)]) for i in input_names]

--- a/hls4ml/converters/utils.py
+++ b/hls4ml/converters/utils.py
@@ -146,14 +146,16 @@ def compute_padding_2d(pad_type, in_height, in_width, stride_height, stride_widt
 def compute_padding_1d_pytorch(pad_type, in_size, stride, filt_size, dilation):
     """Computes the amount of padding required on each side of the 1D input tensor following pytorch conventions.
 
-    In case of ``same`` padding, this routine tries to pad evenly left and right, but if the amount of columns to be added
-    is odd, it will add the extra column to the right.
+    In case of ``same`` padding, the total padding is ``dilation * (filt_size - 1)``, split evenly between left and
+    right; if the total is odd, the extra column goes to the right, matching PyTorch. PyTorch only allows ``same``
+    padding for stride 1.
 
     Args:
-        pad_type (str or int): Padding type. If string, one of ``same``, ``valid`` or ``causal`` (case insensitive).
+        pad_type (str or int): Padding type. If string, one of ``same`` or ``valid`` (case insensitive).
         in_size (int): Input size.
         stride (int): Stride length.
         filt_size (int): Length of the kernel window.
+        dilation (int): Dilation factor of the kernel.
 
     Raises:
         Exception: Raised if the padding type is unknown.
@@ -163,15 +165,13 @@ def compute_padding_1d_pytorch(pad_type, in_size, stride, filt_size, dilation):
     """
     if isinstance(pad_type, str):
         if pad_type.lower() == 'same':
-            n_out = int(
-                math.floor((float(in_size) + 2 - float(dilation) * (float(filt_size) - 1) - 1) / float(stride) + 1)
-            )  # from https://pytorch.org/docs/stable/generated/torch.nn.Conv1d.html
-            if in_size % stride == 0:
-                pad_along_size = max(filt_size - stride, 0)
-            else:
-                pad_along_size = max(filt_size - (in_size % stride), 0)
-            pad_right = pad_along_size // 2
-            pad_left = pad_along_size - pad_right
+            if stride != 1:
+                # PyTorch itself raises for padding='same' with stride != 1
+                raise Exception("padding='same' is not supported for strided convolutions")
+            n_out = in_size
+            pad_along_size = dilation * (filt_size - 1)
+            pad_left = pad_along_size // 2
+            pad_right = pad_along_size - pad_left
         elif pad_type.lower() == 'valid':
             n_out = int(
                 math.floor((float(in_size) - float(dilation) * (float(filt_size) - 1) - 1) / float(stride) + 1)
@@ -204,17 +204,20 @@ def compute_padding_2d_pytorch(
 ):
     """Computes the amount of padding required on each side of the 2D input tensor following pytorch conventions.
 
-    In case of ``same`` padding, this routine tries to pad evenly left and right (top and bottom), but if the amount of
-    columns to be added is odd, it will add the extra column to the right/bottom.
+    In case of ``same`` padding, the total padding along each dimension is ``dilation * (filt_size - 1)``, split evenly
+    between the two sides; if the total is odd, the extra pixel goes to the bottom/right, matching PyTorch. PyTorch only
+    allows ``same`` padding for stride 1.
 
     Args:
-        pad_type (str or int): Padding type. If string, one of ``same`` or ``valid`` (case insensitive).
+        pad_type (str or tuple): Padding type. If string, one of ``same`` or ``valid`` (case insensitive).
         in_height (int): The height of the input tensor.
         in_width (int): The width of the input tensor.
         stride_height (int): Stride height.
         stride_width (int): Stride width.
         filt_height (int): Height of the kernel window.
         filt_width (int): Width of the kernel window.
+        dilation_height (int): Dilation factor of the kernel along the height.
+        dilation_width (int): Dilation factor of the kernel along the width.
 
     Raises:
         Exception: Raised if the padding type is unknown.
@@ -224,27 +227,19 @@ def compute_padding_2d_pytorch(
     """
     if isinstance(pad_type, str):
         if pad_type.lower() == 'same':
+            if stride_height != 1 or stride_width != 1:
+                # PyTorch itself raises for padding='same' with stride != 1
+                raise Exception("padding='same' is not supported for strided convolutions")
             # Height
-            out_height = int(
-                math.floor(float(in_height + 2 - dilation_height * (filt_height - 1) - 1) / float(stride_height) + 1)
-            )
-            if in_height % stride_height == 0:
-                pad_along_height = max(filt_height - stride_height, 0)
-            else:
-                pad_along_height = max(filt_height - (in_height % stride_height), 0)
-            pad_bottom = pad_along_height // 2
-            pad_top = pad_along_height - pad_bottom
-            pad_top = 1
+            out_height = in_height
+            pad_along_height = dilation_height * (filt_height - 1)
+            pad_top = pad_along_height // 2
+            pad_bottom = pad_along_height - pad_top
             # Width
-            out_width = int(
-                math.floor(float(in_width + 2 - dilation_width * (filt_width - 1) - 1) / float(stride_width) + 1)
-            )
-            if in_width % stride_width == 0:
-                pad_along_width = max(filt_width - stride_width, 0)
-            else:
-                pad_along_width = max(filt_width - (in_width % stride_width), 0)
-            pad_right = pad_along_width // 2
-            pad_left = pad_along_width - pad_right
+            out_width = in_width
+            pad_along_width = dilation_width * (filt_width - 1)
+            pad_left = pad_along_width // 2
+            pad_right = pad_along_width - pad_left
         elif pad_type.lower() == 'valid':
             out_height = int(
                 math.floor(float(in_height - dilation_height * (filt_height - 1) - 1) / float(stride_height) + 1)

--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -1989,6 +1989,7 @@ layer_map = {
     'QActivation': Activation,
     'LeakyReLU': ParametrizedActivation,
     'ThresholdedReLU': ParametrizedActivation,
+    'ClippedReLU': ParametrizedActivation,
     'ELU': ParametrizedActivation,
     'PReLU': PReLU,
     'Softmax': Softmax,

--- a/test/pytest/test_batchnorm_pytorch.py
+++ b/test/pytest/test_batchnorm_pytorch.py
@@ -130,3 +130,18 @@ def test_batchnorm_fusion(test_case_id, fusion_data, backend, io_type):
     else:
         hls_prediction = np.reshape(hls_model.predict(fusion_data), pytorch_prediction.shape)
     np.testing.assert_allclose(pytorch_prediction, hls_prediction, rtol=0, atol=atol, verbose=True)
+
+
+def test_batchnorm_no_running_stats_rejected(test_case_id):
+    # with track_running_stats=False the layer normalizes with per-batch statistics even in eval mode,
+    # which hls4ml cannot represent
+    model = nn.Sequential(nn.BatchNorm1d(in_shape, track_running_stats=False)).to()
+    model.eval()
+
+    output_dir = str(test_root_path / test_case_id)
+    with pytest.raises(NotImplementedError, match='track_running_stats'):
+        # config_from_pytorch_model traces the model too, so the reject can fire already there
+        config = hls4ml.utils.config_from_pytorch_model(model, (in_shape,))
+        hls4ml.converters.convert_from_pytorch_model(
+            model, backend='Vivado', hls_config=config, io_type='io_parallel', output_dir=output_dir
+        )

--- a/test/pytest/test_layernorm_pytorch.py
+++ b/test/pytest/test_layernorm_pytorch.py
@@ -76,3 +76,21 @@ def test_layernorm(test_case_id, model, data, backend):
     y_pytorch = model(torch.Tensor(data)).detach().numpy().flatten()
     y_hls = hls_model.predict(data).flatten()
     np.testing.assert_allclose(y_pytorch, y_hls, rtol=0, atol=5e-2, verbose=True)
+
+
+@pytest.mark.parametrize('backend', ['Vivado'])
+def test_layernorm_no_affine(test_case_id, data, backend):
+    # with elementwise_affine=False the weight and bias parameters do not exist; identity values are substituted
+    model = nn.Sequential(OrderedDict([('layer_normalization', nn.LayerNorm(in_shape[-1], elementwise_affine=False))]))
+    model.eval()
+
+    config = hls4ml.utils.config_from_pytorch_model(model, in_shape, granularity='name', backend=backend)
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_pytorch_model(
+        model, backend=backend, hls_config=config, io_type='io_parallel', output_dir=output_dir
+    )
+    hls_model.compile()
+
+    y_pytorch = model(torch.Tensor(data)).detach().numpy().flatten()
+    y_hls = hls_model.predict(data).flatten()
+    np.testing.assert_allclose(y_pytorch, y_hls, rtol=0, atol=5e-2, verbose=True)

--- a/test/pytest/test_merge_pytorch.py
+++ b/test/pytest/test_merge_pytorch.py
@@ -72,3 +72,110 @@ def test_merge(test_case_id, merge_op, io_type, backend):
     hls_prediction = np.transpose(hls_prediction.reshape(output_shape_cl), axes=[0, 3, 1, 2])
 
     np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=0.001)
+
+
+# ---------------------------------------------------------------------------- #
+# Scalar operands, positional concatenation dimension, and rejects of merges
+# hls4ml cannot represent.
+# ---------------------------------------------------------------------------- #
+
+
+class ScalarMergeModel(nn.Module):
+    """Applies an elementwise operation with a scalar operand, in either position."""
+
+    def __init__(self, function):
+        super().__init__()
+        self.function = function
+
+    def forward(self, x):
+        return self.function(x)
+
+
+scalar_merge_ops = {
+    'add': lambda x: x + 2.5,
+    'sub': lambda x: x - 2.5,
+    'rsub': lambda x: 2.5 - x,  # the scalar in the first position used to replace the wrong argument
+    'mul': lambda x: x * 0.5,
+}
+
+
+@pytest.mark.parametrize('merge_op', scalar_merge_ops.keys())
+def test_merge_scalar_operand(test_case_id, merge_op):
+    model = ScalarMergeModel(scalar_merge_ops[merge_op])
+    model.eval()
+
+    config = hls4ml.utils.config_from_pytorch_model(model, (8,), default_precision='ap_fixed<32,16>')
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_pytorch_model(
+        model, hls_config=config, output_dir=output_dir, io_type='io_parallel', backend='Vivado'
+    )
+    hls_model.compile()
+
+    X_input = np.round(np.random.rand(10, 8) * 2**10) * 2**-10
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+    hls_prediction = hls_model.predict(X_input)
+
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=0.001)
+
+
+class ConcatPositionalDimModel(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x, y):
+        return torch.cat([x, y], self.dim)  # the positional dim used to be ignored, defaulting to the batch axis
+
+
+@pytest.mark.parametrize('dim', [1, -1])
+def test_concat_positional_dim(test_case_id, dim):
+    model = ConcatPositionalDimModel(dim)
+    model.eval()
+
+    config = hls4ml.utils.config_from_pytorch_model(model, [(8,), (8,)], default_precision='ap_fixed<32,16>')
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_pytorch_model(
+        model, hls_config=config, output_dir=output_dir, io_type='io_parallel', backend='Vivado'
+    )
+    hls_model.compile()
+
+    X_input1 = np.round(np.random.rand(10, 8) * 2**10) * 2**-10
+    X_input2 = np.round(np.random.rand(10, 8) * 2**10) * 2**-10
+    pytorch_prediction = model(torch.Tensor(X_input1), torch.Tensor(X_input2)).detach().numpy()
+    hls_prediction = hls_model.predict([X_input1, X_input2])
+
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=0.001)
+
+
+def test_concat_batch_dim_rejected(test_case_id):
+    class ConcatBatchModel(nn.Module):
+        def forward(self, x, y):
+            return torch.cat([x, y], 0)
+
+    model = ConcatBatchModel()
+    model.eval()
+
+    output_dir = str(test_root_path / test_case_id)
+    with pytest.raises(NotImplementedError, match='batch dimension'):
+        # config_from_pytorch_model traces the model too, so the reject can fire already there
+        config = hls4ml.utils.config_from_pytorch_model(model, [(8,), (8,)])
+        hls4ml.converters.convert_from_pytorch_model(
+            model, hls_config=config, output_dir=output_dir, io_type='io_parallel', backend='Vivado'
+        )
+
+
+def test_merge_broadcast_rejected(test_case_id):
+    class BroadcastMergeModel(nn.Module):
+        def forward(self, x, y):
+            return x + y
+
+    model = BroadcastMergeModel()
+    model.eval()
+
+    output_dir = str(test_root_path / test_case_id)
+    with pytest.raises(NotImplementedError, match='broadcasting'):
+        # config_from_pytorch_model traces the model too, so the reject can fire already there
+        config = hls4ml.utils.config_from_pytorch_model(model, [(2, 6), (6,)])
+        hls4ml.converters.convert_from_pytorch_model(
+            model, hls_config=config, output_dir=output_dir, io_type='io_parallel', backend='Vivado'
+        )

--- a/test/pytest/test_pytorch_api.py
+++ b/test/pytest/test_pytorch_api.py
@@ -1008,3 +1008,274 @@ def test_einsum_single_input(test_case_id, backend, io_type):
     hls_prediction = np.reshape(hls_model.predict(X_input), pytorch_prediction.shape)
 
     np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=1e-2, atol=0.01)
+
+
+# ---------------------------------------------------------------------------- #
+# Parser behavior for configurations that used to be silently misparsed:
+# faithful 'same'/'valid' padding, positional arguments of functional calls,
+# clipped ReLU activations and rejects of unsupported options.
+# ---------------------------------------------------------------------------- #
+
+
+def _convert_parse_only(model, test_case_id, input_shape, io_type='io_parallel'):
+    """Converts without compiling, to assert parse results and parse-time rejects."""
+    config = config_from_pytorch_model(model, input_shape, channels_last_conversion='off', transpose_outputs=False)
+    output_dir = str(test_root_path / test_case_id)
+    return convert_from_pytorch_model(model, hls_config=config, output_dir=output_dir, backend='Vivado', io_type=io_type)
+
+
+@pytest.mark.parametrize('kernel_size', [1, 2, 3, 4, 5, 7])
+@pytest.mark.parametrize('padds', ['same', 'valid'])
+def test_conv1d_string_padding(test_case_id, kernel_size, padds):
+    n_chan = 2
+    size_in = 8
+
+    model = torch.nn.Sequential(nn.Conv1d(n_chan, n_chan, kernel_size, padding=padds)).to()
+    model.eval()
+
+    X_input = np.random.rand(5, n_chan, size_in)
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    config = config_from_pytorch_model(model, (n_chan, size_in), channels_last_conversion='full', transpose_outputs=True)
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = convert_from_pytorch_model(
+        model, hls_config=config, output_dir=output_dir, backend='Vivado', io_type='io_parallel'
+    )
+    hls_model.compile()
+
+    hls_prediction = np.reshape(hls_model.predict(X_input), pytorch_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=5e-2)
+
+
+@pytest.mark.parametrize('kernel_size', [3, 4])
+@pytest.mark.parametrize('padds', ['same', 'valid'])
+def test_conv2d_string_padding(test_case_id, kernel_size, padds):
+    n_chan = 2
+    size_in = 8
+
+    model = torch.nn.Sequential(nn.Conv2d(n_chan, n_chan, kernel_size, padding=padds)).to()
+    model.eval()
+
+    X_input = np.random.rand(5, n_chan, size_in, size_in)
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    config = config_from_pytorch_model(
+        model, (n_chan, size_in, size_in), channels_last_conversion='full', transpose_outputs=True
+    )
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = convert_from_pytorch_model(
+        model, hls_config=config, output_dir=output_dir, backend='Vivado', io_type='io_parallel'
+    )
+    hls_model.compile()
+
+    hls_prediction = np.reshape(hls_model.predict(X_input), pytorch_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=5e-2)
+
+
+def test_conv2d_asymmetric_dilation_rejected(test_case_id):
+    model = torch.nn.Sequential(nn.Conv2d(2, 2, 3, dilation=(2, 1)))
+    model.eval()
+
+    with pytest.raises(NotImplementedError, match='dilation'):
+        _convert_parse_only(model, test_case_id, (2, 8, 8))
+
+
+class FunctionalCallModel(nn.Module):
+    """Wraps a function of one tensor, so that it traces as a functional call."""
+
+    def __init__(self, function):
+        super().__init__()
+        self.function = function
+        self.linear = nn.Linear(4, 4)
+
+    def forward(self, x):
+        return self.function(self.linear(x))
+
+
+functional_activations = {
+    'leaky_relu_positional': lambda x: torch.nn.functional.leaky_relu(x, 0.2),
+    'leaky_relu_default': lambda x: torch.nn.functional.leaky_relu(x),
+    'elu_positional': lambda x: torch.nn.functional.elu(x, 0.5),
+    'threshold_positional': lambda x: torch.nn.functional.threshold(x, 0.5, 0.0),
+    'softmax_positional': lambda x: torch.nn.functional.softmax(x, 1),
+}
+
+
+@pytest.mark.parametrize('activation', functional_activations.keys())
+def test_functional_activation_arguments(test_case_id, activation):
+    """Functional activations with positional (or omitted) arguments parse and match torch."""
+    model = FunctionalCallModel(functional_activations[activation])
+    model.eval()
+
+    X_input = np.random.rand(10, 4)
+    X_input = np.round(X_input * 2**10) * 2**-10
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    config = config_from_pytorch_model(model, (4,))
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = convert_from_pytorch_model(
+        model, hls_config=config, output_dir=output_dir, backend='Vivado', io_type='io_parallel'
+    )
+    hls_model.compile()
+
+    hls_prediction = hls_model.predict(X_input)
+    # the table-based softmax is coarser than the other activations at the default precision
+    atol = 0.05 if 'softmax' in activation else 0.01
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=1e-2, atol=atol)
+
+
+@pytest.mark.parametrize('activation', ['relu6_module', 'hardtanh_module', 'relu6_functional', 'hardtanh_functional'])
+def test_clipped_relu_parsed(test_case_id, activation):
+    # ReLU6 and Hardtanh(0, x) are ingested as the ClippedReLU parametrized activation.
+    # No kernel computes it yet; the backends are responsible for rejecting it.
+    if activation == 'relu6_module':
+        model = torch.nn.Sequential(nn.Linear(4, 4), nn.ReLU6())
+        max_value = 6.0
+    elif activation == 'hardtanh_module':
+        model = torch.nn.Sequential(nn.Linear(4, 4), nn.Hardtanh(0.0, 4.0))
+        max_value = 4.0
+    elif activation == 'relu6_functional':
+        model = FunctionalCallModel(lambda x: torch.nn.functional.relu6(x))
+        max_value = 6.0
+    else:
+        model = FunctionalCallModel(lambda x: torch.nn.functional.hardtanh(x, 0.0, 4.0))
+        max_value = 4.0
+    model.eval()
+
+    hls_model = _convert_parse_only(model, test_case_id, (4,))
+
+    act_layer = list(hls_model.get_layers())[-1]
+    assert act_layer.attributes['activation'] == 'clippedrelu'
+    assert act_layer.attributes['activ_param'] == max_value
+
+
+def test_hardtanh_below_zero_rejected(test_case_id):
+    model = torch.nn.Sequential(nn.Linear(4, 4), nn.Hardtanh())  # min_val=-1 by default
+    model.eval()
+
+    with pytest.raises(NotImplementedError, match='min_val'):
+        _convert_parse_only(model, test_case_id, (4,))
+
+
+def test_threshold_replacement_value_rejected(test_case_id):
+    # nn.Threshold(threshold, value) outputs `value` below the threshold; only 0 maps to ThresholdedReLU
+    model = torch.nn.Sequential(nn.Linear(4, 4), nn.Threshold(1.0, 5.0))
+    model.eval()
+
+    with pytest.raises(NotImplementedError, match='replacement value'):
+        _convert_parse_only(model, test_case_id, (4,))
+
+
+class FunctionalPoolModel(nn.Module):
+    """Wraps a pooling function of one tensor, so that it traces as a functional call."""
+
+    def __init__(self, function):
+        super().__init__()
+        self.function = function
+
+    def forward(self, x):
+        return self.function(x)
+
+
+functional_pools = {
+    'max_pool1d_positional': (lambda x: torch.nn.functional.max_pool1d(x, 2, 2), 1),
+    'max_pool2d_default_stride': (lambda x: torch.nn.functional.max_pool2d(x, 2), 2),
+    'avg_pool1d_positional': (lambda x: torch.nn.functional.avg_pool1d(x, 2, 2), 1),
+    'avg_pool2d_no_count_include_pad': (lambda x: torch.nn.functional.avg_pool2d(x, 2, 2, 1, False, False), 2),
+}
+
+
+@pytest.mark.parametrize('pool', functional_pools.keys())
+def test_functional_pooling_arguments(test_case_id, pool):
+    """Functional pooling with positional (or omitted) arguments parses and matches torch."""
+    function, dims = functional_pools[pool]
+    n_chan = 2
+    size_in = 8
+
+    model = FunctionalPoolModel(function)
+    model.eval()
+
+    input_shape = (n_chan, size_in) if dims == 1 else (n_chan, size_in, size_in)
+    X_input = np.random.rand(5, *input_shape)
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    config = config_from_pytorch_model(model, input_shape, channels_last_conversion='full', transpose_outputs=True)
+    output_dir = str(test_root_path / test_case_id)
+    hls_model = convert_from_pytorch_model(
+        model, hls_config=config, output_dir=output_dir, backend='Vivado', io_type='io_parallel'
+    )
+    hls_model.compile()
+
+    hls_prediction = np.reshape(hls_model.predict(X_input), pytorch_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=5e-2)
+
+
+pooling_rejects = {
+    'ceil_mode': (lambda: nn.MaxPool2d(2, ceil_mode=True), 'ceil_mode'),
+    'dilation': (lambda: nn.MaxPool1d(3, stride=1, dilation=2), 'dilation'),
+    'divisor_override': (lambda: nn.AvgPool2d(2, divisor_override=3), 'divisor_override'),
+}
+
+
+@pytest.mark.parametrize('reject', pooling_rejects.keys())
+def test_pooling_option_rejected(test_case_id, reject):
+    layer_factory, match = pooling_rejects[reject]
+    model = torch.nn.Sequential(layer_factory())
+    model.eval()
+
+    input_shape = (2, 8) if '1d' in type(model[0]).__name__.lower() else (2, 8, 8)
+    with pytest.raises(NotImplementedError, match=match):
+        _convert_parse_only(model, test_case_id, input_shape)
+
+
+functional_pooling_rejects = {
+    # signature positions: max_pool(input, kernel_size, stride, padding, dilation, ceil_mode),
+    # avg_pool2d(input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
+    'ceil_mode': (lambda x: torch.nn.functional.max_pool2d(x, 2, 2, 0, 1, True), (2, 8, 8), 'ceil_mode'),
+    'dilation': (lambda x: torch.nn.functional.max_pool1d(x, 3, 1, 0, 2), (2, 8), 'dilation'),
+    'divisor_override': (
+        lambda x: torch.nn.functional.avg_pool2d(x, 2, 2, 0, False, True, 3),
+        (2, 8, 8),
+        'divisor_override',
+    ),
+}
+
+
+@pytest.mark.parametrize('reject', functional_pooling_rejects.keys())
+def test_functional_pooling_option_rejected(test_case_id, reject):
+    """The unsupported pooling options are also rejected when passed positionally to the functional forms."""
+    function, input_shape, match = functional_pooling_rejects[reject]
+    model = FunctionalPoolModel(function)
+    model.eval()
+
+    with pytest.raises(NotImplementedError, match=match):
+        _convert_parse_only(model, test_case_id, input_shape)
+
+
+def test_view_literal_batch_size(test_case_id):
+    """A literal batch size in view() must not corrupt the deduction of a -1 entry."""
+
+    class ViewModel(nn.Module):
+        # the linear layer keeps the reshape from being the final layer, which would be optimized away
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(12, 4)
+
+        def forward(self, x):
+            return self.linear(x.view(4, -1))
+
+    model = ViewModel()
+    model.eval()
+
+    hls_model = _convert_parse_only(model, test_case_id, (2, 6))
+
+    reshape_layer = next(layer for layer in hls_model.get_layers() if layer.attributes['class_name'] == 'Reshape')
+    assert reshape_layer.attributes['target_shape'] == [12]
+
+
+def test_functional_threshold_replacement_value_rejected(test_case_id):
+    model = FunctionalCallModel(lambda x: torch.nn.functional.threshold(x, 0.5, 5.0))
+    model.eval()
+
+    with pytest.raises(NotImplementedError, match='replacement value'):
+        _convert_parse_only(model, test_case_id, (4,))

--- a/test/pytest/test_recurrent_pytorch.py
+++ b/test/pytest/test_recurrent_pytorch.py
@@ -225,3 +225,321 @@ def test_rnn(test_case_id, backend, io_type):
         hls_prediction = np.reshape(hls_model.predict([X_input.detach().numpy(), h0.detach().numpy()]), (1, 1, 20))
 
         np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=1e-1)
+
+
+# ---------------------------------------------------------------------------- #
+# Which element of the RNN output tuple the model consumes decides between the
+# full output sequence and the final hidden state; unrepresentable uses raise.
+# ---------------------------------------------------------------------------- #
+
+n_in = 8
+n_hidden = 12
+n_timesteps = 3
+
+
+class SequenceModel(nn.Module):
+    """Consumes the full output sequence (element 0 of the RNN output tuple)."""
+
+    def __init__(self, rnn_cls):
+        super().__init__()
+        self.rnn = rnn_cls(n_in, n_hidden, num_layers=1, batch_first=True)
+
+    def forward(self, x):
+        output, _ = self.rnn(x)
+        return output
+
+
+class StackedSequenceModel(nn.Module):
+    """Feeds the output sequence of one recurrent layer into another."""
+
+    def __init__(self):
+        super().__init__()
+        self.rnn1 = nn.GRU(n_in, n_hidden, num_layers=1, batch_first=True)
+        self.rnn2 = nn.GRU(n_hidden, n_hidden, num_layers=1, batch_first=True)
+
+    def forward(self, x):
+        output, _ = self.rnn1(x)
+        output, _ = self.rnn2(output)
+        return output
+
+
+class GRUStateModel(nn.Module):
+    """Consumes the final hidden state (element 1 of the RNN output tuple)."""
+
+    def __init__(self):
+        super().__init__()
+        self.rnn = nn.GRU(n_in, n_hidden, num_layers=1, batch_first=True)
+
+    def forward(self, x):
+        _, state = self.rnn(x)
+        return state
+
+
+class LSTMStateModel(nn.Module):
+    """Consumes the final hidden state of an LSTM (element [1][0] of the output tuple)."""
+
+    def __init__(self):
+        super().__init__()
+        self.rnn = nn.LSTM(n_in, n_hidden, num_layers=1, batch_first=True)
+
+    def forward(self, x):
+        _, (hidden_state, _) = self.rnn(x)
+        return hidden_state
+
+
+def _quantized_random(shape):
+    x = np.random.rand(*shape) - 0.5
+    return np.round(x * 2**16) * 2**-16  # make it exact fixed<32,16>
+
+
+def _convert(model, test_case_id, backend, input_shape=(None, n_timesteps, n_in)):
+    config = config_from_pytorch_model(
+        model,
+        input_shape,
+        channels_last_conversion='off',
+        transpose_outputs=False,
+        default_precision='fixed<32,16>',
+    )
+    output_dir = str(test_root_path / test_case_id)
+    return convert_from_pytorch_model(
+        model, hls_config=config, output_dir=output_dir, backend=backend, io_type='io_parallel'
+    )
+
+
+@pytest.mark.parametrize(
+    'rnn_cls,backend',
+    [(nn.GRU, 'Vivado'), (nn.LSTM, 'Vivado'), (nn.RNN, 'Quartus')],
+    ids=['gru', 'lstm', 'rnn'],
+)
+def test_rnn_sequence_output(test_case_id, rnn_cls, backend):
+    model = SequenceModel(rnn_cls)
+    model.eval()
+
+    X_input = _quantized_random((5, n_timesteps, n_in))
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    hls_model = _convert(model, test_case_id, backend)
+    assert list(hls_model.get_layers())[1].attributes['return_sequences'] is True
+    hls_model.compile()
+
+    hls_prediction = np.reshape(hls_model.predict(X_input), pytorch_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=2e-2)
+
+
+def test_rnn_stacked_sequence_output(test_case_id):
+    model = StackedSequenceModel()
+    model.eval()
+
+    X_input = _quantized_random((5, n_timesteps, n_in))
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    hls_model = _convert(model, test_case_id, 'Vivado')
+    hls_model.compile()
+
+    hls_prediction = np.reshape(hls_model.predict(X_input), pytorch_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=2e-2)
+
+
+@pytest.mark.parametrize('state_model', [GRUStateModel, LSTMStateModel], ids=['gru', 'lstm'])
+def test_rnn_state_output(test_case_id, state_model):
+    model = state_model()
+    model.eval()
+
+    X_input = _quantized_random((5, n_timesteps, n_in))
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()[0]  # (num_layers, batch, hidden) -> (batch, hidden)
+
+    hls_model = _convert(model, test_case_id, 'Vivado')
+    assert list(hls_model.get_layers())[1].attributes['return_sequences'] is False
+    hls_model.compile()
+
+    hls_prediction = np.reshape(hls_model.predict(X_input), pytorch_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=2e-2)
+
+
+def test_lstm_cell_state_rejected(test_case_id):
+    class CellStateModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rnn = nn.LSTM(n_in, n_hidden, num_layers=1, batch_first=True)
+
+        def forward(self, x):
+            _, (_, cell_state) = self.rnn(x)
+            return cell_state
+
+    model = CellStateModel()
+    model.eval()
+
+    with pytest.raises(NotImplementedError, match='cell state'):
+        _convert(model, test_case_id, 'Vivado')
+
+
+def test_rnn_sequence_and_state_rejected(test_case_id):
+    class BothOutputsModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rnn = nn.GRU(n_in, n_hidden, num_layers=1, batch_first=True)
+
+        def forward(self, x):
+            output, state = self.rnn(x)
+            return output, state
+
+    model = BothOutputsModel()
+    model.eval()
+
+    with pytest.raises(NotImplementedError, match='both the output sequence and the final state'):
+        _convert(model, test_case_id, 'Vivado')
+
+
+def test_rnn_sliced_output_rejected(test_case_id):
+    class SlicedOutputModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rnn = nn.GRU(n_in, n_hidden, num_layers=1, batch_first=True)
+
+        def forward(self, x):
+            output, _ = self.rnn(x)
+            return output[:, -1, :]
+
+    model = SlicedOutputModel()
+    model.eval()
+
+    with pytest.raises(NotImplementedError, match='slicing'):
+        _convert(model, test_case_id, 'Vivado')
+
+
+def test_lstm_proj_size_rejected(test_case_id):
+    class ProjectedLSTMModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rnn = nn.LSTM(n_in, n_hidden, num_layers=1, batch_first=True, proj_size=4)
+
+        def forward(self, x):
+            _, (hidden_state, _) = self.rnn(x)
+            return hidden_state
+
+    model = ProjectedLSTMModel()
+    model.eval()
+
+    with pytest.raises(NotImplementedError, match='proj_size'):
+        _convert(model, test_case_id, 'Vivado')
+
+
+@pytest.mark.parametrize('rnn_cls', [nn.RNN, nn.LSTM, nn.GRU], ids=['rnn', 'lstm', 'gru'])
+def test_rnn_no_bias(test_case_id, rnn_cls):
+    class NoBiasModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rnn = rnn_cls(n_in, n_hidden, num_layers=1, batch_first=True, bias=False)
+
+        def forward(self, x):
+            output, _ = self.rnn(x)
+            return output
+
+    model = NoBiasModel()
+    model.eval()
+
+    X_input = _quantized_random((5, n_timesteps, n_in))
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    backend = 'Quartus' if rnn_cls is nn.RNN else 'Vivado'
+    hls_model = _convert(model, test_case_id, backend)
+    hls_model.compile()
+
+    hls_prediction = np.reshape(hls_model.predict(X_input), pytorch_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=2e-2)
+
+
+def test_rnn_sequence_functional_consumer(test_case_id):
+    """A functional call consuming the RNN output tuple resolves to the sequence output."""
+
+    class FunctionalConsumerModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rnn = nn.GRU(n_in, n_hidden, num_layers=1, batch_first=True)
+
+        def forward(self, x):
+            output, _ = self.rnn(x)
+            return torch.nn.functional.relu(output)
+
+    model = FunctionalConsumerModel()
+    model.eval()
+
+    X_input = _quantized_random((5, n_timesteps, n_in))
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    hls_model = _convert(model, test_case_id, 'Vivado')
+    hls_model.compile()
+
+    hls_prediction = np.reshape(hls_model.predict(X_input), pytorch_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=2e-2)
+
+
+def test_rnn_sequence_method_consumer(test_case_id):
+    """A method call consuming the RNN output tuple resolves to the sequence output."""
+
+    class MethodConsumerModel(nn.Module):
+        # note: no Linear here on purpose — with channels_last_conversion='off' PyTorch Dense
+        # weights are never transposed (pre-existing upstream bug, reported separately)
+        def __init__(self):
+            super().__init__()
+            self.rnn = nn.GRU(n_in, n_hidden, num_layers=1, batch_first=True)
+
+        def forward(self, x):
+            output, _ = self.rnn(x)
+            return torch.nn.functional.relu(output.flatten(1))
+
+    model = MethodConsumerModel()
+    model.eval()
+
+    X_input = _quantized_random((5, n_timesteps, n_in))
+    pytorch_prediction = model(torch.Tensor(X_input)).detach().numpy()
+
+    hls_model = _convert(model, test_case_id, 'Vivado')
+    hls_model.compile()
+
+    hls_prediction = np.reshape(hls_model.predict(X_input), pytorch_prediction.shape)
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=0, atol=2e-2)
+
+
+def test_rnn_state_as_initial_state(test_case_id):
+    """The final state of one RNN used as the initial state of another parses with both inputs wired."""
+
+    class StateChainModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.gru1 = nn.GRU(n_in, n_hidden, num_layers=1, batch_first=True)
+            self.gru2 = nn.GRU(n_in, n_hidden, num_layers=1, batch_first=True)
+
+        def forward(self, x):
+            _, state = self.gru1(x)
+            output, _ = self.gru2(x, state)
+            return output
+
+    model = StateChainModel()
+    model.eval()
+
+    hls_model = _convert(model, test_case_id, 'Vivado')
+
+    gru2_layer = next(layer for layer in hls_model.get_layers() if layer.name == 'gru2')
+    assert gru2_layer.attributes['pass_initial_states'] is True
+    assert gru2_layer.attributes['return_sequences'] is True
+    gru1_layer = next(layer for layer in hls_model.get_layers() if layer.name == 'gru1')
+    assert gru1_layer.attributes['return_sequences'] is False
+
+
+def test_rnn_output_tuple_returned(test_case_id):
+    """A model that returns the RNN output tuple unchanged parses as a final-state output."""
+
+    class TupleReturnModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rnn = nn.GRU(n_in, n_hidden, num_layers=1, batch_first=True)
+
+        def forward(self, x):
+            return self.rnn(x)
+
+    model = TupleReturnModel()
+    model.eval()
+
+    hls_model = _convert(model, test_case_id, 'Vivado')
+    assert list(hls_model.get_layers())[1].attributes['return_sequences'] is False

--- a/test/pytest/test_upsampling_pytorch.py
+++ b/test/pytest/test_upsampling_pytorch.py
@@ -102,3 +102,99 @@ def test_pytorch_upsampling2d(test_case_id, data_2d, io_type, backend):
     hls_prediction = hls_model.predict(data_2d).flatten()
 
     np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=1e-2, atol=0.01)
+
+
+class UpsampleSizeModel(nn.Module):
+    """Upsampling specified through the target size instead of a scale factor."""
+
+    def __init__(self):
+        super().__init__()
+        self.upsample = nn.Upsample(size=in_width * 2)
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        return self.relu(self.upsample(x))
+
+
+@pytest.mark.parametrize('backend', ['Vivado'])
+def test_pytorch_upsampling_size(test_case_id, data_1d, backend):
+    model = UpsampleSizeModel()
+
+    config = hls4ml.utils.config_from_pytorch_model(
+        model,
+        (None, in_feat, in_width),
+        default_precision='ap_fixed<16,6>',
+        channels_last_conversion='internal',
+        transpose_outputs=False,
+    )
+    odir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_pytorch_model(
+        model, hls_config=config, io_type='io_parallel', output_dir=odir, backend=backend
+    )
+    hls_model.compile()
+
+    data_1d_t = np.ascontiguousarray(data_1d.transpose([0, 2, 1]))
+
+    pytorch_prediction = model(torch.Tensor(data_1d)).detach().numpy()
+    hls_prediction = hls_model.predict(data_1d_t)
+
+    pred_shape = list(pytorch_prediction.shape)
+    pred_shape.append(pred_shape.pop(1))  # Transpose shape to channels_last
+    hls_prediction = hls_prediction.reshape(pred_shape).transpose([0, 2, 1])  # Transpose back
+
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=1e-2, atol=0.01)
+
+
+def test_pytorch_upsampling_fractional_size_rejected(test_case_id):
+    class FractionalSizeModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.upsample = nn.Upsample(size=in_width + 2)  # not a multiple of the input size
+
+        def forward(self, x):
+            return self.upsample(x)
+
+    model = FractionalSizeModel()
+
+    odir = str(test_root_path / test_case_id)
+    with pytest.raises(NotImplementedError, match='integer multiple'):
+        # config_from_pytorch_model traces the model too, so the reject can fire already there
+        config = hls4ml.utils.config_from_pytorch_model(
+            model, (None, in_feat, in_width), channels_last_conversion='internal', transpose_outputs=False
+        )
+        hls4ml.converters.convert_from_pytorch_model(
+            model, hls_config=config, io_type='io_parallel', output_dir=odir, backend='Vivado'
+        )
+
+
+class Upsample2DSizeModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.upsample = nn.UpsamplingNearest2d(size=(in_height * 2, in_width * 3))
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        return self.relu(self.upsample(x))
+
+
+@pytest.mark.parametrize('backend', ['Vivado'])
+def test_pytorch_upsampling2d_size(test_case_id, data_2d, backend):
+    model = Upsample2DSizeModel()
+
+    config = hls4ml.utils.config_from_pytorch_model(
+        model,
+        (in_feat, in_height, in_width),
+        default_precision='ap_fixed<16,6>',
+        channels_last_conversion='full',
+        transpose_outputs=True,
+    )
+    odir = str(test_root_path / test_case_id)
+    hls_model = hls4ml.converters.convert_from_pytorch_model(
+        model, hls_config=config, io_type='io_parallel', output_dir=odir, backend=backend
+    )
+    hls_model.compile()
+
+    pytorch_prediction = model(torch.Tensor(data_2d)).detach().numpy().flatten()
+    hls_prediction = hls_model.predict(data_2d).flatten()
+
+    np.testing.assert_allclose(hls_prediction, pytorch_prediction, rtol=1e-2, atol=0.01)


### PR DESCRIPTION
# PyTorch frontend: stop silently misparsing unsupported layer configurations

## Description

This PR is the PyTorch half of the frontend audit for silent misparses started in the Keras parser PR (it is branched on top of that PR and should be rebased once it merges; the last two commits are the ones to review). The rule applied is the same: **never convert a model that computes different math than the one that was trained.**

**Fixed** (previously computed wrong values, or crashed far from the cause):

- *`'same'` padding*: the PyTorch padding helpers hard-coded `pad_top = 1`, used an output-size formula only correct for kernel size 3, and put the odd padding pixel on the opposite side from PyTorch — every `Conv1d(padding='same')` with kernel size other than 3 computed wrong values. `Conv2d` with string padding never reached the helper at all (it indexed into the string, `pad_top = 's'`). The `'same'` branches now implement PyTorch's actual convention (total padding `dilation * (kernel - 1)`, extra pixel on the bottom/right, stride 1 only, output size = input size), and `Conv2d` takes all four pads from the helper.
- *Which element of the RNN output tuple is consumed*: `nn.RNN/LSTM/GRU` return `(sequence, state)`, but the tracer discarded the index — `out, _ = self.lstm(x)` followed by per-timestep layers silently computed on the **last hidden state only**. The parser now inspects the consumed indices: the sequence output sets `return_sequences=True` (with the correct output shape), the final hidden state keeps the previous behavior, and stacked RNNs consuming the sequence output now convert (previously a `KeyError`). Consuming the LSTM cell state, consuming both tuple elements, or slicing the outputs raises a clear error.
- *RNN `bias=False`*: crashed with `AttributeError` (the bias tensors do not exist on the module), and the zeros substitute below the crash used the wrong dimension (the input width instead of the gate width).
- *Scalar merge operands*: the pre-pass that turns scalars in `add/mul/sub` into constant inputs always replaced argument 1 — `2 - x` replaced `x` and kept the scalar, computing garbage — and the merge output shape was copied from input 0, which for a scalar-first expression is the size-1 constant. The scalar's actual position is now used and the output shape comes from the tensor input.
- *`torch.cat` with a positional `dim`*: the dimension was read only from kwargs and defaulted to 0 (the batch axis), so `torch.cat([a, b], 1)` crashed (or, with a numeric batch entry, would have been silently wrong).
- *Functional calls with positional or omitted arguments*: `F.leaky_relu(x, 0.2)`, `F.elu(x, 0.5)`, `F.threshold(x, t, v)`, `F.softmax(x, dim)` and the functional poolings read their parameters only from kwargs — positional spellings crashed with `KeyError`, and `F.leaky_relu(x)` (defaults) crashed too. All of them now read positional-or-keyword with the correct defaults. The functional average poolings also hard-coded `count_include_pad=True`; the flag is now honored.
- *`view` with a literal batch size*: `x.view(4, -1)` included the literal batch in the `-1` deduction, producing a wrong dimension. The batch entry is now dropped before deducing.
- *`nn.Upsample(size=...)`*: `scale_factor` is `None` in this form, crashing with a `TypeError`. The output size is now taken from `size` when it is an integer multiple of the input size, and rejected otherwise.
- *`LayerNorm(elementwise_affine=False)`* (and `bias=False`): fed `None` weight data into the graph; identity values are now substituted, mirroring the Keras-side `center`/`scale` fix.

**Ingested faithfully into the IR** (matching the Keras PR; backend-side rejection is the immediate follow-up):

- *`nn.ReLU6`, `nn.Hardtanh(0, x)` and `F.relu6`*: previously rejected as unsupported layers; now ingested as the `ClippedReLU` parametrized activation introduced by the Keras parser PR. `Hardtanh` with `min_val != 0` stays rejected (it is not a clipped ReLU).

**Rejected with a clear error** (previously silently wrong):

- *`nn.Threshold(threshold, value)` with `value != 0`*: the layer outputs `value` below the threshold, but only the `value == 0` case maps to `ThresholdedReLU`; the value was silently dropped.
- *`LSTM(proj_size > 0)`*: the projection weights were ignored, giving shape mismatches downstream.
- *`BatchNorm*(track_running_stats=False)`*: normalizes with per-batch statistics even in eval mode, which no hls4ml kernel can represent.
- *Pooling with `ceil_mode=True`* (output sizes were silently computed with floor), *max pooling with `dilation != 1`* (silently ignored), *`AvgPool2d(divisor_override=...)`* (silently ignored).
- *`Conv2d` with different dilation factors per dimension*: the second factor was silently dropped (the IR carries a single dilation value, same as the Keras-side reject).
- *`torch.cat` along the batch dimension*, and *broadcasting in elementwise merges* (mismatched non-scalar shapes had the output shape of input 0 silently assumed).

The audit items that overlap open PRs are left out: the `unsqueeze` insert-position bug is fixed by #1496, and grouped/depthwise conv routing was already handled for PyTorch by #1524.

Relates to #1521, #1524, #1496 and the Keras parser audit PR.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (existing configs, APIs or generated code behave differently)
- [ ] New frontend / backend
- [ ] New layer / operator support
- [ ] New configuration option — a new `io_type`, Strategy, or config attribute
- [ ] Research paper implementation
- [ ] Documentation
- [ ] Build, CI or tooling
- [ ] Refactor / cleanup (no functional change)

## Affected areas

**Backends:**
- [x] None directly

**Frontends:**
- [x] PyTorch
- [ ] Not related to a frontend

**Components:**
- [ ] IR (layers + model graph) / optimizer passes
- [ ] C++ templates / HLS sources under `hls4ml/templates/`
- [ ] Profiling, reporting or the CLI
- [ ] Packaging, build or CI

## Configurations affected and exercised

| Backend | `io_type` | Strategy | Verified |
|---|---|---|---|
| all (parsing is backend-independent) | all | all | pytest (C simulation) with Vivado backend |

*The SimpleRNN numeric tests run on the Quartus backend, due to the known behavior of the Vivado SimpleRNN kernel.*

**New configuration axis introduced by this PR**: none. The `ClippedReLU` activation (introduced in the Keras parser PR) becomes reachable from the PyTorch frontend; no backend computes it yet, and the backend-rejection follow-up covers it for both frontends at once.

## Impact on generated HLS

- [ ] This PR **does not change** the generated HLS for existing models.
- [x] This PR **changes** the generated HLS. Numbers below.

**Numerical behaviour:** Only models using the affected configurations are impacted: (1) configurations listed under "rejected" no longer produce (wrong) generated code — conversion raises; (2) previously-wrong configurations (`'same'` padding with kernel size ≠ 3, sequence-consuming RNN models, scalar-first merges, functional average pooling with `count_include_pad=False`, `view` with a literal batch size) and previously-crashing ones (string-padded `Conv2d`, positional functional arguments, `bias=False` RNNs, `Upsample(size=...)`, `LayerNorm` without affine parameters, stacked RNNs) now generate correct code, verified against PyTorch predictions by C simulation. Models not using any affected configuration generate identical code. No synthesis was run — this is a frontend/parse-level change; the resource/latency table is deliberately left out.

## Tests

- `test_pytorch_api.py`: `'same'`/`'valid'` string padding swept over kernel sizes 1–7 (1D) and 3–4 (2D) against PyTorch predictions; functional activations and poolings with positional or omitted arguments (numeric); ReLU6/Hardtanh ingestion as ClippedReLU (parse assertions); rejects for asymmetric dilation, `Hardtanh(min_val != 0)`, `Threshold(value != 0)`, `ceil_mode`, pooling `dilation`, `divisor_override`; `view` literal-batch deduction.
- `test_recurrent_pytorch.py`: sequence-consuming models (`return_sequences=True`) for GRU/LSTM (Vivado) and SimpleRNN (Quartus) with more than one timestep, a stacked GRU on the sequence output, functional (`F.relu`) and method (`.flatten`) consumers of the sequence output, state-consuming models for GRU and LSTM, one RNN's final state as another's initial state (parse), `bias=False` for all three cells — all numeric against PyTorch except the state-chaining parse check; rejects for the cell state, both-outputs, sliced-output and `proj_size` patterns. (The pre-existing tests in this file consume the sequence output with a single timestep, which is why the misparse was invisible; they now parse as `return_sequences=True` and still pass unmodified.)
- `test_merge_pytorch.py`: scalar operands in both positions (`x+2.5`, `x-2.5`, `2.5-x`, `x*0.5`, numeric), positional `torch.cat` dim (numeric), rejects for batch-axis concatenation and non-scalar broadcasting.
- `test_batchnorm_pytorch.py` / `test_layernorm_pytorch.py` / `test_upsampling_pytorch.py`: `track_running_stats=False` reject; `elementwise_affine=False` numeric; `Upsample(size=...)` numeric and the non-integer-multiple reject.

**Test configuration** (OS, Python, ML framework version, HLS tool version): Linux (EL9), Python 3.11, PyTorch (CPU). C simulation via g++; no HLS tool involved.

## Breaking changes and migration

**What breaks:** Models using a configuration listed under "rejected" above previously converted silently (computing the wrong function) or crashed with a confusing error, and now raise `NotImplementedError` naming the layer and option. Models that consumed the RNN sequence output previously produced a last-state-only layer; they now convert to the sequence-producing layer they actually describe, so downstream shapes change to the correct ones.

**How users migrate:** Remove or replace the unsupported option (e.g. `ceil_mode=False`, `reset_after`-style retraining is not needed here; for RNNs consume either the sequence or the final state, not both). Models that do not use any affected option are unaffected.

## AI assistance disclosure

- [ ] **None** — no AI tool was used.
- [ ] **Assisted** — completion, refactoring, docstrings, tests; design and code are mine.
- [ ] **Substantial** — significant AI-generated portions, reviewed and edited by me.
- [x] **Agentic** — produced largely end-to-end by an AI agent from my prompts.

Tool(s) and model(s): Claude Code (Fable 5)

Where it was used: the full branch — frontend audit, parser changes and all tests — under prompt-level direction and review of the scope decisions (what is fixed vs ingested vs rejected, test organization) by the author.

If anything other than *None* is ticked, confirm all of the following:

- [x] **I am the author of this contribution and take full responsibility for it.** I have read and understood every line and can explain and defend it in review.
- [x] I verified the generated code against real hls4ml and HLS semantics — no invented APIs, config keys, pragmas or citations.
- [x] All numbers, logs and test results quoted in this PR come from runs I actually performed, not from agent output.
- [x] I have the right to submit this work under the project's licence, and to my knowledge it does not reproduce third-party code that would conflict with it.
- [x] No AI tool is credited as an author in any commit in this branch.

## Checklist

**Required:**
- [x] I have read the [contributing guidelines](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I installed and ran `pre-commit` on the files I edited.
- [x] I added tests under `test/pytest` covering this change (a bug fix should add a test that fails on `main` and passes here).
- [x] I self-reviewed the full diff and it contains no leftover debug code, commented-out blocks or unrelated changes.
- [x] The AI assistance disclosure above is complete and accurate.

**If applicable:**
- [x] Documentation under `docs/` updated.
- [ ] No new build or synthesis warnings.
- [ ] Public API / config schema changes are documented.

## Release note

```release-note
Fixed several PyTorch parser bugs, notably 'same' padding and RNN output handling; PyTorch layer options that hls4ml cannot faithfully implement now raise an error at conversion time instead of being silently misparsed.
```
