### PR TITLE
Serialize NumPy arrays nested inside lists and tuples

### DIFF
--- a/hls4ml/utils/serialization.py
+++ b/hls4ml/utils/serialization.py
@@ -189,18 +189,37 @@ def _serialize_array_attrs(attr_dict, layer_name, dest_dir):
     for attr_name, attr_val in attr_dict.items():
         if isinstance(attr_val, dict):
             _serialize_array_attrs(attr_val, layer_name, dest_dir)
-        if isinstance(attr_val, np.ndarray):
+        if isinstance(attr_val, (np.ndarray, list, tuple)):
             # arr_name ensures a nicer name for the data of weight variables and avoids name-clashing
             arr_name = layer_name
             if 'name' in attr_dict and attr_dict['name'] != layer_name:
                 arr_name += '_' + attr_dict['name']
             arr_name += '_' + attr_name
-            serialized_name = _serialize_ndarray(attr_val, arr_name, dest_dir)
-            attr_dict[attr_name] = serialized_name
+            if isinstance(attr_val, np.ndarray):
+                attr_dict[attr_name] = _serialize_ndarray(attr_val, arr_name, dest_dir)
+            else:
+                attr_dict[attr_name] = _serialize_sequence(attr_val, arr_name, layer_name, dest_dir)
         if isinstance(attr_val, np.integer):
             attr_dict[attr_name] = int(attr_val)
         if isinstance(attr_val, np.floating):
             attr_dict[attr_name] = float(attr_val)
+
+
+def _serialize_sequence(seq, name_prefix, layer_name, dest_dir):
+    serialized = []
+    for idx, val in enumerate(seq):
+        if isinstance(val, dict):
+            _serialize_array_attrs(val, layer_name, dest_dir)
+        if isinstance(val, np.ndarray):
+            val = _serialize_ndarray(val, name_prefix + '_' + str(idx), dest_dir)
+        elif isinstance(val, (list, tuple)):
+            val = _serialize_sequence(val, name_prefix + '_' + str(idx), layer_name, dest_dir)
+        if isinstance(val, np.integer):
+            val = int(val)
+        if isinstance(val, np.floating):
+            val = float(val)
+        serialized.append(val)
+    return tuple(serialized) if isinstance(seq, tuple) else serialized
 
 
 def _serialize_ndarray(arr, name_prefix, dest_dir):
@@ -227,6 +246,21 @@ def _deserialize_array_attrs(src_dir, attr_dict):
         if isinstance(attr_val, str) and attr_val.startswith('@ndarray:'):
             arr = _deserialize_ndarray(src_dir, attr_val)
             attr_dict[attr_name] = arr
+        if isinstance(attr_val, list):
+            attr_dict[attr_name] = _deserialize_sequence(src_dir, attr_val)
+
+
+def _deserialize_sequence(src_dir, seq):
+    deserialized = []
+    for val in seq:
+        if isinstance(val, dict):
+            _deserialize_array_attrs(src_dir, val)
+        if isinstance(val, str) and val.startswith('@ndarray:'):
+            val = _deserialize_ndarray(src_dir, val)
+        elif isinstance(val, list):
+            val = _deserialize_sequence(src_dir, val)
+        deserialized.append(val)
+    return deserialized
 
 
 def _deserialize_ndarray(src_dir, arr_name):

--- a/test/pytest/test_serialization_utils.py
+++ b/test/pytest/test_serialization_utils.py
@@ -1,0 +1,50 @@
+import json
+
+import numpy as np
+
+from hls4ml.utils.serialization import _deserialize_array_attrs, _serialize_array_attrs
+
+
+def test_serialize_array_attrs_in_sequences(tmp_path):
+    """Arrays nested inside lists/tuples (e.g., mask_kbi of FixedPointQuantizer) should be serialized. See #1526."""
+    model_arch = {
+        'layer': {
+            'state': {
+                'attributes': {
+                    'name': 'layer',
+                    'mask_kbi': (
+                        np.array([[0, 1, 0]], dtype=np.int16),
+                        np.array([[1, 2, 3]], dtype=np.int16),
+                        np.array([[4, 5, 6]], dtype=np.int16),
+                    ),
+                    'nested_list': [[np.array([1.5, 2.5])], 'foo', np.int32(7)],
+                }
+            }
+        }
+    }
+
+    for layer_name, layer_dict in model_arch.items():
+        _serialize_array_attrs(layer_dict, layer_name, tmp_path)
+
+    attrs = model_arch['layer']['state']['attributes']
+    assert attrs['mask_kbi'] == (
+        '@ndarray:layer_mask_kbi_0.npy',
+        '@ndarray:layer_mask_kbi_1.npy',
+        '@ndarray:layer_mask_kbi_2.npy',
+    )
+    assert attrs['nested_list'] == [['@ndarray:layer_nested_list_0_0.npy'], 'foo', 7]
+
+    # The resulting architecture must be JSON serializable
+    arch_json = json.dumps(model_arch)
+
+    # Round-trip: arrays inside (JSON-decoded) lists should be restored on deserialization
+    restored_arch = json.loads(arch_json)
+    _deserialize_array_attrs(tmp_path, restored_arch)
+
+    restored_attrs = restored_arch['layer']['state']['attributes']
+    k, b, i = restored_attrs['mask_kbi']
+    np.testing.assert_array_equal(k, np.array([[0, 1, 0]], dtype=np.int16))
+    np.testing.assert_array_equal(b, np.array([[1, 2, 3]], dtype=np.int16))
+    np.testing.assert_array_equal(i, np.array([[4, 5, 6]], dtype=np.int16))
+    np.testing.assert_array_equal(restored_attrs['nested_list'][0][0], np.array([1.5, 2.5]))
+    assert restored_attrs['nested_list'][1:] == ['foo', 7]


### PR DESCRIPTION
# Description

`_serialize_array_attrs()` only matches `np.ndarray` values, so arrays sitting inside a list or tuple are left untouched and `json.dump()` on the model architecture fails with "Object of type ndarray is not JSON serializable". The `mask_kbi` tuple of `FixedPointQuantizer` layers hits this. Fixes #1526.

The serializer now walks lists and tuples too (recursively, including dicts inside them) and saves each array as `<prefix>_<index>.npy` with the usual `@ndarray:` reference, so `mask_kbi` comes out as `["@ndarray:layer_mask_kbi_0.npy", ...]` like the issue expects. np.integer/np.floating scalars inside sequences are converted the same way they already are for dict values. I added the matching handling in `_deserialize_array_attrs()` as well, otherwise a saved `.fml` with `mask_kbi` loads back as a list of strings and the fix doesn't round-trip.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

New test in `test/pytest/test_serialization_utils.py`: builds a layer dict with a `mask_kbi` tuple of int16 arrays plus a nested list case, checks the `@ndarray:` references, that `json.dumps` then succeeds, and that a JSON round-trip plus `_deserialize_array_attrs` gives the arrays back.

```
pytest -q test/pytest/test_serialization_utils.py
```

1 passed with the fix, and 1 failed with `serialization.py` reverted to main, so it does catch the bug. The issue's minimal reproducer gives the expected output too. It only needs numpy and base hls4ml, unlike the end-to-end tests in `test_serialization.py`, which need qkeras/tensorflow/qonnx and a compiler and which I did not run locally. `ruff check`, `ruff format --check` and `flake8` with the repo's config are clean on both files.

**Test Configuration**: Linux, Python venv with numpy and hls4ml installed editable, no vendor tools.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
