### PR TITLE
patch einsum, leakyrelu name

### DIFF
--- a/hls4ml/model/optimizer/passes/bit_exact.py
+++ b/hls4ml/model/optimizer/passes/bit_exact.py
@@ -693,7 +693,7 @@ def _(layer: Activation):
             i = np.minimum(i, 1)
             f = np.full_like(f, 126, dtype=np.int16)
         case _:
-            k = np.ones(k, dtype=np.int16)
+            k = np.ones_like(k, dtype=np.int16)
             i = np.full_like(i, 126, dtype=np.int16)
             f = np.full_like(f, 126, dtype=np.int16)
     return k, i, f
@@ -707,7 +707,7 @@ def _(layer: ParametrizedActivation):
     p = layer.attributes['activ_param']
     _k, _i, _f = minimal_kif(np.array(p))
     match fn_name:
-        case 'leakyrelu':
+        case 'leakyrelu' | 'leaky_relu':
             k = k & np.int16(p > 0)
             i += np.maximum(0, _i - 1)
             f += np.maximum(0, _f)
@@ -720,7 +720,7 @@ def _(layer: ParametrizedActivation):
             f = np.full_like(f, 126, dtype=np.int16)
             i = np.maximum(i, _i)
         case _:
-            k = np.ones(k, dtype=np.int16)
+            k = np.ones_like(k, dtype=np.int16)
             i = np.full_like(i, 126, dtype=np.int16)
             f = np.full_like(f, 126, dtype=np.int16)
     return k, i, f

