### PR TITLE
fix(model): drop the stray positional dims argument from RNN state output variables

### DIFF
--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -1466,12 +1466,11 @@ class SimpleRNN(Layer):
 
         if self.attributes['return_state']:
             state_shape = [self.attributes['n_out']]
-            state_dims = [f'N_OUT_{self.index}']
             self.add_output_variable(
-                state_shape, state_dims, out_name=self.outputs[1], var_name='layer{index}_h', type_name='layer{index}_h_t'
+                state_shape, out_name=self.outputs[1], var_name='layer{index}_h', type_name='layer{index}_h_t'
             )
             self.add_output_variable(
-                state_shape, state_dims, out_name=self.outputs[2], var_name='layer{index}_c', type_name='layer{index}_c_t'
+                state_shape, out_name=self.outputs[2], var_name='layer{index}_c', type_name='layer{index}_c_t'
             )
 
         # weights
@@ -1516,12 +1515,11 @@ class LSTM(Layer):
 
         if self.attributes['return_state']:
             state_shape = [self.attributes['n_out']]
-            state_dims = [f'N_OUT_{self.index}']
             self.add_output_variable(
-                state_shape, state_dims, out_name=self.outputs[1], var_name='layer{index}_h', type_name='layer{index}_h_t'
+                state_shape, out_name=self.outputs[1], var_name='layer{index}_h', type_name='layer{index}_h_t'
             )
             self.add_output_variable(
-                state_shape, state_dims, out_name=self.outputs[2], var_name='layer{index}_c', type_name='layer{index}_c_t'
+                state_shape, out_name=self.outputs[2], var_name='layer{index}_c', type_name='layer{index}_c_t'
             )
 
         # weights
@@ -1572,12 +1570,11 @@ class GRU(Layer):
 
         if self.attributes['return_state']:
             state_shape = [self.attributes['n_out']]
-            state_dims = [f'N_OUT_{self.index}']
             self.add_output_variable(
-                state_shape, state_dims, out_name=self.outputs[1], var_name='layer{index}_h', type_name='layer{index}_h_t'
+                state_shape, out_name=self.outputs[1], var_name='layer{index}_h', type_name='layer{index}_h_t'
             )
             self.add_output_variable(
-                state_shape, state_dims, out_name=self.outputs[2], var_name='layer{index}_c', type_name='layer{index}_c_t'
+                state_shape, out_name=self.outputs[2], var_name='layer{index}_c', type_name='layer{index}_c_t'
             )
 
         # weights


### PR DESCRIPTION
### Problem

`SimpleRNN`, `LSTM` and `GRU` in `hls4ml/model/layers.py` build their `return_state` output
variables like this:

```python
if self.attributes['return_state']:
    state_shape = [self.attributes['n_out']]
    state_dims = [f'N_OUT_{self.index}']
    self.add_output_variable(
        state_shape, state_dims, out_name=self.outputs[1], var_name='layer{index}_h', type_name='layer{index}_h_t'
    )
    self.add_output_variable(
        state_shape, state_dims, out_name=self.outputs[2], var_name='layer{index}_c', type_name='layer{index}_c_t'
    )
```

but `add_output_variable`'s second parameter has been `out_name` for a while:

```python
# hls4ml/model/layers.py:263
def add_output_variable(
    self,
    shape: int | list[int] | tuple[int, ...],
    out_name: str | None = None,
    var_name='layer{index}_out',
    type_name='layer{index}_t',
    precision=None,
):
```

So `state_dims` lands in `out_name` positionally and then `out_name=` is supplied again:
`TypeError: add_output_variable() got multiple values for argument 'out_name'`.

`state_dims` itself is dead — `dim_names` no longer exists anywhere in the package, and
`TensorVariable.__init__` (`hls4ml/model/types.py:608`) takes
`(shape, var_name, type_name, precision, **kwargs)` with no dims parameter.

### The fix is already in the file

`Bidirectional.initialize()` (`layers.py:1641`) has the corrected form — no `state_dims`,
no stray positional:

```python
if self.attributes['return_state']:
    state_shape = [self.attributes['n_out']]
    self.add_output_variable(
        state_shape, out_name=self.outputs[1], var_name='layer{index}_h', type_name='layer{index}_h_t'
    )
    self.add_output_variable(
        state_shape, out_name=self.outputs[2], var_name='layer{index}_c', type_name='layer{index}_c_t'
    )
```

This PR makes the other three blocks **byte-identical** to that one. Net `-9` lines,
no other change.

### How reachable is it?

Honestly: latent today, not a live crash. Every shipped frontend refuses `return_state=True`
before it can reach `initialize()` —

* `converters/keras/recurrent.py:79` and `:245` — `raise Exception('"return_state" of {} layer is not yet supported.')`
* `converters/keras_v3/recurrent.py:31` and `:124` — `raise Exception(f'return_state=True is not supported ...')`
* `converters/pytorch/recurrent.py:65` — `layer['return_state'] = False  # parameter does not exist in pytorch`

so the branch only fires for a `ModelGraph` assembled directly from a layer list with the
attribute set. It is the code that has to work the day `return_state` support is switched on,
and right now three of the four copies cannot run at all.

### Verification

Signature mismatch, so no synthesis run is needed. I extracted `Layer.add_output_variable`'s
signature from `main` (`e998745`) by AST and bound both call shapes with `inspect.Signature.bind`:

```
Layer.add_output_variable (self, shape, out_name=None, var_name=None, type_name=None, precision=None)
   TypeError SimpleRNN:1471 / LSTM:1521 / GRU:1577 (broken)  -> multiple values for argument 'out_name'
   OK        Bidirectional:1643 (correct sibling)
```

Formatting is provably neutral for `ruff-format`/`flake8 --max-line-length=125`: the three
patched blocks are now character-for-character the same text as the `Bidirectional` block that
already passes the hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
