### PR TITLE
Add Conv1D dilation support for io_parallel

### DIFF
--- a/docs/ir/ir.rst
+++ b/docs/ir/ir.rst
@@ -55,6 +55,8 @@ Parallel IO is applicable to small models that require low latency implementatio
 
 In Vivado/Vitis backends, parallel convolution relies on the *im2col* transformation of the input, which turns convolution into a matrix-multiplication task. This task is then implemented as a sequence of matrix-vector multiplications using the routine mentioned above. The ``Latency`` and ``Resource`` strategies refer to the function used for matrix-vector multiplication routine, with ``Resource`` allowing for a slightly larger models to be synthesized. Parallelism can be further controlled via the ``ParallelizationFactor``. Catapult backend in turn uses a direct implementation of convolution via nested loops. The ``Quartus``, ``oneAPI``, and ``Catapult`` backends also implement a ``Winograd`` algorithm choosable by setting the ``implementation`` to ``Winograd`` or ``combination``. Winograd implementation is available for only a handful of filter size configurations, and it is less concerned about bit accuracy and overflow. In certain conditions it can be faster.
 
+Dilated Conv1D is supported by the Vivado/Vitis backends with ``io_parallel``. It is not supported with ``io_stream``.
+
 io_stream
 ^^^^^^^^^
 

--- a/hls4ml/backends/vivado/passes/im2col_codegen.py
+++ b/hls4ml/backends/vivado/passes/im2col_codegen.py
@@ -39,6 +39,7 @@ class GenerateConvIm2col(OptimizerPass):
             kernel=node.get_attr('filt_width'),
             stride=node.get_attr('stride_width'),
             pad=(node.get_attr('pad_left'), node.get_attr('pad_right')),
+            dilation=node.get_attr('dilation'),
         )
 
         node.set_attr('line_buffer_codegen', Source(code_str))

--- a/hls4ml/backends/vivado/vivado_backend.py
+++ b/hls4ml/backends/vivado/vivado_backend.py
@@ -373,6 +373,12 @@ class VivadoBackend(FPGABackend):
     # TODO consolidate these functions into a single `init_conv`
     @layer_optimizer(Conv1D)
     def init_conv1d(self, layer):
+        # Dilated convolutions are not supported by the io_stream implementation.
+        if layer.get_attr('dilation') != 1 and layer.model.config.get_config_value('IOType') != 'io_parallel':
+            raise NotImplementedError(
+                f'Layer {layer.name}: Conv1D dilation_rate={layer.get_attr("dilation")} is only supported with io_parallel.'
+            )
+
         if len(layer.weights['weight'].data.shape) == 2:  # This can happen if we assign weights of Dense layer to 1x1 Conv1D
             layer.weights['weight'].data = np.expand_dims(layer.weights['weight'].data, axis=(0, 1))
 

--- a/hls4ml/model/layers.py
+++ b/hls4ml/model/layers.py
@@ -531,6 +531,7 @@ class Conv1D(Layer):
         Attribute('n_filt'),
         Attribute('filt_width'),
         Attribute('stride_width'),
+        Attribute('dilation', default=1),
         Attribute('pad_left'),
         Attribute('pad_right'),
         WeightAttribute('weight'),

--- a/test/pytest/test_conv1d_dilation.py
+++ b/test/pytest/test_conv1d_dilation.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pytest
+import tensorflow as tf
+
+import hls4ml
+
+
+def make_model(dilation, padding):
+    inputs = tf.keras.Input(shape=(17, 2))
+    outputs = tf.keras.layers.Conv1D(3, 3, padding=padding, dilation_rate=dilation, name='conv')(inputs)
+    model = tf.keras.Model(inputs, outputs)
+
+    # Use fixed weights so the test always produces the same result.
+    kernel = np.arange(18, dtype=np.float32).reshape(3, 2, 3) / 32 - 0.25
+    bias = np.array([-0.125, 0.0, 0.125], dtype=np.float32)
+    model.get_layer('conv').set_weights([kernel, bias])
+    return model
+
+
+# Test each dilation rate with both padding modes on Vivado and Vitis.
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis'])
+@pytest.mark.parametrize(
+    'dilation,padding',
+    [(1, 'valid'), (1, 'same'), (2, 'valid'), (2, 'same'), (4, 'valid'), (4, 'same')],
+)
+def test_conv1d_dilation(tmp_path, backend, dilation, padding):
+    tf.keras.utils.set_random_seed(123)
+    model = make_model(dilation, padding)
+    x = np.arange(2 * 17 * 2, dtype=np.float32).reshape(2, 17, 2) / 64 - 0.5
+
+    config = hls4ml.utils.config_from_keras_model(model, granularity='model', backend=backend)
+    config['Model']['Precision'] = 'fixed<32,12>'
+    hls_model = hls4ml.converters.convert_from_keras_model(
+        model,
+        hls_config=config,
+        backend=backend,
+        io_type='io_parallel',
+        output_dir=str(tmp_path),
+    )
+
+    assert tuple(hls_model.get_output_variables()[0].shape) == model.output_shape[1:]
+
+    hls_model.compile()
+    y_keras = model(x, training=False).numpy()
+    y_hls = hls_model.predict(x).reshape(y_keras.shape)
+    np.testing.assert_allclose(y_hls, y_keras, rtol=0, atol=2e-3)
+
+
+@pytest.mark.parametrize('backend', ['Vivado', 'Vitis'])
+def test_conv1d_dilation_stream_rejected(tmp_path, backend):
+    model = make_model(2, 'valid')
+    config = hls4ml.utils.config_from_keras_model(model, granularity='model', backend=backend)
+
+    with pytest.raises(NotImplementedError, match='only supported with io_parallel'):
+        hls4ml.converters.convert_from_keras_model(
+            model,
+            hls_config=config,
+            backend=backend,
+            io_type='io_stream',
+            output_dir=str(tmp_path),
+        )


### PR DESCRIPTION
# Description

Add dilated Conv1D support for Vivado and Vitis using `io_parallel`.

The requested dilation rate is now passed to the existing Conv1D im2col code. The `io_stream` path does not support dilation yet and raises an error.


## Type of change

This addresses the Conv1D dilation bug reported in #1508.

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Tests

Ran the Conv1D dilation and Keras converter tests:

```bash
python -m pytest -q test/pytest/test_conv1d_dilation.py test/pytest/test_keras_converter.py
```

All 35 tests passed. Pre-commit checks also passed.

**Test Configuration**:

- Python 3.13.12
- TensorFlow 2.21.0
- Keras 3.15.1
- Vivado and Vitis with `io_parallel`

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.