--- a/hls4ml/utils/qinterval.py
+++ b/hls4ml/utils/qinterval.py
@@ -255,6 +255,21 @@ def _exec_einsum(recipe: EinsumRecipe, input0: np.ndarray | QIntervalArray, inpu
     Returns:
         np.ndarray: output array.
     """
+
+    def direct_sum(array, axes):
+        if not axes:
+            return array
+        if isinstance(array, QIntervalArray):
+            return QIntervalArray(
+                np.sum(array.min, axis=axes),
+                np.sum(array.max, axis=axes),
+                np.min(array.delta, axis=axes),
+            )
+        return np.sum(array, axis=axes)
+
+    sum_axis0, sum_axis1 = recipe['direct_sum_axis']
+    input0 = direct_sum(input0, sum_axis0)
+    input1 = direct_sum(input1, sum_axis1)
     input0 = input0.transpose(recipe['in_transpose_idxs'][0]).ravel()
     input1 = input1.transpose(recipe['in_transpose_idxs'][1]).ravel()
     # output = np.zeros(recipe['L0'] * recipe['L1'] * recipe['I'], dtype=input0.dtype)

--- a/hls4ml/utils/qinterval.py
+++ b/hls4ml/utils/qinterval.py
@@ -256,22 +256,28 @@ def _exec_einsum(recipe: EinsumRecipe, input0: np.ndarray | QIntervalArray, inpu
         np.ndarray: output array.
     """
 
-    def direct_sum(array, axes):
+    def direct_sum(array, axes, transpose_axes):
         if not axes:
-            return array
+            return array, transpose_axes
         if isinstance(array, QIntervalArray):
-            return QIntervalArray(
+            array = QIntervalArray(
                 np.sum(array.min, axis=axes),
                 np.sum(array.max, axis=axes),
                 np.min(array.delta, axis=axes),
             )
-        return np.sum(array, axis=axes)
+        else:
+            array = np.sum(array, axis=axes)
+
+        # The recipe stores axes in the original inputs. Renumber the
+        # transpose axes after removing the direct-sum dimensions.
+        transpose_axes = tuple(axis - sum(reduced < axis for reduced in axes) for axis in transpose_axes)
+        return array, transpose_axes
 
     sum_axis0, sum_axis1 = recipe['direct_sum_axis']
-    input0 = direct_sum(input0, sum_axis0)
-    input1 = direct_sum(input1, sum_axis1)
-    input0 = input0.transpose(recipe['in_transpose_idxs'][0]).ravel()
-    input1 = input1.transpose(recipe['in_transpose_idxs'][1]).ravel()
+    input0, transpose0 = direct_sum(input0, sum_axis0, recipe['in_transpose_idxs'][0])
+    input1, transpose1 = direct_sum(input1, sum_axis1, recipe['in_transpose_idxs'][1])
+    input0 = input0.transpose(transpose0).ravel()
+    input1 = input1.transpose(transpose1).ravel()
     # output = np.zeros(recipe['L0'] * recipe['L1'] * recipe['I'], dtype=input0.dtype)
     output = []
 

--- a/test/pytest/test_bit_exact_parametrized_activation.py
+++ b/test/pytest/test_bit_exact_parametrized_activation.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from hls4ml.model.layers import ParametrizedActivation
+from hls4ml.model.optimizer.passes import bit_exact
+
+
+def test_produce_kif_accepts_keras_leaky_relu_name(monkeypatch):
+    """Keras uses ``leaky_relu`` rather than the legacy ``leakyrelu`` name."""
+    input_kif = (
+        np.array([1, 0], dtype=np.int16),
+        np.array([2, 2], dtype=np.int16),
+        np.array([3, 3], dtype=np.int16),
+    )
+    monkeypatch.setattr(bit_exact, 'get_input_kifs', lambda _: (input_kif,))
+
+    def produce(activation_name):
+        layer = object.__new__(ParametrizedActivation)
+        layer.attributes = {'activation': activation_name, 'activ_param': 0.25}
+        return bit_exact._produce_kif(layer)
+
+    legacy_result = produce('leakyrelu')
+    keras_result = produce('leaky_relu')
+
+    for legacy_value, keras_value in zip(legacy_result, keras_result):
+        np.testing.assert_array_equal(keras_value, legacy_value)

--- a/test/pytest/test_bit_exact_parametrized_activation.py
+++ b/test/pytest/test_bit_exact_parametrized_activation.py
@@ -1,25 +1,46 @@
 import numpy as np
+import pytest
 
-from hls4ml.model.layers import ParametrizedActivation
+from hls4ml.model.layers import Activation, ParametrizedActivation
 from hls4ml.model.optimizer.passes import bit_exact
 
 
-def test_produce_kif_accepts_keras_leaky_relu_name(monkeypatch):
-    """Keras uses ``leaky_relu`` rather than the legacy ``leakyrelu`` name."""
-    input_kif = (
+@pytest.fixture
+def input_kif(monkeypatch):
+    value = (
         np.array([1, 0], dtype=np.int16),
         np.array([2, 2], dtype=np.int16),
         np.array([3, 3], dtype=np.int16),
     )
-    monkeypatch.setattr(bit_exact, 'get_input_kifs', lambda _: (input_kif,))
+    monkeypatch.setattr(bit_exact, 'get_input_kifs', lambda _: (tuple(v.copy() for v in value),))
+    return value
 
-    def produce(activation_name):
-        layer = object.__new__(ParametrizedActivation)
-        layer.attributes = {'activation': activation_name, 'activ_param': 0.25}
-        return bit_exact._produce_kif(layer)
 
-    legacy_result = produce('leakyrelu')
-    keras_result = produce('leaky_relu')
+def make_layer(layer_type, activation, **attributes):
+    layer = object.__new__(layer_type)
+    layer.attributes = {'activation': activation, **attributes}
+    return layer
 
-    for legacy_value, keras_value in zip(legacy_result, keras_result):
-        np.testing.assert_array_equal(keras_value, legacy_value)
+
+def test_produce_kif_accepts_keras_leaky_relu_name(input_kif):
+    """Keras uses ``leaky_relu`` rather than the legacy ``leakyrelu`` name."""
+    layer = make_layer(ParametrizedActivation, 'leaky_relu', activ_param=0.25)
+
+    k, i, f = bit_exact._produce_kif(layer)
+
+    np.testing.assert_array_equal(k, input_kif[0])
+    np.testing.assert_array_equal(i, input_kif[1])
+    np.testing.assert_array_equal(f, input_kif[2] + 2)
+
+
+@pytest.mark.parametrize(
+    'layer',
+    [make_layer(Activation, 'unknown'), make_layer(ParametrizedActivation, 'unknown', activ_param=0.25)],
+    ids=['activation', 'parametrized_activation'],
+)
+def test_produce_kif_fallback_preserves_shape_and_dtype(input_kif, layer):
+    k, i, f = bit_exact._produce_kif(layer)
+
+    for value in (k, i, f):
+        assert value.shape == input_kif[0].shape
+        assert value.dtype == np.int16

--- a/test/pytest/test_qinterval.py
+++ b/test/pytest/test_qinterval.py
@@ -94,20 +94,27 @@ def test_qinterval_einsum(qint_arr1, qint_arr2, eq):
     assert_is_represented(einsum_symbolic, einsum_sampled)
 
 
-@pytest.mark.parametrize('eq, input0_shape', [('ji,jk->k', (3, 2)), ('ij,jk->i', (2, 3))])
-def test_qinterval_einsum_direct_sum(eq, input0_shape):
-    """Axes present in only one input must be summed before contraction."""
-    input0 = np.arange(6, dtype=float).reshape(input0_shape)
-    input1 = np.arange(12, dtype=float).reshape(3, 4)
-    expected = np.einsum(eq, input0, input1)
-
-    interval0 = QIntervalArray(input0, input0, np.ones_like(input0))
-    interval1 = QIntervalArray(input1, input1, np.ones_like(input1))
+@pytest.mark.parametrize('eq', ['ij,jk->k', 'ji,jk->k', 'ij,jk->i', 'ij,kj->i', 'ij,kl->'])
+def test_qinterval_einsum_direct_sum(eq):
+    """Direct sums on either input and at any axis preserve sampled results."""
+    inputs, out = eq.split('->', 1)
+    in0, in1 = inputs.split(',')
+    interval0 = random_arr(seed=1)[:3, :3]
+    interval1 = random_arr(seed=2)[:3, :3]
+    sampled0 = interval0.sample(1000)
+    sampled1 = interval1.sample(1000)
 
     result = einsum(eq, interval0, interval1)
+    expected = np.einsum(f'A{in0},A{in1}->A{out}', sampled0, sampled1)
+    assert_is_represented(result, expected)
 
-    np.testing.assert_array_equal(result.min, expected)
-    np.testing.assert_array_equal(result.max, expected)
+    result = einsum(eq, interval0, sampled1[0])
+    expected = np.einsum(f'A{in0},{in1}->A{out}', sampled0, sampled1[0])
+    assert_is_represented(result, expected)
+
+    result = einsum(eq, sampled0[0], interval1)
+    expected = np.einsum(f'{in0},A{in1}->A{out}', sampled0[0], sampled1)
+    assert_is_represented(result, expected)
 
 
 def test_qinterval_to_kif(qint_arr1):

--- a/test/pytest/test_qinterval.py
+++ b/test/pytest/test_qinterval.py
@@ -94,6 +94,22 @@ def test_qinterval_einsum(qint_arr1, qint_arr2, eq):
     assert_is_represented(einsum_symbolic, einsum_sampled)
 
 
+@pytest.mark.parametrize('eq, input0_shape', [('ji,jk->k', (3, 2)), ('ij,jk->i', (2, 3))])
+def test_qinterval_einsum_direct_sum(eq, input0_shape):
+    """Axes present in only one input must be summed before contraction."""
+    input0 = np.arange(6, dtype=float).reshape(input0_shape)
+    input1 = np.arange(12, dtype=float).reshape(3, 4)
+    expected = np.einsum(eq, input0, input1)
+
+    interval0 = QIntervalArray(input0, input0, np.ones_like(input0))
+    interval1 = QIntervalArray(input1, input1, np.ones_like(input1))
+
+    result = einsum(eq, interval0, interval1)
+
+    np.testing.assert_array_equal(result.min, expected)
+    np.testing.assert_array_equal(result.max, expected)
+
+
 def test_qinterval_to_kif(qint_arr1):
     k, i, f = qint_arr1.to_kif()
     samples = qint_arr1.sample(10000)


### PR DESCRIPTION
# Description

## Summary

This PR fixes two issues in bit-exact precision and interval propagation:

- Recognizes both `leakyrelu` and `leaky_relu` activation names when inferring precision for `ParametrizedActivation`.
- Correctly applies direct-sum axes when propagating numeric and quantized intervals through Einsum operations.
- Uses `np.ones_like` when constructing fallback signedness arrays, preserving the expected shape and dtype.

## Motivation and context

Keras may serialize Leaky ReLU as `leaky_relu`, while the bit-exact optimizer previously handled only `leakyrelu`. The unmatched name caused the optimizer to use overly conservative fallback precision.

Einsum recipes may also contain input axes that must be reduced before transposition and contraction. The interval implementation ignored these direct-sum axes, producing incorrect shapes or bounds for equations containing input-only reduction dimensions. This PR aligns interval execution with the existing numeric Einsum recipe implementation.

## Dependencies

No new dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Ran the existing quantized-interval test suite:
`pytest test/pytest/test_qinterval.py -q`